### PR TITLE
Simplify backward compatible handling

### DIFF
--- a/audb/core/backward.py
+++ b/audb/core/backward.py
@@ -1,8 +1,14 @@
+import re
+import typing
+import warnings
+
 import pandas as pd
 
 import audeer
 
 from audb.core.api import default_cache_root
+from audb.core.dependencies import Dependencies
+from audb.core.utils import mix_mapping
 
 
 @audeer.deprecated(
@@ -11,3 +17,105 @@ from audb.core.api import default_cache_root
 )
 def get_default_cache_root() -> str:
     return default_cache_root()
+
+
+def include_exclude_mapping(
+        deps: Dependencies,
+        include: typing.Optional[typing.Union[str, typing.Sequence[str]]],
+        exclude: typing.Optional[typing.Union[str, typing.Sequence[str]]],
+) -> typing.Sequence[str]:
+    r"""Map include and exclude to media argument."""
+    media = None
+
+    if include is not None:
+        archives = set([deps.archive(f) for f in deps.media])
+        if isinstance(include, str):
+            pattern = re.compile(include)
+            include = [a for a in archives if pattern.search(a)]
+        media = [x for x in deps.media if deps.archive(x) in include]
+
+    if media is None:
+        media = deps.media
+
+    if exclude is not None:
+        archives = set([deps.archive(f) for f in deps.media])
+        if isinstance(exclude, str):
+            pattern = re.compile(exclude)
+            exclude = [a for a in archives if pattern.search(a)]
+        media = [x for x in media if deps.archive(x) not in exclude]
+
+    return media
+
+
+def parse_deprecated_load_arguments(
+        channels: typing.Union[int, typing.Sequence[int]],
+        mixdown: bool,
+        media: typing.Union[str, typing.Sequence[str]],
+        deps: Dependencies,
+        kwargs,
+) -> typing.List[
+    typing.Optional[typing.List[int]],
+    bool,
+    typing.Optional[typing.List[str]],
+]:
+    r"""Reassign deprecated audb.load arguments
+
+    It maps the deprecated argument ``'mix'``
+    to ``'channels'`` and ``'mixdown'``.
+    It maps the deprecated arguments
+    ``'include'``
+    and ``'exclude'``
+    to the selection of media files.
+
+    If some of the original arguments contain already a setting
+    they will be overwritten.
+
+    Args:
+        channels: channel selection, see :func:`audresample.remix`
+        mixdown: apply mono mix-down
+        media: include only media matching the regular expression or
+            provided in the list
+        deps: database dependencies
+        kwargs: keyword arguments containing possibly deprecated arguments
+
+    Returns:
+        channels: updated channel argument
+        mixdown: updated mixdown argument
+        media: updated media argument
+
+    """
+    # Map 'mix'
+    if (
+            channels is None
+            and not mixdown
+            and 'mix' in kwargs
+    ):  # pragma: no cover
+        mix = kwargs['mix']
+        channels, mixdown = mix_mapping(mix)
+
+    # Map 'include' and 'exclude'
+    if 'include' in kwargs or 'exclude' in kwargs:  # pragma: no cover
+        include = None
+        if 'include' in kwargs:
+            include = kwargs['include']
+            warnings.warn(
+                "Argument 'include' is deprecated "
+                "and will be removed with version '1.2.0'. "
+                "Use 'media' instead.",
+                category=UserWarning,
+                stacklevel=2,
+            )
+        exclude = None
+        if 'exclude' in kwargs:  # pragma: no cover
+            exclude = kwargs['exclude']
+            warnings.warn(
+                "Argument 'exclude' is deprecated "
+                "and will be removed with version '1.2.0'. "
+                "Use 'media' instead.",
+                category=UserWarning,
+                stacklevel=2,
+            )
+        if include is not None or exclude is not None:
+            media = include_exclude_mapping(deps, include, exclude)
+
+    return channels, mixdown, media

--- a/audb/core/backward.py
+++ b/audb/core/backward.py
@@ -53,7 +53,7 @@ def parse_deprecated_load_arguments(
         media: typing.Union[str, typing.Sequence[str]],
         deps: Dependencies,
         kwargs,
-) -> typing.List[
+) -> typing.Tuple[
     typing.Optional[typing.List[int]],
     bool,
     typing.Optional[typing.List[str]],


### PR DESCRIPTION
This moves all the handling of the `audb.load()` backward compatible argument mappings from `load.py` to `backward.py` as a first step to improve the code in `load.py`. In an ideal world we would now also move the `mix_mapping()` function from `audb.core.utils` to backward and move the warning out of the function, but as we use `audb.core.utils.mix_mapping()` already in `audbenchmark` and we will remove it in version 1.2.0 of `audb` anyway, I have not applied this change.