### PR TITLE
audb.info.header() now caches and works offline

### DIFF
--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -1,12 +1,9 @@
-import os
-import tempfile
 import typing
 
 import pandas as pd
 
 import audformat
 
-from audb.core import define
 from audb.core.api import (
     dependencies,
     latest_version,
@@ -15,7 +12,6 @@ from audb.core.load import (
     database_cache_folder,
     load_header,
 )
-from audb.core.utils import lookup_backend
 
 
 def author(

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -11,7 +11,10 @@ from audb.core.api import (
     dependencies,
     latest_version,
 )
-from audb.core.load import load_header
+from audb.core.load import (
+    database_cache_folder,
+    load_header,
+)
 from audb.core.utils import lookup_backend
 
 
@@ -182,7 +185,7 @@ def header(
     """
     if version is None:
         version = latest_version(name)
-    db_root = database_cache_folder(name, version, Flavor(), cache_root)
+    db_root = database_cache_folder(name, version, cache_root)
     db, _ = load_header(db_root, name, version)
     return db
 

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -11,6 +11,7 @@ from audb.core.api import (
     dependencies,
     latest_version,
 )
+from audb.core.load import load_header
 from audb.core.utils import lookup_backend
 
 
@@ -18,18 +19,21 @@ def author(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> str:
     """Author(s) of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         author(s) of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.author
 
 
@@ -89,18 +93,21 @@ def description(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> str:
     """Description of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         description of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.description
 
 
@@ -159,16 +166,15 @@ def header(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> audformat.Database:
     r"""Load header of database.
-
-    Downloads the :file:`db.yaml` to a temporal directory,
-    loads the database header and returns it.
-    Does not write to the :mod:`audb` cache folders.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         database object without table data
@@ -176,18 +182,8 @@ def header(
     """
     if version is None:
         version = latest_version(name)
-    backend = lookup_backend(name, version)
-
-    with tempfile.TemporaryDirectory() as root:
-        remote_header = backend.join(name, define.HEADER_FILE)
-        local_header = os.path.join(root, define.HEADER_FILE)
-        backend.get_file(
-            remote_header,
-            local_header,
-            version,
-        )
-        db = audformat.Database.load(root, load_data=False)
-
+    db_root = database_cache_folder(name, version, Flavor(), cache_root)
+    db, _ = load_header(db_root, name, version)
     return db
 
 
@@ -195,18 +191,21 @@ def languages(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.List[str]:
     """Languages of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         languages of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.languages
 
 
@@ -214,18 +213,21 @@ def license(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> str:
     """License of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         license of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.license
 
 
@@ -233,18 +235,21 @@ def license_url(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> str:
     """License URL of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         license URL of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.license_url
 
 
@@ -252,18 +257,21 @@ def media(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Dict:
     """Audio and video media of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         media of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.media
 
 
@@ -271,18 +279,21 @@ def meta(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Dict:
     """Meta information of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         meta information of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.meta
 
 
@@ -290,18 +301,21 @@ def organization(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> str:
     """Organization responsible for database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         organization responsible for database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.organization
 
 
@@ -309,18 +323,21 @@ def raters(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Dict:
     """Raters contributed to database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         raters of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.raters
 
 
@@ -354,18 +371,21 @@ def schemes(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Dict:
     """Schemes of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         schemes of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.schemes
 
 
@@ -373,18 +393,21 @@ def source(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> str:
     """Source of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         source of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.source
 
 
@@ -392,18 +415,21 @@ def splits(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Dict:
     """Splits of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         splits of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.splits
 
 
@@ -411,18 +437,21 @@ def tables(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> typing.Dict:
     """Tables of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         tables of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.tables
 
 
@@ -430,16 +459,19 @@ def usage(
         name: str,
         *,
         version: str = None,
+        cache_root: str = None,
 ) -> str:
     """Usage of database.
 
     Args:
         name: name of database
         version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
 
     Returns:
         usage of database
 
     """
-    db = header(name, version=version)
+    db = header(name, version=version, cache_root=cache_root)
     return db.usage

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -499,16 +499,16 @@ def _tables(
 def database_cache_folder(
         name: str,
         version: str,
-        flavor: Flavor,
-        cache_root: typing.Optional[str],
+        cache_root: str = None,
+        flavor: Flavor = None,
 ) -> str:
     r"""Create and return database cache folder.
 
     Args:
         name: name of database
         version: version of database
-        flavor: flavor of database
         cache_root: path to cache folder
+        flavor: flavor of database
 
     Returns:
         path to cache folder
@@ -522,12 +522,14 @@ def database_cache_folder(
     else:
         cache_roots = [cache_root]
     for cache_root in cache_roots:
-        db_root = audeer.safe_path(
-            os.path.join(
+        if flavor is None:
+            db_root = cache_root
+        else:
+            db_root = os.path.join(
                 cache_root,
                 flavor.path(name, version),
             )
-        )
+        db_root = audeer.safe_path(db_root)
         if os.path.exists(db_root):
             break
 
@@ -650,7 +652,7 @@ def load(
         bit_depth=bit_depth,
         sampling_rate=sampling_rate,
     )
-    db_root = database_cache_folder(name, version, flavor, cache_root)
+    db_root = database_cache_folder(name, version, cache_root, flavor)
     db_root_tmp = database_tmp_folder(db_root)
 
     if verbose:  # pragma: no cover

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -523,7 +523,11 @@ def database_cache_folder(
         cache_roots = [cache_root]
     for cache_root in cache_roots:
         if flavor is None:
-            db_root = cache_root
+            db_root = os.path.join(
+                cache_root,
+                name,
+                version,
+            )
         else:
             db_root = os.path.join(
                 cache_root,

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -279,8 +279,6 @@ def load_to(
 
     db_header.save(db_root_tmp, header_only=True)
     tables = _find_tables(db_header, db_root, deps, num_workers, verbose)
-    if backend is None:
-        backend = lookup_backend(name, version)
     _get_tables(tables, db_root, db_root_tmp, name, deps, backend,
                 num_workers, verbose)
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -279,6 +279,8 @@ def load_to(
 
     db_header.save(db_root_tmp, header_only=True)
     tables = _find_tables(db_header, db_root, deps, num_workers, verbose)
+    if backend is None:
+        backend = lookup_backend(name, version)
     _get_tables(tables, db_root, db_root_tmp, name, deps, backend,
                 num_workers, verbose)
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -162,12 +162,18 @@ def fixture_publish_db():
 
 def test_database_cache_folder():
     cache_root = os.path.join(pytest.CACHE_ROOT, 'cache')
+    version = '1.0.0'
     db_root = audb.core.load.database_cache_folder(
         DB_NAME,
-        '1.0.0',
+        version,
         cache_root,
     )
-    assert db_root.startswith(audeer.safe_path(cache_root))
+    expected_db_root = os.path.join(
+        cache_root,
+        DB_NAME,
+        version,
+    )
+    assert db_root == expected_db_root
 
 
 @pytest.mark.parametrize(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -165,8 +165,7 @@ def test_database_cache_folder():
     db_root = audb.core.load.database_cache_folder(
         DB_NAME,
         '1.0.0',
-        audb.Flavor(),
-        cache_root=cache_root,
+        cache_root,
     )
     assert db_root.startswith(audeer.safe_path(cache_root))
 


### PR DESCRIPTION
This allows `audb.info` module to work offline by caching the header files.

`audb.info.header()` before was returning the original header without any flavor info. I cache this now under `cache_root/name/version` as we also do with the dependency file.
It also differs from the header cached under the flavors as those do not store the original header, but insert the audb meta entry.

This pull request also has the advantage that now all functions under `audb.info` have the `cache_root` argument.

This of course also speeds the processing up as the header is cached:

Don't use the cache at all (master):
```python
>>> timeit.timeit("audb.info.description('emodb', version='1.1.1')", number=5, setup="import audb")
19.351356413993926
```

Starting from cache:
```python
>>> timeit.timeit("audb.info.description('emodb', version='1.1.1')", number=5, setup="import audb")
0.09034161500312621
```