### PR TITLE
Speedup some audb.info functions

### DIFF
--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -53,7 +53,7 @@ def bit_depths(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set(df[df.type == define.DependType.MEDIA]['bit_depth'])
+    return set(df[df.type == define.DependType.MEDIA].bit_depth)
 
 
 def channels(
@@ -76,7 +76,7 @@ def channels(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set(df[df.type == define.DependType.MEDIA]['channels'])
+    return set(df[df.type == define.DependType.MEDIA].channels)
 
 
 def description(
@@ -119,7 +119,7 @@ def duration(
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
     return pd.to_timedelta(
-        df[df.type == define.DependType.MEDIA]['duration'].sum(),
+        df[df.type == define.DependType.MEDIA].duration.sum(),
         unit='s',
     )
 
@@ -144,7 +144,7 @@ def formats(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set(df[df.type == define.DependType.MEDIA]['format'])
+    return set(df[df.type == define.DependType.MEDIA].format)
 
 
 def header(
@@ -336,7 +336,7 @@ def sampling_rates(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set(df[df.type == define.DependType.MEDIA]['sampling_rate'])
+    return set(df[df.type == define.DependType.MEDIA].sampling_rate)
 
 
 def schemes(

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -52,11 +52,8 @@ def bit_depths(
 
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
-    return set(
-        [
-            deps.bit_depth(file) for file in deps.media
-        ]
-    )
+    df = deps()
+    return set(df[df.type == define.DependType.MEDIA]['bit_depth'])
 
 
 def channels(
@@ -78,11 +75,8 @@ def channels(
 
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
-    return set(
-        [
-            deps.channels(file) for file in deps.media
-        ]
-    )
+    df = deps()
+    return set(df[df.type == define.DependType.MEDIA]['channels'])
 
 
 def description(
@@ -123,8 +117,9 @@ def duration(
 
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
+    df = deps()
     return pd.to_timedelta(
-        sum([deps.duration(file) for file in deps.media]),
+        sum([df[df.type == define.DependType.MEDIA]['duration']]),
         unit='s',
     )
 
@@ -148,11 +143,8 @@ def formats(
 
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
-    return set(
-        [
-            deps.format(file) for file in deps.media
-        ]
-    )
+    df = deps()
+    return set([df[df.type == define.DependType.MEDIA]['format']])
 
 
 def header(
@@ -343,11 +335,8 @@ def sampling_rates(
 
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
-    return set(
-        [
-            deps.sampling_rate(file) for file in deps.media
-        ]
-    )
+    df = deps()
+    return set([df[df.type == define.DependType.MEDIA]['sampling_rate']])
 
 
 def schemes(

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -144,7 +144,7 @@ def formats(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set(df[df.type == define.DependType.MEDIA]['format'].values)
+    return set(df[df.type == define.DependType.MEDIA]['format'])
 
 
 def header(
@@ -336,7 +336,7 @@ def sampling_rates(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set(df[df.type == define.DependType.MEDIA]['sampling_rate'].values)
+    return set(df[df.type == define.DependType.MEDIA]['sampling_rate'])
 
 
 def schemes(

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -119,7 +119,7 @@ def duration(
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
     return pd.to_timedelta(
-        sum([df[df.type == define.DependType.MEDIA]['duration']]),
+        df[df.type == define.DependType.MEDIA]['duration'].sum(),
         unit='s',
     )
 
@@ -144,7 +144,7 @@ def formats(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set([df[df.type == define.DependType.MEDIA]['format']])
+    return set(df[df.type == define.DependType.MEDIA]['format'].values)
 
 
 def header(
@@ -336,7 +336,7 @@ def sampling_rates(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     df = deps()
-    return set([df[df.type == define.DependType.MEDIA]['sampling_rate']])
+    return set(df[df.type == define.DependType.MEDIA]['sampling_rate'].values)
 
 
 def schemes(


### PR DESCRIPTION
Speedup some functions in `audb.info` by accessing the dataframe directly.

A benchmark starting from having the dependency file cached already.

Current master:
```python
>>> timeit.timeit("audb.info.duration('msppodcast', version='2.3.0')", number=5, setup="import audb")
2.2127648669993505
```

```python
>>> timeit.timeit("audb.info.duration('msppodcast', version='2.3.0')", number=5, setup="import audb")
0.15798950500175124
```