### PR TITLE
Rename is_removed to removed in audb.Dependencies

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -150,7 +150,7 @@ class Dependencies:
 
         """
         select = [
-            file for file in self.media if self.is_removed(file)
+            file for file in self.media if self.removed(file)
         ]
         return select
 
@@ -254,7 +254,7 @@ class Dependencies:
         """
         return self[file][define.DependField.FORMAT]
 
-    def is_removed(self, file: str) -> bool:
+    def removed(self, file: str) -> bool:
         r"""Check if file is marked as removed.
 
         Args:

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -42,7 +42,7 @@ class Dependencies:
         'c1f5cc6f-6d00-348a-ba3b-4adaa2436aad'
         >>> deps.duration('wav/03a01Fa.wav')
         1.89825
-        >>> deps.is_removed('wav/03a01Fa.wav')
+        >>> deps.removed('wav/03a01Fa.wav')
         False
         >>> # Check if a file is part of the dependencies
         >>> 'wav/03a01Fa.wav' in deps

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -123,7 +123,7 @@ def _database_check_complete(
             if not os.path.exists(os.path.join(db_root, table)):
                 return False
         for media in deps.media:
-            if not deps.is_removed(media):
+            if not deps.removed(media):
                 path = os.path.join(db_root, media)
                 path = flavor.destination(path)
                 if not os.path.exists(path):

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -27,7 +27,7 @@ def _find_media(
     media = []
 
     def job(file: str):
-        if not deps.is_removed(file):
+        if not deps.removed(file):
             full_file = os.path.join(db_root, file)
             if not os.path.exists(full_file):
                 media.append(file)

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -83,7 +83,7 @@ def _find_media(
             else:
                 archive = audeer.uid(from_string=file.replace('\\', '/'))
             deps._add_media(db_root, file, archive, checksum, version)
-        elif not deps.is_removed(file):
+        elif not deps.removed(file):
             checksum = audbackend.md5(path)
             if checksum != deps.checksum(file):
                 archive = deps.data[file][define.DependField.ARCHIVE]
@@ -114,7 +114,7 @@ def _put_media(
     # select archives with new or altered files for upload
     map_media_to_files = collections.defaultdict(list)
     for file in deps.media:
-        if not deps.is_removed(file):
+        if not deps.removed(file):
             map_media_to_files[deps.archive(file)].append(file)
             if deps.version(file) == version:
                 media.add(deps.archive(file))


### PR DESCRIPTION
As discussed in https://github.com/audeering/audb/pull/51#issuecomment-828224898 this 
renames `audb.Dependencies.is_removed()` to `audb.Dependencies.removed()`.