### PR TITLE
Fix audb.info.duration() for large databases

### DIFF
--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -117,7 +117,7 @@ def duration(
     """
     deps = dependencies(name, version=version)
     return pd.to_timedelta(
-        sum([deps.duration(file) for file in deps.media]),
+        deps()['duration'].sum(),
         unit='s',
     )
 


### PR DESCRIPTION
Closes #24.

Now I get:

```python
>>> audb.info.duration('audioset')
Timedelta('230 days 02:12:59.737141866')
```