### PR TITLE
WIP: Speedup dict conversion in Dependencies.load()

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -325,7 +325,7 @@ class Dependencies:
                 dtype=dtype_mapping,
             )
             self._data = {
-                file: list(row) for file, row in df.iterrows()
+                row.Index: list(row)[1:] for row in df.itertuples()
             }
 
     def remove(self, file: str):


### PR DESCRIPTION
As a first step to tackle #28 this speedups the conversion of the dataframe to dict in `audb.Dependencies.load()` by a large amount, compare https://github.com/audeering/audb/pull/38#issuecomment-820445877.

In a next step we could consider if we need this conversion at all.