### PR TITLE
DOC: expand docstring of audb.Dependencies

### DIFF
--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+import audb
+
+
+@pytest.fixture(autouse=True)
+def add_audb_with_public_data(doctest_namespace):
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name='data-public',
+            host='https://audeering.jfrog.io/artifactory',
+            backend='artifactory',
+        ),
+    ]
+    doctest_namespace['audb'] = audb
+    yield
+    audb.config.REPOSITORIES = pytest.REPOSITORIES

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -10,8 +10,12 @@ def add_audb_with_public_data(doctest_namespace):
     Some tests in the docstrings need access to the emodb database.
     As all the unit tests defined under ``tests/*``
     should not be able to see the public repository
-    as the number of available databases would then not be deterministic,
-    we have to add the extra ``conftest.py`` file here instead.
+    as the number of available databases would then not be deterministic.
+    We provide this access here
+    with the help of the ``doctest_namespace`` fixture.
+
+    The ``conftest.py`` file has to be in the same folder
+    as the code file where the docstring is defined.
 
     """
     audb.config.REPOSITORIES = [

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -5,6 +5,15 @@ import audb
 
 @pytest.fixture(autouse=True)
 def add_audb_with_public_data(doctest_namespace):
+    r"""Provide access to the public Artifactory repository.
+
+    Some tests in the docstrings need access to the emodb database.
+    As all the unit tests defined under ``tests/*``
+    should not be able to see the public repository
+    as the number of available databases would then not be deterministic,
+    we have to add the extra ``conftest.py`` file here instead.
+
+    """
     audb.config.REPOSITORIES = [
         audb.Repository(
             name='data-public',

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -16,7 +16,7 @@ class Dependencies:
     a database contains
     and metadata about them
     in a single object.
-    The metadata contain information
+    The metadata contains information
     about the single files
     like duration,
     but also what version of the file is required.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -37,7 +37,7 @@ class Dependencies:
         ['db.emotion.csv', 'db.files.csv', 'wav/03a01Fa.wav']
         >>> deps.archives[:2]
         ['005d2b91-5317-0c80-d602-6d55f0323f8c', '014f82d8-3491-fd00-7397-c3b2ac3b2875']
-        >>> # Access a column for a given file
+        >>> # Access properties for a given file
         >>> deps.archive('wav/03a01Fa.wav')
         'c1f5cc6f-6d00-348a-ba3b-4adaa2436aad'
         >>> deps.duration('wav/03a01Fa.wav')

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -98,7 +98,7 @@ class Dependencies:
 
         """
         archives = [self.archive(file) for file in self.files]
-        return list(set(archives))
+        return sorted(list(set(archives)))
 
     @property
     def data(self) -> typing.Dict[str, typing.List]:

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -12,9 +12,10 @@ from audb.core import define
 class Dependencies:
     r"""Dependencies of a database.
 
-    This gathers all files a database contains
+    :class:`audb.Dependencies` gathers all files
+    a database contains
     and metadata about them
-    in a single onbject.
+    in a single object.
     The metadata contain information
     about the single files
     like duration,
@@ -36,7 +37,7 @@ class Dependencies:
         ['db.emotion.csv', 'db.files.csv', 'wav/03a01Fa.wav']
         >>> deps.archives[:2]
         ['005d2b91-5317-0c80-d602-6d55f0323f8c', '014f82d8-3491-fd00-7397-c3b2ac3b2875']
-        >>> # Access a column as a property for a given file
+        >>> # Access a column for a given file
         >>> deps.archive('wav/03a01Fa.wav')
         'c1f5cc6f-6d00-348a-ba3b-4adaa2436aad'
         >>> deps.duration('wav/03a01Fa.wav')

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -10,14 +10,50 @@ from audb.core import define
 
 
 class Dependencies:
-    r"""Hold dependencies of a database.
+    r"""Dependencies of a database.
 
-    """
+    This gathers all files a database contains
+    and metadata about them
+    in a single onbject.
+    The metadata contain information
+    about the single files
+    like duration,
+    but also what version of the file is required.
+
+    The dependencies of a database can be requested with
+    :func:`audb.dependencies`.
+
+    Example:
+        >>> deps = Dependencies()
+        >>> deps()
+        Empty DataFrame
+        Columns: [archive, bit_depth, channels, checksum, duration, format, removed, sampling_rate, type, version]
+        Index: []
+        >>> # Request dependencies for emodb 1.1.0
+        >>> deps = audb.dependencies('emodb', version='1.1.0')
+        >>> # List all files or archives
+        >>> deps.files[:3]
+        ['db.emotion.csv', 'db.files.csv', 'wav/03a01Fa.wav']
+        >>> deps.archives[:2]
+        ['005d2b91-5317-0c80-d602-6d55f0323f8c', '014f82d8-3491-fd00-7397-c3b2ac3b2875']
+        >>> # Access a column as a property for a given file
+        >>> deps.archive('wav/03a01Fa.wav')
+        'c1f5cc6f-6d00-348a-ba3b-4adaa2436aad'
+        >>> deps.duration('wav/03a01Fa.wav')
+        1.89825
+        >>> deps.is_removed('wav/03a01Fa.wav')
+        False
+        >>> # Check if a file is part of the dependencies
+        >>> 'wav/03a01Fa.wav' in deps
+        True
+
+    """  # noqa: E501
+
     def __init__(self):
         self._data = {}
 
     def __call__(self) -> pd.DataFrame:
-        r"""Create dependency table.
+        r"""Return dependencies as a table.
 
         Returns:
             table with dependencies
@@ -30,7 +66,7 @@ class Dependencies:
         )
 
     def __contains__(self, file: str) -> bool:
-        r"""Check if file exists.
+        r"""Check if file is part of dependencies.
 
         Args:
             file: relative file path


### PR DESCRIPTION
In preparation to continue with https://github.com/audeering/audb/pull/40 I would like to make a few updates to `audb.Dependencies` first. Those will break the API, but this is fine as it is a bug fix in order to make it easier later on to not break the API.

The first one just extends the documentation of what `audb.Dependencies` actually is:

![image](https://user-images.githubusercontent.com/173624/116248952-9b600580-a76c-11eb-8710-d0a61c6ada09.png)
