### PR TITLE
Remove conversion to dict in audb.Dependencies

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -232,15 +232,6 @@ class Dependencies:
         """
         return self[file][define.DependField.CHECKSUM]
 
-    def drop(self, file: str):
-        r"""Drop file from table.
-
-        Args:
-            file: relative file path
-
-        """
-        self._df.drop(file, inplace=True)
-
     def duration(self, file: str) -> float:
         r"""Duration of file.
 
@@ -438,6 +429,15 @@ class Dependencies:
             define.DependType.META,  # type
             version,                 # version
         ]
+
+    def _drop(self, file: str):
+        r"""Drop file from table.
+
+        Args:
+            file: relative file path
+
+        """
+        self._df.drop(file, inplace=True)
 
     def _remove(self, file: str):
         r"""Mark file as removed.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -1,6 +1,7 @@
 import os
 import typing
 
+import pandas
 import pandas as pd
 
 import audeer
@@ -118,7 +119,6 @@ class Dependencies:
 
         """
         return {row.Index: list(row)[1:] for row in self._df.itertuples()}
-        # return {file: self[file] for file in self.files}
 
     @property
     def files(self) -> typing.List[str]:
@@ -233,6 +233,15 @@ class Dependencies:
         """
         return self[file][define.DependField.CHECKSUM]
 
+    def drop(self, file: str):
+        r"""Drop file from table.
+
+        Args:
+            file: relative file path
+
+        """
+        self._df.drop(file, inplace=True)
+
     def duration(self, file: str) -> float:
         r"""Duration of file.
 
@@ -319,6 +328,24 @@ class Dependencies:
         """
         path = audeer.safe_path(path)
         self._df.to_csv(path)
+
+    def set_value(
+            self,
+            file: str,
+            field: typing.Union[int, str],
+            value: typing.Any,
+    ):
+        r"""Set field to a new value.
+
+        Args:
+            file: relative file path
+            field: field index or name
+            value: new value
+
+        """
+        if isinstance(field, int):
+            field = define.DEPEND_FIELD_NAMES[field]
+        self._df.at[file, field] = value
 
     def type(self, file: str) -> define.DependType:
         r"""Type of file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -51,7 +51,13 @@ class Dependencies:
     """  # noqa: E501
 
     def __init__(self):
-        self._df = pd.DataFrame(columns=define.DEPEND_FIELD_NAMES.values())
+        data = {}
+        for name, dtype in zip(
+                define.DEPEND_FIELD_NAMES.values(),
+                define.DEPEND_FIELD_DTYPES.values(),
+        ):
+            data[name] = pd.Series(dtype=dtype)
+        self._df = pd.DataFrame(data)
 
     def __call__(self) -> pd.DataFrame:
         r"""Return dependencies as a table.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -51,7 +51,7 @@ class Dependencies:
     """  # noqa: E501
 
     def __init__(self):
-        self._df = {}
+        self._df = pd.DataFrame(columns=define.DEPEND_FIELD_NAMES.values())
 
     def __call__(self) -> pd.DataFrame:
         r"""Return dependencies as a table.
@@ -271,7 +271,7 @@ class Dependencies:
             path: path to file
 
         """
-        self._df = {}
+        self._df = pd.DataFrame(columns=define.DEPEND_FIELD_NAMES.values())
         path = audeer.safe_path(path)
         if os.path.exists(path):
             # Data type of dependency columns

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -1,5 +1,4 @@
 import os
-import threading
 import typing
 
 import pandas as pd
@@ -59,7 +58,6 @@ class Dependencies:
         ):
             data[name] = pd.Series(dtype=dtype)
         self._df = pd.DataFrame(data)
-        self._lock = threading.Lock()
 
     def __call__(self) -> pd.DataFrame:
         r"""Return dependencies as a table.
@@ -241,8 +239,7 @@ class Dependencies:
             file: relative file path
 
         """
-        with self._lock:
-            self._df.drop(file, inplace=True)
+        self._df.drop(file, inplace=True)
 
     def duration(self, file: str) -> float:
         r"""Duration of file.
@@ -347,8 +344,7 @@ class Dependencies:
         """
         if isinstance(field, int):
             field = define.DEPEND_FIELD_NAMES[field]
-        with self._lock:
-            self._df.at[file, field] = value
+        self._df.at[file, field] = value
 
     def type(self, file: str) -> define.DependType:
         r"""Type of file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -1,7 +1,7 @@
 import os
+import threading
 import typing
 
-import pandas
 import pandas as pd
 
 import audeer
@@ -59,6 +59,7 @@ class Dependencies:
         ):
             data[name] = pd.Series(dtype=dtype)
         self._df = pd.DataFrame(data)
+        self._lock = threading.Lock()
 
     def __call__(self) -> pd.DataFrame:
         r"""Return dependencies as a table.
@@ -240,7 +241,8 @@ class Dependencies:
             file: relative file path
 
         """
-        self._df.drop(file, inplace=True)
+        with self._lock:
+            self._df.drop(file, inplace=True)
 
     def duration(self, file: str) -> float:
         r"""Duration of file.
@@ -345,7 +347,8 @@ class Dependencies:
         """
         if isinstance(field, int):
             field = define.DEPEND_FIELD_NAMES[field]
-        self._df.at[file, field] = value
+        with self._lock:
+            self._df.at[file, field] = value
 
     def type(self, file: str) -> define.DependType:
         r"""Type of file.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -110,16 +110,6 @@ class Dependencies:
         return sorted(list(set(archives)))
 
     @property
-    def data(self) -> typing.Dict[str, typing.List]:
-        r"""Get table data.
-
-        Returns:
-            dictionary with table entries
-
-        """
-        return {row.Index: list(row)[1:] for row in self._df.itertuples()}
-
-    @property
     def files(self) -> typing.List[str]:
         r"""All files (table and media).
 

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -93,10 +93,10 @@ class Dependencies:
         return list(self._df.loc[file])
 
     def __len__(self) -> int:
-        return len(self._data)
+        return len(self._df)
 
     def __str__(self) -> str:
-        return self().to_string()
+        return self._df.to_string()
 
     @property
     def archives(self) -> typing.List[str]:

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -72,7 +72,7 @@ class Dependencies:
             ``True`` if a dependency to the file exists
 
         """
-        return file in self._df
+        return file in self._df.index
 
     def __getitem__(self, file: str) -> typing.List:
         r"""File information.
@@ -84,7 +84,7 @@ class Dependencies:
             list with meta information
 
         """
-        return self._df.loc[file]
+        return list(self._df.loc[file])
 
     def __len__(self) -> int:
         return len(self._data)
@@ -112,6 +112,7 @@ class Dependencies:
 
         """
         return {row.Index: list(row)[1:] for row in self._df.itertuples()}
+        # return {file: self[file] for file in self.files}
 
     @property
     def files(self) -> typing.List[str]:
@@ -417,4 +418,5 @@ class Dependencies:
             file: relative file path
 
         """
-        self._df.loc[file, define.DependField.REMOVED] = 1
+        removed_column = define.DEPEND_FIELD_NAMES[define.DependField.REMOVED]
+        self._df.at[file, removed_column] = 1

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -76,7 +76,7 @@ def _find_media(
             else:
                 archive = audeer.uid(from_string=file.replace('\\', '/'))
             deps._add_media(db_root, file, version, archive, checksum)
-        elif not deps.is_removed(file):
+        elif not deps.removed(file):
             checksum = audbackend.md5(path)
             if checksum != deps.checksum(file):
                 archive = deps.archive(file)

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -27,7 +27,7 @@ def _find_tables(
 
     db_tables = [f'db.{table}.csv' for table in db.tables]
     for file in set(deps.tables) - set(db_tables):
-        deps.data.pop(file)
+        deps.drop(file)
 
     tables = []
 
@@ -39,8 +39,8 @@ def _find_tables(
             deps._add_meta(file, table, checksum, version)
             tables.append(table)
         elif checksum != deps.checksum(file):
-            deps.data[file][define.DependField.CHECKSUM] = checksum
-            deps.data[file][define.DependField.VERSION] = version
+            deps.set_value(file, define.DependField.CHECKSUM, checksum)
+            deps.set_value(file, define.DependField.VERSION, version)
             tables.append(table)
 
     audeer.run_tasks(
@@ -70,7 +70,7 @@ def _find_media(
     db_media = db.files
     for file in set(deps.media) - set(db_media):
         media.add(deps.archive(file))
-        deps.data.pop(file)
+        deps.drop(file)
 
     # update version of altered media and insert new ones
 
@@ -86,7 +86,7 @@ def _find_media(
         elif not deps.removed(file):
             checksum = audbackend.md5(path)
             if checksum != deps.checksum(file):
-                archive = deps.data[file][define.DependField.ARCHIVE]
+                archive = deps.archive(file)
                 deps._add_media(db_root, file, archive, checksum, version)
 
     audeer.run_tasks(
@@ -122,7 +122,7 @@ def _put_media(
     def job(archive):
         if archive in map_media_to_files:
             for file in map_media_to_files[archive]:
-                deps.data[file][define.DependField.VERSION] = version
+                deps.set_value(file, define.DependField.VERSION, version)
             archive_file = backend.join(
                 db_name,
                 define.DEPEND_TYPE_NAMES[define.DependType.MEDIA],

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -27,7 +27,7 @@ def _find_tables(
 
     db_tables = [f'db.{table}.csv' for table in db.tables]
     for file in set(deps.tables) - set(db_tables):
-        deps.drop(file)
+        deps._drop(file)
 
     tables = []
     for table in audeer.progress_bar(
@@ -59,7 +59,7 @@ def _find_media(
     db_media = db.files
     for file in set(deps.media) - set(db_media):
         media.add(deps.archive(file))
-        deps.drop(file)
+        deps._drop(file)
 
     # update version of altered media and insert new ones
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -105,7 +105,7 @@ def test_tables(deps):
 
 
 def test_add_media(deps):
-    deps.add_media(
+    deps._add_media(
         'root',
         'file.mp3',
         'archive3',
@@ -117,7 +117,7 @@ def test_add_media(deps):
 
 
 def test_add_meta(deps):
-    deps.add_meta(
+    deps._add_meta(
         'db.segments.csv',
         'archive4',
         'ebd3d5e2ec352bed24117e23f1c5c375',
@@ -177,7 +177,7 @@ def test_load_save(deps):
 
 
 def test_remove(deps):
-    deps.remove('file.wav')
+    deps._remove('file.wav')
     assert 'file.wav' in deps.files
     assert deps.is_removed('file.wav')
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -80,10 +80,6 @@ def test_archives(deps):
     assert deps.archives == get_entries(audb.core.define.DependField.ARCHIVE)
 
 
-def test_data(deps):
-    assert deps.data == ENTRIES
-
-
 def test_files(deps):
     assert deps.files == list(ENTRIES.keys())
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,96 @@
+import pandas as pd
+import pytest
+
+import audb
+
+
+ENTRIES = {
+    'db.csv': [
+        'archive1',
+        0,
+        0,
+        '7c1f6b568f7221ab968a705fd5e7477b',
+        0,
+        'csv',
+        0,
+        0,
+        0,
+        '1.0.0',
+    ],
+    'file.wav': [
+        'archive2',
+        16,
+        2,
+        '917338b854ad9c72f76bc9a68818dcd8',
+        1.23,
+        'wav',
+        0,
+        16000,
+        1,
+        '1.0.0',
+    ],
+}
+
+
+def get_entries(index):
+    return [v[index] for k, v in ENTRIES.items()]
+
+
+def test_get_entries():
+    assert get_entries(0) == ['archive1', 'archive2']
+
+
+@pytest.fixture(
+    scope='function',
+)
+def deps():
+    deps = audb.Dependencies()
+    deps._df = pd.DataFrame(
+        data=list(ENTRIES.values()),
+        columns=audb.core.define.DEPEND_FIELD_NAMES.values(),
+        index=list(ENTRIES.keys()),
+    )
+    return deps
+
+
+def test_init():
+    deps = audb.Dependencies()
+    expected_columns = audb.core.define.DEPEND_FIELD_NAMES.values()
+    assert deps._df.columns == expected_columns
+
+
+def test_call(deps):
+    assert deps() == deps._df
+
+
+def test_contains(deps):
+    assert 'db.csv' in deps
+    assert 'file.wav' in deps
+    assert 'not.csv' not in deps
+
+
+def test_get_item(deps):
+    assert deps['db.csv'] == ENTRIES['db.csv']
+    assert deps['file.wav'] == ENTRIES['file.wav']
+
+
+def test_archives(deps):
+    assert deps.archives == get_entries(audb.core.define.DependField.ARCHIVE)
+
+
+def test_data(deps):
+    assert deps.data == ENTRIES
+
+
+def test_files(deps):
+    assert deps.files == list(ENTRIES.values())
+
+
+def test_media(deps):
+    assert deps.media == [list(ENTRIES.keys())[1]]
+
+
+def test_removed_media(deps):
+    assert deps.removed_media == [
+        get_entries(audb.core.define.DependField.REMOVED)[1]
+    ]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -104,29 +104,6 @@ def test_tables(deps):
     assert deps.tables == ['db.files.csv']
 
 
-def test_add_media(deps):
-    deps._add_media(
-        'root',
-        'file.mp3',
-        'archive3',
-        '7c1f6b568f7221ab968a705fd5e7477b',
-        '1.0.0',
-    )
-    assert 'file.mp3' in deps._df.index
-    assert deps._df.loc['file.mp3']['archive'] == 'archive3'
-
-
-def test_add_meta(deps):
-    deps._add_meta(
-        'db.segments.csv',
-        'archive4',
-        'ebd3d5e2ec352bed24117e23f1c5c375',
-        '1.0.0',
-    )
-    assert 'db.segments.csv' in deps._df.index
-    assert deps._df.loc['db.segments.csv']['archive'] == 'archive4'
-
-
 def test_archive(deps):
     assert deps.archive('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.ARCHIVE

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -136,8 +136,8 @@ def test_format(deps):
     ]
 
 
-def test_is_removed(deps):
-    assert not deps.is_removed('file.wav')
+def test_removed(deps):
+    assert not deps.removed('file.wav')
 
 
 def test_load_save(deps):
@@ -152,7 +152,7 @@ def test_load_save(deps):
 def test_remove(deps):
     deps._remove('file.wav')
     assert 'file.wav' in deps.files
-    assert deps.is_removed('file.wav')
+    assert deps.removed('file.wav')
 
 
 def test_sampling_rate(deps):

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -24,8 +24,6 @@ DB_ROOT_VERSION = {
     ['1.0.0', '2.0.0', '2.1.0', '3.0.0', '4.0.0', '5.0.0']
 }
 
-NUM_WORKERS = 1
-
 
 def clear_root(root: str):
     root = audeer.safe_path(root)
@@ -114,7 +112,7 @@ def test_invalid_archives(name):
             '1.0.1',
             pytest.PUBLISH_REPOSITORY,
             archives=archives,
-            num_workers=NUM_WORKERS,
+            num_workers=pytest.NUM_WORKERS,
             verbose=False,
         )
 
@@ -160,7 +158,7 @@ def test_publish(version):
         pytest.PUBLISH_REPOSITORY,
         archives=archives,
         previous_version=None,
-        num_workers=NUM_WORKERS,
+        num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
     backend = audb.core.utils.lookup_backend(DB_NAME, version)
@@ -176,7 +174,7 @@ def test_publish(version):
         DB_NAME,
         version=version,
         full_path=False,
-        num_workers=NUM_WORKERS,
+        num_workers=pytest.NUM_WORKERS,
     )
     assert db.name == DB_NAME
 
@@ -294,7 +292,7 @@ def test_publish_error_messages():
                 version,
                 pytest.PUBLISH_REPOSITORY,
                 previous_version=None,
-                num_workers=NUM_WORKERS,
+                num_workers=pytest.NUM_WORKERS,
                 verbose=False,
             )
 
@@ -308,7 +306,7 @@ def test_update_database():
         DB_ROOT_VERSION[version],
         DB_NAME,
         version=start_version,
-        num_workers=NUM_WORKERS,
+        num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
 
@@ -336,7 +334,7 @@ def test_update_database():
             version,
             pytest.PUBLISH_REPOSITORY,
             previous_version=previous_version,
-            num_workers=NUM_WORKERS,
+            num_workers=pytest.NUM_WORKERS,
             verbose=False,
         )
 
@@ -346,7 +344,7 @@ def test_update_database():
         DB_ROOT_VERSION[version],
         DB_NAME,
         version=start_version,
-        num_workers=NUM_WORKERS,
+        num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
     # Remove one file as in version 3.0.0
@@ -377,7 +375,7 @@ def test_update_database():
             version,
             pytest.PUBLISH_REPOSITORY,
             previous_version=previous_version,
-            num_workers=NUM_WORKERS,
+            num_workers=pytest.NUM_WORKERS,
             verbose=False,
         )
 
@@ -394,7 +392,7 @@ def test_update_database():
             version,
             pytest.PUBLISH_REPOSITORY,
             previous_version=previous_version,
-            num_workers=NUM_WORKERS,
+            num_workers=pytest.NUM_WORKERS,
             verbose=False,
         )
 
@@ -404,7 +402,7 @@ def test_update_database():
         version,
         pytest.PUBLISH_REPOSITORY,
         previous_version=previous_version,
-        num_workers=NUM_WORKERS,
+        num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
 
@@ -419,14 +417,14 @@ def test_update_database():
         DB_NAME,
         version=version,
         full_path=False,
-        num_workers=NUM_WORKERS,
+        num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
     db2 = audb.load(
         DB_NAME,
         version='3.0.0',
         full_path=False,
-        num_workers=NUM_WORKERS,
+        num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
     db1.meta['audb'] = {}

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -24,6 +24,8 @@ DB_ROOT_VERSION = {
     ['1.0.0', '2.0.0', '2.1.0', '3.0.0', '4.0.0', '5.0.0']
 }
 
+NUM_WORKERS = 1
+
 
 def clear_root(root: str):
     root = audeer.safe_path(root)
@@ -112,7 +114,7 @@ def test_invalid_archives(name):
             '1.0.1',
             pytest.PUBLISH_REPOSITORY,
             archives=archives,
-            num_workers=pytest.NUM_WORKERS,
+            num_workers=NUM_WORKERS,
             verbose=False,
         )
 
@@ -158,7 +160,7 @@ def test_publish(version):
         pytest.PUBLISH_REPOSITORY,
         archives=archives,
         previous_version=None,
-        num_workers=pytest.NUM_WORKERS,
+        num_workers=NUM_WORKERS,
         verbose=False,
     )
     backend = audb.core.utils.lookup_backend(DB_NAME, version)
@@ -174,7 +176,7 @@ def test_publish(version):
         DB_NAME,
         version=version,
         full_path=False,
-        num_workers=pytest.NUM_WORKERS,
+        num_workers=NUM_WORKERS,
     )
     assert db.name == DB_NAME
 
@@ -292,7 +294,7 @@ def test_publish_error_messages():
                 version,
                 pytest.PUBLISH_REPOSITORY,
                 previous_version=None,
-                num_workers=pytest.NUM_WORKERS,
+                num_workers=NUM_WORKERS,
                 verbose=False,
             )
 
@@ -306,7 +308,7 @@ def test_update_database():
         DB_ROOT_VERSION[version],
         DB_NAME,
         version=start_version,
-        num_workers=pytest.NUM_WORKERS,
+        num_workers=NUM_WORKERS,
         verbose=False,
     )
 
@@ -334,7 +336,7 @@ def test_update_database():
             version,
             pytest.PUBLISH_REPOSITORY,
             previous_version=previous_version,
-            num_workers=pytest.NUM_WORKERS,
+            num_workers=NUM_WORKERS,
             verbose=False,
         )
 
@@ -344,7 +346,7 @@ def test_update_database():
         DB_ROOT_VERSION[version],
         DB_NAME,
         version=start_version,
-        num_workers=pytest.NUM_WORKERS,
+        num_workers=NUM_WORKERS,
         verbose=False,
     )
     # Remove one file as in version 3.0.0
@@ -375,7 +377,7 @@ def test_update_database():
             version,
             pytest.PUBLISH_REPOSITORY,
             previous_version=previous_version,
-            num_workers=pytest.NUM_WORKERS,
+            num_workers=NUM_WORKERS,
             verbose=False,
         )
 
@@ -392,7 +394,7 @@ def test_update_database():
             version,
             pytest.PUBLISH_REPOSITORY,
             previous_version=previous_version,
-            num_workers=pytest.NUM_WORKERS,
+            num_workers=NUM_WORKERS,
             verbose=False,
         )
 
@@ -402,7 +404,7 @@ def test_update_database():
         version,
         pytest.PUBLISH_REPOSITORY,
         previous_version=previous_version,
-        num_workers=pytest.NUM_WORKERS,
+        num_workers=NUM_WORKERS,
         verbose=False,
     )
 
@@ -417,14 +419,14 @@ def test_update_database():
         DB_NAME,
         version=version,
         full_path=False,
-        num_workers=pytest.NUM_WORKERS,
+        num_workers=NUM_WORKERS,
         verbose=False,
     )
     db2 = audb.load(
         DB_NAME,
         version='3.0.0',
         full_path=False,
-        num_workers=pytest.NUM_WORKERS,
+        num_workers=NUM_WORKERS,
         verbose=False,
     )
     db1.meta['audb'] = {}


### PR DESCRIPTION
This removes the internal conversion to a dictionary inside `audb.Dependencies` as this is not needed and very slow.