### PR TITLE
Speedup audb.Dependencies methods

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -107,8 +107,7 @@ class Dependencies:
             list of archives
 
         """
-        df = self()
-        archives = list(df.archive.values)
+        archives = list(self._df.archive.values)
         return sorted(list(set(archives)))
 
     @property
@@ -129,10 +128,9 @@ class Dependencies:
             list of media
 
         """
-        df = self()
         return list(
-            df[
-                df['type'] == define.DependType.MEDIA
+            self._df[
+                self._df['type'] == define.DependType.MEDIA
             ].index
         )
 
@@ -144,11 +142,10 @@ class Dependencies:
             list of media
 
         """
-        df = self()
         return list(
-            df[
-                (df['type'] == define.DependType.MEDIA)
-                & (df['removed'] == 1)
+            self._df[
+                (self._df['type'] == define.DependType.MEDIA)
+                & (self._df['removed'] == 1)
             ].index
         )
 
@@ -174,9 +171,10 @@ class Dependencies:
             list of tables
 
         """
-        df = self()
         return list(
-            df[df['type'] == define.DependType.META].index
+            self._df[
+                self._df['type'] == define.DependType.META
+            ].index
         )
 
     def archive(self, file: str) -> str:

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -187,7 +187,7 @@ class Dependencies:
             archive name
 
         """
-        return self[file][define.DependField.ARCHIVE]
+        return self._df.archive[file]
 
     def bit_depth(self, file: str) -> int:
         r"""Bit depth of media file.
@@ -199,7 +199,7 @@ class Dependencies:
             bit depth
 
         """
-        return self[file][define.DependField.BIT_DEPTH]
+        return int(self._df.bit_depth[file])
 
     def channels(self, file: str) -> int:
         r"""Number of channels of media file.
@@ -211,7 +211,7 @@ class Dependencies:
             number of channels
 
         """
-        return self[file][define.DependField.CHANNELS]
+        return int(self._df.channels[file])
 
     def checksum(self, file: str) -> str:
         r"""Checksum of file.
@@ -223,7 +223,7 @@ class Dependencies:
             checksum of file
 
         """
-        return self[file][define.DependField.CHECKSUM]
+        return self._df.checksum[file]
 
     def duration(self, file: str) -> float:
         r"""Duration of file.
@@ -235,7 +235,7 @@ class Dependencies:
             duration in seconds
 
         """
-        return self[file][define.DependField.DURATION]
+        return float(self._df.duration[file])
 
     def format(self, file: str) -> str:
         r"""Format of file.
@@ -247,19 +247,7 @@ class Dependencies:
             file format (always lower case)
 
         """
-        return self[file][define.DependField.FORMAT]
-
-    def removed(self, file: str) -> bool:
-        r"""Check if file is marked as removed.
-
-        Args:
-            file: relative file path
-
-        Returns:
-            ``True`` if file was removed
-
-        """
-        return self[file][define.DependField.REMOVED] != 0
+        return self._df.format[file]
 
     def load(self, path: str):
         r"""Read dependencies from file.
@@ -309,6 +297,18 @@ class Dependencies:
                 dtype=dtype_mapping,
             )
 
+    def removed(self, file: str) -> bool:
+        r"""Check if file is marked as removed.
+
+        Args:
+            file: relative file path
+
+        Returns:
+            ``True`` if file was removed
+
+        """
+        return bool(self._df.removed[file])
+
     def sampling_rate(self, file: str) -> int:
         r"""Sampling rate of media file.
 
@@ -319,7 +319,7 @@ class Dependencies:
             sampling rate in Hz
 
         """
-        return self[file][define.DependField.SAMPLING_RATE]
+        return int(self._df.sampling_rate[file])
 
     def save(self, path: str):
         r"""Write dependencies to file.
@@ -335,7 +335,7 @@ class Dependencies:
         elif path.endswith('pkl'):
             self._df.to_pickle(path)
 
-    def type(self, file: str) -> define.DependType:
+    def type(self, file: str) -> int:
         r"""Type of file.
 
         Args:
@@ -345,7 +345,7 @@ class Dependencies:
             type
 
         """
-        return self[file][define.DependField.TYPE]
+        return int(self._df.type[file])
 
     def version(self, file: str) -> str:
         r"""Version of file.
@@ -357,7 +357,7 @@ class Dependencies:
             version string
 
         """
-        return self[file][define.DependField.VERSION]
+        return self._df.version[file]
 
     def _add_media(
             self,
@@ -462,5 +462,4 @@ class Dependencies:
             file: relative file path
 
         """
-        removed_column = define.DEPEND_FIELD_NAMES[define.DependField.REMOVED]
-        self._df.at[file, removed_column] = 1
+        self._df.at[file, 'removed'] = 1

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -107,7 +107,7 @@ class Dependencies:
             list of archives
 
         """
-        archives = list(self._df.archive.values)
+        archives = self._df.archive.to_list()
         return sorted(list(set(archives)))
 
     @property

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -107,7 +107,8 @@ class Dependencies:
             list of archives
 
         """
-        archives = [self.archive(file) for file in self.files]
+        df = self()
+        archives = list(df.archive.values)
         return sorted(list(set(archives)))
 
     @property
@@ -128,11 +129,12 @@ class Dependencies:
             list of media
 
         """
-        select = [
-            file for file in self.files
-            if self.type(file) == define.DependType.MEDIA
-        ]
-        return select
+        df = self()
+        return list(
+            df[
+                df['type'] == define.DependType.MEDIA
+            ].index
+        )
 
     @property
     def removed_media(self) -> typing.List[str]:
@@ -142,10 +144,13 @@ class Dependencies:
             list of media
 
         """
-        select = [
-            file for file in self.media if self.removed(file)
-        ]
-        return select
+        df = self()
+        return list(
+            df[
+                (df['type'] == define.DependType.MEDIA)
+                & (df['removed'] == 1)
+            ].index
+        )
 
     @property
     def table_ids(self) -> typing.List[str]:
@@ -169,11 +174,10 @@ class Dependencies:
             list of tables
 
         """
-        select = [
-            file for file in self.files
-            if self.type(file) == define.DependType.META
-        ]
-        return select
+        df = self()
+        return list(
+            df[df['type'] == define.DependType.META].index
+        )
 
     def archive(self, file: str) -> str:
         r"""Name of archive the file belongs to.

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -144,7 +144,7 @@ def test_format(deps):
 
 def test_removed(deps):
     assert not deps.removed('file.wav')
-    assert type (deps.removed('file.wav')) == bool
+    assert type(deps.removed('file.wav')) == bool
 
 
 def test_load_save(deps):

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -104,40 +104,47 @@ def test_archive(deps):
     assert deps.archive('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.ARCHIVE
     ]
+    assert type(deps.archive('file.wav')) == str
 
 
 def test_bit_depth(deps):
     assert deps.bit_depth('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.BIT_DEPTH
     ]
+    assert type(deps.bit_depth('file.wav')) == int
 
 
 def test_channels(deps):
     assert deps.channels('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.CHANNELS
     ]
+    assert type(deps.channels('file.wav')) == int
 
 
 def test_checksum(deps):
     assert deps.checksum('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.CHECKSUM
     ]
+    assert type(deps.checksum('file.wav')) == str
 
 
 def test_duration(deps):
     assert deps.duration('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.DURATION
     ]
+    assert type(deps.duration('file.wav')) == float
 
 
 def test_format(deps):
     assert deps.format('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.FORMAT
     ]
+    assert type(deps.format('file.wav')) == str
 
 
 def test_removed(deps):
     assert not deps.removed('file.wav')
+    assert type (deps.removed('file.wav')) == bool
 
 
 def test_load_save(deps):
@@ -164,18 +171,21 @@ def test_sampling_rate(deps):
     assert deps.sampling_rate('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.SAMPLING_RATE
     ]
+    assert type(deps.sampling_rate('file.wav')) == int
 
 
 def test_type(deps):
     assert deps.type('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.TYPE
     ]
+    assert type(deps.type('file.wav')) == int
 
 
 def test_version(deps):
     assert deps.version('file.wav') == ENTRIES['file.wav'][
         audb.core.define.DependField.VERSION
     ]
+    assert type(deps.version('file.wav')) == str
 
 
 def test_len(deps):


### PR DESCRIPTION
First step to tackle #65.

This updates the behavior of:
* `audb.Dependencies.archives`
* `audb.Dependencies.media`
* `audb.Dependencies.removed_media`
* `audb.Dependencies.tables`

Benchmarks for those methods and different versions of **audb**:

**audb 1.0.4**

```python
>>> import timeit
>>> import audb
>>> deps = audb.dependencies('msppodcast', version='2.3.0')
>>> timeit.timeit("deps.archives", number=5, setup="from __main__ import deps")
0.11034618501435034
>>> timeit.timeit("deps.media", number=5, setup="from __main__ import deps")
0.13136671000393108
>>> timeit.timeit("deps.removed_media", number=5, setup="from __main__ import deps")
0.2797733129991684
>>> timeit.timeit("deps.tables", number=5, setup="from __main__ import deps")
0.13713882298907265
```

**audb 1.1.1**

```python
>>> import timeit
>>> import audb
>>> deps = audb.dependencies('msppodcast', version='2.3.0')
>>> timeit.timeit("deps.archives", number=5, setup="from __main__ import deps")
37.68356798301102
>>> timeit.timeit("deps.media", number=5, setup="from __main__ import deps")
37.831175989005715
>>> timeit.timeit("deps.removed_media", number=5, setup="from __main__ import deps")
76.96915411399095
>>> timeit.timeit("deps.tables", number=5, setup="from __main__ import deps")
38.687777246988844
```

So it turned out we made loading of the dependencies much faster but slowed down some of the methods to access the data.
This pull request fixes this and gets even better performance than we had in audb 1.0.4:

**this pull request**

```python
>>> import timeit
>>> import audb
>>> deps = audb.dependencies('msppodcast', version='2.3.0')
>>> timeit.timeit("deps.archives", number=5, setup="from __main__ import deps")
0.008474344009300694
>>> timeit.timeit("deps.media", number=5, setup="from __main__ import deps")
0.06901428097626194
>>> timeit.timeit("deps.removed_media", number=5, setup="from __main__ import deps")
0.018163354019634426
>>> timeit.timeit("deps.tables", number=5, setup="from __main__ import deps")
0.005193330987822264
```

The speedup is achieved by always directly using the dataframe.