### PR TITLE
Make audb.Dependencies.add_meta() private

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -145,37 +145,6 @@ class Dependencies:
         ]
         return select
 
-    def add_meta(
-            self,
-            file: str,
-            archive: str,
-            checksum: str,
-            version: str,
-    ):
-        r"""Add table file.
-
-        Args:
-            file: relative file path
-            archive: archive name without extension
-            checksum: checksum of file
-            version: version string
-
-        """
-        format = audeer.file_extension(file).lower()
-
-        self.data[file] = [
-            archive,                 # archive
-            0,                       # bit_depth
-            0,                       # channels
-            checksum,                # checksum
-            0.0,                     # duration
-            format,                  # format
-            0,                       # removed
-            0,                       # sampling_rate
-            define.DependType.META,  # type
-            version,                 # version
-        ]
-
     def archive(self, file: str) -> str:
         r"""Name of archive the file belongs to.
 
@@ -387,4 +356,35 @@ class Dependencies:
             sampling_rate,
             define.DependType.MEDIA,
             version,
+        ]
+
+    def _add_meta(
+            self,
+            file: str,
+            archive: str,
+            checksum: str,
+            version: str,
+    ):
+        r"""Add table file.
+
+        Args:
+            file: relative file path
+            archive: archive name without extension
+            checksum: checksum of file
+            version: version string
+
+        """
+        format = audeer.file_extension(file).lower()
+
+        self.data[file] = [
+            archive,                 # archive
+            0,                       # bit_depth
+            0,                       # channels
+            checksum,                # checksum
+            0.0,                     # duration
+            format,                  # format
+            0,                       # removed
+            0,                       # sampling_rate
+            define.DependType.META,  # type
+            version,                 # version
         ]

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -36,7 +36,7 @@ def _find_tables(
         file = f'db.{table}.csv'
         checksum = audbackend.md5(os.path.join(db_root, file))
         if file not in deps:
-            deps.add_meta(file, table, checksum, version)
+            deps._add_meta(file, table, checksum, version)
             tables.append(table)
         elif checksum != deps.checksum(file):
             deps.data[file][define.DependField.CHECKSUM] = checksum


### PR DESCRIPTION
Follow up on #52.

It renames `audb.Dependencies.add_meta()` to `audb.Dependencies._add_meta()`