### PR TITLE
Let audb.Dependencies methods return fix types

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -246,7 +246,7 @@ class Dependencies:
             number of channels
 
         """
-        return self[file][define.DependField.CHANNELS] or 0
+        return self[file][define.DependField.CHANNELS]
 
     def checksum(self, file: str) -> str:
         r"""Checksum of file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -234,7 +234,7 @@ class Dependencies:
             bit depth
 
         """
-        return self[file][define.DependField.BIT_DEPTH] or 0
+        return self[file][define.DependField.BIT_DEPTH]
 
     def channels(self, file: str) -> int:
         r"""Number of channels of media file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -270,7 +270,7 @@ class Dependencies:
             duration in seconds
 
         """
-        return self[file][define.DependField.DURATION] or 0.0
+        return self[file][define.DependField.DURATION]
 
     def format(self, file: str) -> str:
         r"""Format of file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -224,7 +224,7 @@ class Dependencies:
         """
         return self[file][define.DependField.ARCHIVE]
 
-    def bit_depth(self, file: str) -> typing.Optional[int]:
+    def bit_depth(self, file: str) -> int:
         r"""Bit depth of media file.
 
         Args:
@@ -234,9 +234,9 @@ class Dependencies:
             bit depth
 
         """
-        return self[file][define.DependField.BIT_DEPTH] or None
+        return self[file][define.DependField.BIT_DEPTH] or 0
 
-    def channels(self, file: str) -> typing.Optional[int]:
+    def channels(self, file: str) -> int:
         r"""Number of channels of media file.
 
         Args:
@@ -246,7 +246,7 @@ class Dependencies:
             number of channels
 
         """
-        return self[file][define.DependField.CHANNELS] or None
+        return self[file][define.DependField.CHANNELS] or 0
 
     def checksum(self, file: str) -> str:
         r"""Checksum of file.
@@ -260,7 +260,7 @@ class Dependencies:
         """
         return self[file][define.DependField.CHECKSUM]
 
-    def duration(self, file: str) -> typing.Optional[float]:
+    def duration(self, file: str) -> float:
         r"""Duration of file.
 
         Args:
@@ -270,7 +270,7 @@ class Dependencies:
             duration in seconds
 
         """
-        return self[file][define.DependField.DURATION] or None
+        return self[file][define.DependField.DURATION] or 0.0
 
     def format(self, file: str) -> str:
         r"""Format of file.
@@ -337,7 +337,7 @@ class Dependencies:
         """
         self._data[file][define.DependField.REMOVED] = 1
 
-    def sampling_rate(self, file: str) -> typing.Optional[int]:
+    def sampling_rate(self, file: str) -> int:
         r"""Sampling rate of media file.
 
         Args:
@@ -347,7 +347,7 @@ class Dependencies:
             sampling rate in Hz
 
         """
-        return self[file][define.DependField.SAMPLING_RATE] or None
+        return self[file][define.DependField.SAMPLING_RATE] or 0
 
     def save(self, path: str):
         r"""Write dependencies to CSV file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -347,7 +347,7 @@ class Dependencies:
             sampling rate in Hz
 
         """
-        return self[file][define.DependField.SAMPLING_RATE] or 0
+        return self[file][define.DependField.SAMPLING_RATE]
 
     def save(self, path: str):
         r"""Write dependencies to CSV file.

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -331,7 +331,6 @@ def sampling_rates(
     return set(
         [
             deps.sampling_rate(file) for file in deps.media
-            if deps.sampling_rate(file)
         ]
     )
 

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -52,7 +52,6 @@ def bit_depths(
     return set(
         [
             deps.bit_depth(file) for file in deps.media
-            if deps.bit_depth(file)
         ]
     )
 
@@ -76,7 +75,6 @@ def channels(
     return set(
         [
             deps.channels(file) for file in deps.media
-            if deps.channels(file)
         ]
     )
 

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -117,7 +117,7 @@ def duration(
     """
     deps = dependencies(name, version=version)
     return pd.to_timedelta(
-        deps()['duration'].sum(),
+        sum([deps.duration(file) for file in deps.media]),
         unit='s',
     )
 


### PR DESCRIPTION
This is a follow up on #24 and #25.

I changed the methods of `audb.Dependencies` to always return fix types which seems to me much safer as our current approach (even if the current approach makes semantically maybe more sense).

I also changed back the calculation of duration due to this:

```python
>>> deps = audb.dependencies('audioset')
>>> timeit.timeit("deps()['duration'].sum()", number=10, setup="from __main__ import deps")
23.182365000000573
>>> timeit.timeit("sum([deps.duration(file) for file in deps.media])", number=10, setup="from __main__ import deps")
17.973571905007702
```