### PR TITLE
Cache dependencies as PKL files

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -213,8 +213,13 @@ def dependencies(
             break
 
     audeer.mkdir(deps_root)
-    deps_path = os.path.join(deps_root, define.DEPENDENCIES_FILE)
+    ext = audeer.file_extension(define.DEPENDENCIES_FILE)
+    deps_path = os.path.join(
+        deps_root,
+        define.DEPENDENCIES_FILE[:-len(ext)] + 'pkl',
+    )
 
+    deps = Dependencies()
     if not os.path.exists(deps_path):
         with tempfile.TemporaryDirectory() as tmp_root:
             archive = backend.join(name, define.DB)
@@ -223,13 +228,10 @@ def dependencies(
                 tmp_root,
                 version,
             )
-            shutil.move(
-                os.path.join(tmp_root, define.DEPENDENCIES_FILE),
-                deps_path,
-            )
-
-    deps = Dependencies()
-    deps.load(deps_path)
+            deps.load(os.path.join(tmp_root, define.DEPENDENCIES_FILE))
+            deps.save(deps_path)
+    else:
+        deps.load(deps_path)
 
     return deps
 

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -114,6 +114,11 @@ def cached(
                 define.CACHED_DEPENDENCIES_FILE,
             )
             if deps_path not in files and deps_path_cached not in files:
+                # Skip all cache entries
+                # that don't contain a db.csv or db.pkl file
+                # as those stem from audb<1.0.0.
+                # We only look for db.csv
+                # as we switched to db.pkl with audb>=1.0.5
                 continue  # pragma: no cover
 
             for flavor_id_path in flavor_id_paths:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -109,8 +109,12 @@ def cached(
             # Skip old audb cache (e.g. 1 as flavor)
             files = audeer.list_file_names(version_path)
             deps_path = os.path.join(version_path, define.DEPENDENCIES_FILE)
-            if deps_path not in files:  # pragma: no cover
-                continue
+            deps_path_cached = os.path.join(
+                version_path,
+                define.CACHED_DEPENDENCIES_FILE,
+            )
+            if deps_path not in files and deps_path_cached not in files:
+                continue  # pragma: no cover
 
             for flavor_id_path in flavor_id_paths:
                 flavor_id = os.path.basename(flavor_id_path)
@@ -213,11 +217,7 @@ def dependencies(
             break
 
     audeer.mkdir(deps_root)
-    ext = audeer.file_extension(define.DEPENDENCIES_FILE)
-    deps_path = os.path.join(
-        deps_root,
-        define.DEPENDENCIES_FILE[:-len(ext)] + 'pkl',
-    )
+    deps_path = os.path.join(deps_root, define.CACHED_DEPENDENCIES_FILE)
 
     deps = Dependencies()
     if not os.path.exists(deps_path):

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -11,6 +11,7 @@ HEADER_FILE = f'{DB}.yaml'
 
 # Dependencies
 DEPENDENCIES_FILE = f'{DB}.csv'
+CACHED_DEPENDENCIES_FILE = f'{DB}.pkl'
 
 
 class DependField:

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import typing
 
@@ -267,12 +268,28 @@ class Dependencies:
             path: path to file.
                 File extension can be ``csv`` or ``pkl``.
 
+        Raises:
+            ValueError: if file extension is not ``csv`` or ``pkl``
+            FileNotFoundError: if ``path`` does not exists
+
         """
         self._df = pd.DataFrame(columns=define.DEPEND_FIELD_NAMES.values())
         path = audeer.safe_path(path)
-        if path.endswith('pkl') and os.path.exists(path):
+        extension = audeer.file_extension(path)
+        if extension not in ['csv', 'pkl']:
+            raise ValueError(
+                f"File extension of 'path' has to be 'csv' or 'pkl' "
+                f"not '{extension}'"
+            )
+        if not os.path.exists(path):
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                path,
+            )
+        if extension == 'pkl':
             self._df = pd.read_pickle(path)
-        elif path.endswith('csv') and os.path.exists(path):
+        elif extension == 'csv':
             # Data type of dependency columns
             dtype_mapping = {
                 name: dtype for name, dtype in zip(

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -271,7 +271,7 @@ class Dependencies:
         self._df = pd.DataFrame(columns=define.DEPEND_FIELD_NAMES.values())
         path = audeer.safe_path(path)
         if path.endswith('pkl') and os.path.exists(path):
-            self._df = pd.read_pickle(path, compression='xz')
+            self._df = pd.read_pickle(path)
         elif path.endswith('csv') and os.path.exists(path):
             # Data type of dependency columns
             dtype_mapping = {
@@ -314,7 +314,7 @@ class Dependencies:
         if path.endswith('csv'):
             self._df.to_csv(path)
         elif path.endswith('pkl'):
-            self._df.to_pickle(path, compression='xz')
+            self._df.to_pickle(path)
 
     def type(self, file: str) -> define.DependType:
         r"""Type of file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -259,17 +259,20 @@ class Dependencies:
         return self[file][define.DependField.REMOVED] != 0
 
     def load(self, path: str):
-        r"""Read dependencies from CSV file.
+        r"""Read dependencies from file.
 
         Clears existing dependencies.
 
         Args:
-            path: path to file
+            path: path to file.
+                File extension can be ``csv`` or ``pkl``.
 
         """
         self._df = pd.DataFrame(columns=define.DEPEND_FIELD_NAMES.values())
         path = audeer.safe_path(path)
-        if os.path.exists(path):
+        if path.endswith('pkl') and os.path.exists(path):
+            self._df = pd.read_pickle(path, compression='xz')
+        elif path.endswith('csv') and os.path.exists(path):
             # Data type of dependency columns
             dtype_mapping = {
                 name: dtype for name, dtype in zip(
@@ -300,14 +303,18 @@ class Dependencies:
         return self[file][define.DependField.SAMPLING_RATE]
 
     def save(self, path: str):
-        r"""Write dependencies to CSV file.
+        r"""Write dependencies to file.
 
         Args:
-            path: path to file
+            path: path to file.
+                File extension can be ``csv`` or ``pkl``.
 
         """
         path = audeer.safe_path(path)
-        self._df.to_csv(path)
+        if path.endswith('csv'):
+            self._df.to_csv(path)
+        elif path.endswith('pkl'):
+            self._df.to_pickle(path, compression='xz')
 
     def type(self, file: str) -> define.DependType:
         r"""Type of file.

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -254,7 +254,8 @@ def publish(
     # load database and dependencies
     deps_path = os.path.join(db_root, define.DEPENDENCIES_FILE)
     deps = Dependencies()
-    deps.load(deps_path)
+    if os.path.exists(deps_path):
+        deps.load(deps_path)
 
     # check if database folder depends on the right version
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -147,6 +147,11 @@ def test_load_save(deps):
     deps2.load(deps_file)
     pd.testing.assert_frame_equal(deps(), deps2())
     os.remove(deps_file)
+    # Wrong extension or file missng
+    with pytest.raises(ValueError, match=r".*'txt'.*"):
+        deps2.load('deps.txt')
+    with pytest.raises(FileNotFoundError):
+        deps.load(deps_file)
 
 
 def test_remove(deps):


### PR DESCRIPTION
Tackles #28.

This caches now all dependencies as uncompressed PKL files in the cache.
For databases that are already in the cache it will store the PKL along the CSV file, but this shouldn't lead to any problems.

This provides a speedup when requesting the first and second time, see https://github.com/audeering/audb/pull/38#issuecomment-828990575