### PR TITLE
Mark deprecated removal for version 1.2.0

### DIFF
--- a/audb/core/backward.py
+++ b/audb/core/backward.py
@@ -6,7 +6,7 @@ from audb.core.api import default_cache_root
 
 
 @audeer.deprecated(
-    removal_version='1.1.0',
+    removal_version='1.2.0',
     alternative='default_cache_root',
 )
 def get_default_cache_root() -> str:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -689,7 +689,7 @@ def load(
             include = kwargs['include']
             warnings.warn(
                 "Argument 'include' is deprecated "
-                "and will be removed with version '1.1.0'. "
+                "and will be removed with version '1.2.0'. "
                 "Use 'media' instead.",
                 category=UserWarning,
                 stacklevel=2,
@@ -699,7 +699,7 @@ def load(
             exclude = kwargs['exclude']
             warnings.warn(
                 "Argument 'exclude' is deprecated "
-                "and will be removed with version '1.1.0'. "
+                "and will be removed with version '1.2.0'. "
                 "Use 'media' instead.",
                 category=UserWarning,
                 stacklevel=2,

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -76,7 +76,7 @@ def mix_mapping(
     if warn:
         warnings.warn(
             "Argument 'mix' is deprecated "
-            "and will be removed with version '1.1.0'. "
+            "and will be removed with version '1.2.0'. "
             "Use 'channels' and 'mixdown' instead.",
             category=UserWarning,
             stacklevel=2,


### PR DESCRIPTION
As we released the latest version as 1.1.0 and not 1.0.5 we need to fix the deprecated removal warnings as it is much too early to remove them already.