### PR TITLE
Fix: replace media extension after filtering media

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -540,7 +540,7 @@ def _remove_media(
     removed_files = deps.removed_media
     if removed_files:
         db.drop_files(
-            deps.removed_media,
+            removed_files,
             num_workers=num_workers,
             verbose=verbose,
         )

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -534,21 +534,13 @@ def _move_file(
 def _remove_media(
         db: audformat.Database,
         deps: Dependencies,
-        flavor: Flavor,
         num_workers: int,
         verbose: bool,
 ):
-    removed_files = []
-    for file in deps.removed_media:
-        if flavor.format is not None:
-            # Rename removed media file to requested format
-            name, _ = os.path.splitext(file)
-            file = f'{name}.{flavor.format}'
-        removed_files.append(file)
-
+    removed_files = deps.removed_media
     if removed_files:
         db.drop_files(
-            removed_files,
+            deps.removed_media,
             num_workers=num_workers,
             verbose=verbose,
         )
@@ -784,16 +776,16 @@ def load(
                 verbose,
             )
 
-    # fix media extension in tables
-    if flavor.format is not None:
-        _fix_media_ext(db.tables.values(), flavor.format, num_workers, verbose)
-
     # filter media
     if media is not None or tables is not None:
         db.pick_files(requested_media)
 
     if not removed_media:
-        _remove_media(db, deps, flavor, num_workers, verbose)
+        _remove_media(db, deps, num_workers, verbose)
+
+    # fix media extension in tables
+    if flavor.format is not None:
+        _fix_media_ext(db.tables.values(), flavor.format, num_workers, verbose)
 
     # convert to full path
     if full_path:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -169,9 +169,10 @@ def test_include_and_exclude(include, exclude, expected_files):
 
 
 @pytest.mark.parametrize(
-    'media, expected_files',
+    'media, format, expected_files',
     [
         (
+            None,
             None,
             ['audio/000.wav', 'audio/001.wav',
              'audio/010.wav', 'audio/011.wav',
@@ -179,22 +180,31 @@ def test_include_and_exclude(include, exclude, expected_files):
         ),
         (
             [],
+            None,
             [],
         ),
         (
             ['audio/000.wav', 'audio/001.wav'],
+            None,
             ['audio/000.wav', 'audio/001.wav'],
         ),
         (
+            ['audio/000.wav', 'audio/001.wav'],
+            'flac',
+            ['audio/000.flac', 'audio/001.flac'],
+        ),
+        (
             r'.*0\.wav',
+            None,
             ['audio/000.wav', 'audio/010.wav', 'audio/1/020.wav'],
         ),
     ]
 )
-def test_media(media, expected_files):
+def test_media(media, format, expected_files):
     db = audb.load(
         DB_NAME,
         media=media,
+        format=format,
         full_path=False,
         num_workers=pytest.NUM_WORKERS,
         verbose=False,
@@ -204,9 +214,10 @@ def test_media(media, expected_files):
 
 
 @pytest.mark.parametrize(
-    'tables, expected_tables, expected_files',
+    'tables, format, expected_tables, expected_files',
     [
         (
+            None,
             None,
             ['dev', 'test', 'train'],
             ['audio/000.wav', 'audio/001.wav',
@@ -215,32 +226,44 @@ def test_media(media, expected_files):
         ),
         (
             'test',
+            None,
             ['test'],
             ['audio/000.wav', 'audio/001.wav'],
         ),
         (
             't.*',
+            None,
             ['test', 'train'],
             ['audio/000.wav', 'audio/001.wav',
              'audio/1/020.wav', 'audio/2/021.wav'],
         ),
         (
             ['dev', 'train'],
+            None,
             ['dev', 'train'],
             ['audio/010.wav', 'audio/011.wav',
              'audio/1/020.wav', 'audio/2/021.wav'],
         ),
         (
+            ['dev', 'train'],
+            'flac',
+            ['dev', 'train'],
+            ['audio/010.flac', 'audio/011.flac',
+             'audio/1/020.flac', 'audio/2/021.flac'],
+        ),
+        (
             'bad',
+            None,
             [],
             [],
         ),
     ]
 )
-def test_tables(tables, expected_tables, expected_files):
+def test_tables(tables, format, expected_tables, expected_files):
     db = audb.load(
         DB_NAME,
         tables=tables,
+        format=format,
         full_path=False,
         num_workers=pytest.NUM_WORKERS,
         verbose=False,


### PR DESCRIPTION
Closes #60 

The following works now as expected:

```python
import audb


db = audb.load(
    'testdata',
    tables='emotion.dev.gold',
    format='flac',
    full_path=False,
)
db['emotion.dev.gold'].get()
```
```
                                                              emotion
file           start                  end                            
audio/003.flac 0 days 00:00:02.374641 0 days 00:00:04.101248  unhappy
               0 days 00:00:05.445999 0 days 00:00:13.061626    happy
               0 days 00:00:13.960496 0 days 00:00:14.897836    happy
               0 days 00:00:21.454417 0 days 00:00:28.235479  unhappy
               0 days 00:00:31.573883 0 days 00:00:35.081475    happy
               0 days 00:00:46.336832 0 days 00:00:49.666294  neutral
               0 days 00:00:53.288169 0 days 00:00:57.397128  neutral
audio/004.flac 0 days 00:00:04.441153 0 days 00:00:05.069330  unhappy
               0 days 00:00:08.263919 0 days 00:00:13.812035  neutral
               0 days 00:00:15.163421 0 days 00:00:18.361817  neutral
               0 days 00:00:23.164433 0 days 00:00:23.922398  neutral
               0 days 00:00:32.178272 0 days 00:00:35.268576  neutral
               0 days 00:00:42.320708 0 days 00:00:42.838252  neutral
               0 days 00:00:47.715380 0 days 00:00:48.870772  neutral
               0 days 00:00:50.283749 0 days 00:00:51.663219    happy
               0 days 00:00:57.899072 0 days 00:00:58.337701  unhappy
audio/005.flac 0 days 00:00:04.113521 0 days 00:00:06.757677  unhappy
               0 days 00:00:07.189011 0 days 00:00:09.499757  neutral
               0 days 00:00:10.056658 0 days 00:00:17.380463  neutral
               0 days 00:00:20.189824 0 days 00:00:24.043259    happy
               0 days 00:00:25.961979 0 days 00:00:26.743246  neutral
               0 days 00:00:27.502626 0 days 00:00:27.814136  neutral
               0 days 00:00:36.057617 0 days 00:00:39.101987  neutral
               0 days 00:00:43.284854 0 days 00:00:46.313790  neutral
               0 days 00:00:49.399081 0 days 00:00:49.681210    happy
               0 days 00:00:53.789372 0 days 00:00:59.017524    happy
```

Additional tests have been added.
