### PR TITLE
Cache dependencies independent of flavors

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -114,7 +114,8 @@ def cached(
 
             # Skip old audb cache (e.g. 1 as flavor)
             files = audeer.list_file_names(version_path)
-            if len(files) > 1:  # pragma: no cover
+            deps_path = os.path.join(version_path, define.DEPENDENCIES_FILE)
+            if deps_path not in files:  # pragma: no cover
                 continue
 
             for flavor_id_path in flavor_id_paths:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -1,7 +1,7 @@
 import os
+import shutil
 import tempfile
 import typing
-import warnings
 
 import pandas as pd
 
@@ -113,7 +113,8 @@ def cached(
             flavor_id_paths = audeer.list_dir_names(version_path)
 
             # Skip old audb cache (e.g. 1 as flavor)
-            if audeer.list_file_names(version_path):  # pragma: no cover
+            files = audeer.list_file_names(version_path)
+            if len(files) > 1:  # pragma: no cover
                 continue
 
             for flavor_id_path in flavor_id_paths:
@@ -183,12 +184,15 @@ def dependencies(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> Dependencies:
     r"""Database dependencies.
 
     Args:
         name: name of database
         version: version string
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         dependency object
@@ -198,16 +202,39 @@ def dependencies(
         version = latest_version(name)
     backend = lookup_backend(name, version)
 
-    with tempfile.TemporaryDirectory() as root:
-        archive = backend.join(name, define.DB)
-        deps_path = backend.get_archive(
-            archive,
-            root,
-            version,
-        )[0]
-        deps_path = os.path.join(root, deps_path)
-        deps = Dependencies()
-        deps.load(deps_path)
+    cache_roots = [
+        default_cache_root(True),  # check shared cache first
+        default_cache_root(False),
+    ] if cache_root is None else [cache_root]
+    for cache_root in cache_roots:
+        deps_root = audeer.safe_path(
+            os.path.join(
+                cache_root,
+                name,
+                version,
+            )
+        )
+        if os.path.exists(deps_root):
+            break
+
+    audeer.mkdir(deps_root)
+    deps_path = os.path.join(deps_root, define.DEPENDENCIES_FILE)
+
+    if not os.path.exists(deps_path):
+        with tempfile.TemporaryDirectory() as tmp_root:
+            archive = backend.join(name, define.DB)
+            backend.get_archive(
+                archive,
+                tmp_root,
+                version,
+            )
+            shutil.move(
+                os.path.join(tmp_root, define.DEPENDENCIES_FILE),
+                deps_path,
+            )
+
+    deps = Dependencies()
+    deps.load(deps_path)
 
     return deps
 

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -37,18 +37,21 @@ def bit_depths(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Set[int]:
     """Media bit depth.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         bit depths
 
     """
-    deps = dependencies(name, version=version)
+    deps = dependencies(name, version=version, cache_root=cache_root)
     return set(
         [
             deps.bit_depth(file) for file in deps.media
@@ -60,18 +63,21 @@ def channels(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Set[int]:
     """Media channels.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         channel numbers
 
     """
-    deps = dependencies(name, version=version)
+    deps = dependencies(name, version=version, cache_root=cache_root)
     return set(
         [
             deps.channels(file) for file in deps.media
@@ -102,18 +108,21 @@ def duration(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> pd.Timedelta:
     """Total media duration.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         duration
 
     """
-    deps = dependencies(name, version=version)
+    deps = dependencies(name, version=version, cache_root=cache_root)
     return pd.to_timedelta(
         sum([deps.duration(file) for file in deps.media]),
         unit='s',
@@ -124,18 +133,21 @@ def formats(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Set[str]:
     """Media formats.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         format
 
     """
-    deps = dependencies(name, version=version)
+    deps = dependencies(name, version=version, cache_root=cache_root)
     return set(
         [
             deps.format(file) for file in deps.media
@@ -316,18 +328,21 @@ def sampling_rates(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Set[int]:
     """Media sampling rates.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         sampling rates
 
     """
-    deps = dependencies(name, version=version)
+    deps = dependencies(name, version=version, cache_root=cache_root)
     return set(
         [
             deps.sampling_rate(file) for file in deps.media

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -233,7 +233,8 @@ def load_to(
         name: name of database
         version: version string, latest if ``None``
         cache_root: cache folder where databases are stored.
-            If not set :meth:`audb.default_cache_root` is used
+            If not set :meth:`audb.default_cache_root` is used.
+            Only used to read the dependencies of the requested version
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -7,7 +7,10 @@ import audeer
 import audformat
 
 from audb.core import define
-from audb.core.api import latest_version
+from audb.core.api import (
+    dependencies,
+    latest_version,
+)
 from audb.core.dependencies import Dependencies
 from audb.core.utils import lookup_backend
 
@@ -211,6 +214,7 @@ def load_to(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
         num_workers: typing.Optional[int] = 1,
         verbose: bool = True,
 ) -> audformat.Database:
@@ -228,6 +232,8 @@ def load_to(
         root: target directory
         name: name of database
         version: version string, latest if ``None``
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5
@@ -248,11 +254,7 @@ def load_to(
     # to ensure we load correct version
     update = os.path.exists(db_root) and os.listdir(db_root)
     audeer.mkdir(db_root)
-    archive = backend.join(name, define.DB)
-    backend.get_archive(archive, db_root, version)
-    deps_path = os.path.join(db_root, define.DEPENDENCIES_FILE)
-    deps = Dependencies()
-    deps.load(deps_path)
+    deps = dependencies(name, version=version, cache_root=cache_root)
     if update:
         for file in deps.files:
             full_file = os.path.join(db_root, file)

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -223,7 +223,8 @@ def publish(
             if no version was published.
             If ``None`` it assumes you start from scratch.
         cache_root: cache folder where databases are stored.
-            If not set :meth:`audb.default_cache_root` is used
+            If not set :meth:`audb.default_cache_root` is used.
+            Only used to read the dependencies of the previous version
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -9,7 +9,6 @@ import audformat
 
 from audb.core import define
 from audb.core.api import dependencies
-from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.repository import Repository
 
@@ -289,13 +288,17 @@ def publish(
 
     # dependencies do not match version
     if previous_version is not None and len(deps) > 0:
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_root:
             previous_deps_path = os.path.join(
-                tmp_dir,
+                tmp_root,
                 define.DEPENDENCIES_FILE,
             )
-            previous_deps = dependencies(db.name, version=previous_version)
-            previous_deps.save(previous_deps_path)
+            archive = backend.join(db.name, define.DB)
+            backend.get_archive(
+                archive,
+                tmp_root,
+                previous_version,
+            )
             if audbackend.md5(deps_path) != audbackend.md5(previous_deps_path):
                 raise RuntimeError(
                     f"You want to depend on '{previous_version}' "

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -134,5 +134,5 @@ def test_remove(publish_db, format):
 
         # Make sure calling it again doesn't raise error
         audb.remove_media(DB_NAME, remove)
-        # remove db from cache to ensure we always get a fresh copy
-        shutil.rmtree(db.meta['audb']['root'])
+        # remove db cache to ensure we always get a fresh copy
+        shutil.rmtree(pytest.CACHE_ROOT)

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -100,6 +100,9 @@ def test_remove(publish_db, format):
             DB_FILES['2.0.0'][0],  # new
     ):
 
+        # remove db cache to ensure we always get a fresh copy
+        shutil.rmtree(pytest.CACHE_ROOT)
+
         audb.remove_media(DB_NAME, remove)
 
         for removed_media in [False, True]:
@@ -134,5 +137,3 @@ def test_remove(publish_db, format):
 
         # Make sure calling it again doesn't raise error
         audb.remove_media(DB_NAME, remove)
-        # remove db cache to ensure we always get a fresh copy
-        shutil.rmtree(pytest.CACHE_ROOT)


### PR DESCRIPTION
In https://github.com/audeering/audb/issues/28 we decided to share the dependencies file between flavors of the same version. Hence, instead of storing a copy of `db.csv` with every flavor, we cache it once at the top level of the flavors, i.e.: `<cache-root>/<db-name>/<version>/db.csv`. We also read from (or write if it does not exist to) this location when calling `audb.dependencies()` now.

In another PR we should also pickle the dependencies to further speed up the caching.

Some notes about the implementation:

1. the public cache is always checked first
2. `cache_root` has been added as an argument to `dependencies` and all functions of `audb.info` that read from the dependencies
3. `audb.load()` now relies on `audb.dependencies()`
~~4. `audb.dependencies()` is not used in `publish()` (anymore) and also not `load_to()` - somehow it feels cleaner to not interact with the cache in those functions~~
