### PR TITLE
Make audb.Dependencies.add_media() private

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -53,6 +53,12 @@ class Dependencies:
         """
         return self._data[file]
 
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __str__(self) -> str:
+        return self().to_string()
+
     @property
     def archives(self) -> typing.List[str]:
         r"""All archives (table and media).
@@ -138,48 +144,6 @@ class Dependencies:
             if self.type(file) == define.DependType.META
         ]
         return select
-
-    def add_media(
-            self,
-            root: str,
-            file: str,
-            archive: str,
-            checksum: str,
-            version: str,
-    ):
-        r"""Add media file.
-
-        Args:
-            root: root directory
-            file: relative file path
-            archive: archive name without extension
-            checksum: checksum of file
-            version: version string
-
-        """
-        format = audeer.file_extension(file).lower()
-
-        bit_depth = channels = sampling_rate = 0
-        duration = 0.0
-        if format in define.FORMATS:
-            path = os.path.join(root, file)
-            bit_depth = audiofile.bit_depth(path)
-            channels = audiofile.channels(path)
-            duration = audiofile.duration(path)
-            sampling_rate = audiofile.sampling_rate(path)
-
-        self.data[file] = [
-            archive,
-            bit_depth,
-            channels,
-            checksum,
-            duration,
-            format,
-            0,  # removed
-            sampling_rate,
-            define.DependType.MEDIA,
-            version,
-        ]
 
     def add_meta(
             self,
@@ -383,8 +347,44 @@ class Dependencies:
         """
         return self[file][define.DependField.VERSION]
 
-    def __len__(self) -> int:
-        return len(self._data)
+    def _add_media(
+            self,
+            root: str,
+            file: str,
+            archive: str,
+            checksum: str,
+            version: str,
+    ):
+        r"""Add media file.
 
-    def __str__(self) -> str:
-        return self().to_string()
+        Args:
+            root: root directory
+            file: relative file path
+            archive: archive name without extension
+            checksum: checksum of file
+            version: version string
+
+        """
+        format = audeer.file_extension(file).lower()
+
+        bit_depth = channels = sampling_rate = 0
+        duration = 0.0
+        if format in define.FORMATS:
+            path = os.path.join(root, file)
+            bit_depth = audiofile.bit_depth(path)
+            channels = audiofile.channels(path)
+            duration = audiofile.duration(path)
+            sampling_rate = audiofile.sampling_rate(path)
+
+        self.data[file] = [
+            archive,
+            bit_depth,
+            channels,
+            checksum,
+            duration,
+            format,
+            0,  # removed
+            sampling_rate,
+            define.DependType.MEDIA,
+            version,
+        ]

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -82,12 +82,12 @@ def _find_media(
                 archive = archives[file]
             else:
                 archive = audeer.uid(from_string=file.replace('\\', '/'))
-            deps.add_media(db_root, file, archive, checksum, version)
+            deps._add_media(db_root, file, archive, checksum, version)
         elif not deps.is_removed(file):
             checksum = audbackend.md5(path)
             if checksum != deps.checksum(file):
                 archive = deps.data[file][define.DependField.ARCHIVE]
-                deps.add_media(db_root, file, archive, checksum, version)
+                deps._add_media(db_root, file, archive, checksum, version)
 
     audeer.run_tasks(
         job,


### PR DESCRIPTION
As discussed in https://github.com/audeering/audb/pull/40#discussion_r621144565 it is a good idea to hide all methods from the user that can change the dependency table as the user should never be doing it manually. It has also the advantage that it makes the documentation of `audb.Dependencies` shorter and easier to understand.

And if a power user really needs to do this, she can still use the private functions or use the `load()` and `save()` functions and modify the CSV file in between.

This starts with renaming `audb.Dependencies.add_media()` to `audb.Dependencies._add_media()`