### PR TITLE
Fix: consider format when searching the cache

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -496,9 +496,9 @@ def _missing_media(
             desc='Missing media',
             disable=not verbose
     ):
-        if flavor.format is not None:
-            file = audeer.replace_file_extension(file, flavor.format)
         path = os.path.join(db_root, file)
+        if flavor.format is not None:
+            path = audeer.replace_file_extension(path, flavor.format)
         if not os.path.exists(path):
             missing_media.append(file)
     return missing_media

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -65,6 +65,7 @@ def _cached_files(
         cached_versions: typing.Sequence[
             typing.Tuple[LooseVersion, str, Dependencies],
         ],
+        flavor: Flavor,
         verbose: bool,
 ) -> (typing.Sequence[typing.Union[str, str]], typing.Sequence[str]):
     r"""Find cached files."""
@@ -83,10 +84,20 @@ def _cached_files(
             if cache_version >= file_version:
                 if deps.checksum(file) == cache_deps.checksum(file):
                     path = os.path.join(cache_root, file)
+                    if flavor.format is not None:
+                        path = audeer.replace_file_extension(
+                            path,
+                            flavor.format,
+                        )
                     if os.path.exists(path):
                         found = True
                         break
         if found:
+            if flavor.format is not None:
+                file = audeer.replace_file_extension(
+                    file,
+                    flavor.format,
+                )
             cached_files.append((cache_root, file))
         else:
             missing_files.append(file)
@@ -329,6 +340,7 @@ def _get_media_from_cache(
         cached_versions: typing.Sequence[
             typing.Tuple[LooseVersion, str, Dependencies]
         ],
+        flavor: Flavor,
         num_workers: int,
         verbose: bool,
 ) -> typing.Sequence[str]:
@@ -338,6 +350,7 @@ def _get_media_from_cache(
         media,
         deps,
         cached_versions,
+        flavor,
         verbose,
     )
 
@@ -408,6 +421,7 @@ def _get_tables_from_cache(
         cached_versions: typing.Sequence[
             typing.Tuple[LooseVersion, str, Dependencies]
         ],
+        flavor: Flavor,
         num_workers: int,
         verbose: bool,
 ) -> typing.Sequence[str]:
@@ -417,6 +431,7 @@ def _get_tables_from_cache(
         tables,
         deps,
         cached_versions,
+        flavor,
         verbose,
     )
 
@@ -725,6 +740,7 @@ def load(
                     db_root_tmp,
                     deps,
                     cached_versions,
+                    flavor,
                     num_workers,
                     verbose,
                 )
@@ -773,6 +789,7 @@ def load(
                     db_root_tmp,
                     deps,
                     cached_versions,
+                    flavor,
                     num_workers,
                     verbose,
                 )

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -487,6 +487,7 @@ def _media(
 def _missing_media(
         db_root: str,
         media: typing.Sequence[str],
+        flavor: Flavor,
         verbose: bool,
 ) -> typing.Sequence[str]:
     missing_media = []
@@ -495,6 +496,8 @@ def _missing_media(
             desc='Missing media',
             disable=not verbose
     ):
+        if flavor.format is not None:
+            file = audeer.replace_file_extension(file, flavor.format)
         path = os.path.join(db_root, file)
         if not os.path.exists(path):
             missing_media.append(file)
@@ -752,6 +755,7 @@ def load(
         missing_media = _missing_media(
             db_root,
             requested_media,
+            flavor,
             verbose,
         )
         if missing_media:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -161,6 +161,13 @@ def fixture_publish_db():
 
 
 @pytest.mark.parametrize(
+    'format',
+    [
+        None,
+        'flac',
+    ]
+)
+@pytest.mark.parametrize(
     'version',
     [
         '1.0.0',
@@ -174,13 +181,18 @@ def fixture_publish_db():
         ),
     ]
 )
-def test_load(version):
+def test_load(format, version):
 
-    assert not audb.exists(DB_NAME, version=version)
+    assert not audb.exists(
+        DB_NAME,
+        version=version,
+        format=format,
+    )
 
     db = audb.load(
         DB_NAME,
         version=version,
+        format=format,
         full_path=False,
         num_workers=pytest.NUM_WORKERS,
         verbose=False,
@@ -194,6 +206,11 @@ def test_load(version):
     else:
         resolved_version = version
     db_original = audformat.Database.load(DB_ROOT_VERSION[resolved_version])
+
+    if format is not None:
+        db_original.map_files(
+            lambda x: audeer.replace_file_extension(x, format)
+        )
 
     pd.testing.assert_index_equal(db.files, db_original.files)
     for file in db.files:


### PR DESCRIPTION
During #61 I realized that `load()` is not correctly resolving missing media or copying from other versions when a format is requested that is different from the original format. This fixes it.

Background:

During `load()` we have to figure out which media files are not yet in the cache and download them. Therefore, we check for every media file that is requested if it exists on disk yet. Now, if we have a file `audio/file.wav` in the dependency table, but the user has requested files in `flac` format, we actually have to check if a file `audio/file.flac` exists in the cache. Otherwise `audb` thinks the file is not there and downloads it again. The same applies to the case where we copy files from other versions in the cache. Again we need to take into account that the file extension of those files may have changed when a specific format is requested.