### PR TITLE
DOC: add return type to Dependencies.__contain__

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -29,7 +29,7 @@ class Dependencies:
             columns=list(define.DEPEND_FIELD_NAMES.values()),
         )
 
-    def __contains__(self, file: str):
+    def __contains__(self, file: str) -> bool:
         r"""Check if file exists.
 
         Args:


### PR DESCRIPTION
The return type of `audb.Dependencies.__contains__()` was missing.