### PR TITLE
DOC: add section on shared cache right management

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -99,3 +99,6 @@ Note,
 1. overwrites all other methods,
 2. overwrites 3. and 4.,
 and so on.
+
+
+.. _adjust the rights: https://superuser.com/a/264406

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -18,14 +18,35 @@ Next time your request it again,
 :mod:`audb` will directly load the database from there.
 
 :mod:`audb` distinguishes two :file:`<cache>` folders.
-A system wide shared cache folder.
-By default it is located at
+A system wide shared cache folder and a user cache folder.
+
+
+Shared cache
+------------
+
+By default the shared cache is located at
 
 .. jupyter-execute::
 
     audb.default_cache_root(shared=True)
 
 and is meant to be shared by several users.
+
+In order to provide read and write access
+to all users to the shared cache folder,
+they need to be in the same group
+and you have to `adjust the rights`_
+of the shared cache folder with
+
+.. code-block:: bash
+
+    $ chmod 775 /data/audb  # set right of cache folder
+    $ chmod g+s /data/audb  # content inherits group ownership
+    $ setfacl -d -m u::rwx,g::rwx,o::rx- /data/audb  # content inherits rights
+
+
+User cache
+----------
 
 The second cache folder should be
 accessible to you only.
@@ -38,6 +59,10 @@ By default it points to
 When you request a database with :meth:`audb.load`,
 :mod:`audb` first looks for it in the shared cache folder
 and afterwards in your local cache folder.
+
+
+Changing cache locations
+------------------------
 
 There are four ways to change the default locations:
 


### PR DESCRIPTION
Closes #58.

Adds documentation on how to configure the shared cache folder to make it work with read+write rights shared across users.
It also introduces sub-section in the caching documentation page.

![image](https://user-images.githubusercontent.com/173624/117124409-91f02200-ad98-11eb-9fc3-677c968b1437.png)

This settles for the proposal described in https://github.com/audeering/audb/pull/72#issuecomment-832534640,
before it tried to implement the right management directly inside `audb` as we did before version 1.0.0.