### PR TITLE
Allow audb.load() to work offline

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -204,7 +204,6 @@ def dependencies(
     """
     if version is None:
         version = latest_version(name)
-    backend = lookup_backend(name, version)
 
     cache_roots = [
         default_cache_root(True),  # check shared cache first
@@ -226,6 +225,7 @@ def dependencies(
 
     deps = Dependencies()
     if not os.path.exists(deps_path):
+        backend = lookup_backend(name, version)
         with tempfile.TemporaryDirectory() as tmp_root:
             archive = backend.join(name, define.DB)
             backend.get_archive(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -543,7 +543,7 @@ def database_tmp_folder(
     The temporary cache folder is created under ``cache_root + '~'``.
 
     Args:
-        cache_root: oath to cache folder
+        cache_root: path to cache folder
 
     Returns:
         path to temporary cache folder

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -797,6 +797,7 @@ def load_header(
         *,
         flavor: Flavor = None,
         add_audb_meta: bool = False,
+        overwrite: bool = False,
 ) -> typing.Tuple[audformat.Database, typing.Optional[audbackend.Backend]]:
     r"""Load database header from folder or backend.
 
@@ -813,11 +814,13 @@ def load_header(
             needed if ``add_audb_meta`` is True
         add_audb_meta: if ``True`` it adds an ``audb`` meta entry
             to the database header before storing it in cache
+        overwrite: always load header from backend
+            and overwrite the one found in ``db_root``
 
     """
     backend = None
     local_header = os.path.join(db_root, define.HEADER_FILE)
-    if not os.path.exists(local_header):
+    if overwrite or not os.path.exists(local_header):
         backend = lookup_backend(name, version)
         remote_header = backend.join(name, define.HEADER_FILE)
         if add_audb_meta:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -817,6 +817,9 @@ def load_header(
         overwrite: always load header from backend
             and overwrite the one found in ``db_root``
 
+    Returns:
+        database header and backend
+
     """
     backend = None
     local_header = os.path.join(db_root, define.HEADER_FILE)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -641,7 +641,6 @@ def load(
         kwargs,
     )
 
-    backend = lookup_backend(name, version)
     cached_versions = None
 
     flavor = Flavor(

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -16,7 +16,6 @@ from audb.core.load import (
     database_tmp_folder,
     load_header,
 )
-from audb.core.utils import lookup_backend
 
 
 def _find_media(

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -250,7 +250,6 @@ def load_to(
     """
     if version is None:
         version = latest_version(name)
-    backend = lookup_backend(name, version)
 
     db_root = audeer.safe_path(root)
     db_root_tmp = database_tmp_folder(db_root)
@@ -268,16 +267,19 @@ def load_to(
                 if checksum != deps.checksum(file):
                     os.remove(full_file)
 
-    # load database header without tables
+    # load database header without tables from backend
 
-    db_header, backend = load_header(db_root_tmp, name, version)
+    db_header, backend = load_header(
+        db_root_tmp,
+        name,
+        version,
+        overwrite=True,
+    )
 
     # get altered and new tables
 
     db_header.save(db_root_tmp, header_only=True)
     tables = _find_tables(db_header, db_root, deps, num_workers, verbose)
-    if backend is None:
-        backend = lookup_backend(name, version)
     _get_tables(tables, db_root, db_root_tmp, name, deps, backend,
                 num_workers, verbose)
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -160,6 +160,17 @@ def fixture_publish_db():
     clear_root(pytest.FILE_SYSTEM_HOST)
 
 
+def test_database_cache_folder():
+    cache_root = os.path.join(pytest.CACHE_ROOT, 'cache')
+    db_root = audb.core.load.database_cache_folder(
+        DB_NAME,
+        '1.0.0',
+        audb.Flavor(),
+        cache_root=cache_root,
+    )
+    assert db_root.startswith(audeer.safe_path(cache_root))
+
+
 @pytest.mark.parametrize(
     'format',
     [

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -131,6 +131,23 @@ def test_load_on_demand():
     pd.testing.assert_index_equal(db.files, db_original['table1'].files)
     assert not db.meta['audb']['complete']
 
+    # Remove table to force downloading from backend again
+    os.remove(os.path.join(db.meta['audb']['root'], 'db.table1.csv'))
+    os.remove(os.path.join(db.meta['audb']['root'], 'db.table1.pkl'))
+
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        only_metadata=True,
+        full_path=False,
+        verbose=False,
+    )
+
+    assert db['table1'] == db_original['table1']
+    assert db['table2'] == db_original['table2']
+    pd.testing.assert_index_equal(db.files, db_original.files)
+    assert not db.meta['audb']['complete']
+
     db = audb.load(
         DB_NAME,
         version=DB_VERSION,


### PR DESCRIPTION
Closes #64.

As stated in #64 `audb.load()` requires always an Internet connection at the moment as it always creates a backend object.

This fixes it by only requesting a backend if really needed. I discovered that it would make sense to start tackling #46 as well and adjusted the `load_header()` function to work in both cases.

In addition, `audb.dependenceis()` is also updated to only connect to a backend if really needed.

I don't know how easy you can write a test for checking that it works offline.
So far I only tested it manually with the two commands:
```python
db = audb.load('emodb', only_metadata=True, version='1.1.0')
db = audb.load('emodb', version='1.1.0')
```
which both have worked.