### PR TITLE
Make audb.Dependencies.remove() private

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -451,7 +451,7 @@ def remove_media(
                             )
 
                     # mark file as removed
-                    deps.remove(file)
+                    deps._remove(file)
                     upload = True
 
             # upload dependencies

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -261,15 +261,6 @@ class Dependencies:
                 file: list(row) for file, row in df.iterrows()
             }
 
-    def remove(self, file: str):
-        r"""Mark file as removed.
-
-        Args:
-            file: relative file path
-
-        """
-        self._data[file][define.DependField.REMOVED] = 1
-
     def sampling_rate(self, file: str) -> int:
         r"""Sampling rate of media file.
 
@@ -388,3 +379,12 @@ class Dependencies:
             define.DependType.META,  # type
             version,                 # version
         ]
+
+    def _remove(self, file: str):
+        r"""Mark file as removed.
+
+        Args:
+            file: relative file path
+
+        """
+        self._data[file][define.DependField.REMOVED] = 1


### PR DESCRIPTION
Follow up on #52.

This renames `audb.Dependencies.remove()` to `audb.Dependencies._remove()`