### PR TITLE
DOC: explicitly specify repository for building docs

### DIFF
--- a/audb/info/__init__.py
+++ b/audb/info/__init__.py
@@ -1,19 +1,25 @@
 r"""Get information from database headers.
 
-Instead of caching the header (:file:`db.yaml`)
-of a database first locally to inspect it,
-the functions under :mod:`audb.info`
-provide you direct access to this information.
-
-So instead of running:
-
+.. Specify repository to overwrite local config files
 .. jupyter-execute::
-    :stderr:
     :hide-code:
     :hide-output:
 
     import audb
 
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name='data-public',
+            host='https://audeering.jfrog.io/artifactory',
+            backend='artifactory',
+        )
+    ]
+
+.. Pre-load data without being verbose
+.. jupyter-execute::
+    :stderr:
+    :hide-code:
+    :hide-output:
 
     audb.load(
         'emodb',
@@ -22,6 +28,12 @@ So instead of running:
         verbose=False,
     )
 
+Instead of caching the header (:file:`db.yaml`)
+of a database first locally to inspect it,
+the functions under :mod:`audb.info`
+provide you direct access to this information.
+
+So instead of running:
 
 .. jupyter-execute::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,11 @@ html_title = title
 
 
 # cache databases to avoid progress bar in code examples
-
+audb.config.REPOSITORIES = audb.Repository(
+    name='data-public',
+    host='https://audeering.jfrog.io/artifactory',
+    backend='artifactory',
+)
 if not audb.exists('emodb', version='1.1.0'):
     print('Pre-caching emodb v1.1.0')
     audb.load(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,11 +81,13 @@ html_title = title
 
 
 # cache databases to avoid progress bar in code examples
-audb.config.REPOSITORIES = audb.Repository(
-    name='data-public',
-    host='https://audeering.jfrog.io/artifactory',
-    backend='artifactory',
-)
+audb.config.REPOSITORIES = [
+    audb.Repository(
+        name='data-public',
+        host='https://audeering.jfrog.io/artifactory',
+        backend='artifactory',
+    )
+]
 if not audb.exists('emodb', version='1.1.0'):
     print('Pre-caching emodb v1.1.0')
     audb.load(

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,9 +1,23 @@
-.. Specify pandas format output in cells
+.. Specify repository to overwrite local config files
 .. jupyter-execute::
     :hide-code:
     :hide-output:
 
     import audb
+
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name='data-public',
+            host='https://audeering.jfrog.io/artifactory',
+            backend='artifactory',
+        )
+    ]
+
+.. Specify pandas format output in cells
+.. jupyter-execute::
+    :hide-code:
+    :hide-output:
+
     import pandas as pd
 
     pd.set_option('display.max_columns', 7)

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -1,9 +1,23 @@
-.. Specify pandas format output in cells
+.. Specify repository to overwrite local config files
 .. jupyter-execute::
     :hide-code:
     :hide-output:
 
     import audb
+
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name='data-public',
+            host='https://audeering.jfrog.io/artifactory',
+            backend='artifactory',
+        )
+    ]
+
+.. Specify pandas format output in cells
+.. jupyter-execute::
+    :hide-code:
+    :hide-output:
+
     import pandas as pd
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,3 +1,18 @@
+.. Specify repository to overwrite local config files
+.. jupyter-execute::
+    :hide-code:
+    :hide-output:
+
+    import audb
+
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name='data-public',
+            host='https://audeering.jfrog.io/artifactory',
+            backend='artifactory',
+        )
+    ]
+
 .. _quickstart:
 
 Quickstart


### PR DESCRIPTION
Make sure the correct repository is used when building the documentation locally by setting it explicitly (this overwrites any user config file).