### PR TITLE
Remove dependency to fire

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
     audiofile >=0.4.0
     audobject >=0.4.12
     audresample >=0.1.4
-    fire >=0.4.0
     oyaml
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
We do not provide a command line interface at the moment, so we can remove the dependency to `fire`.