### PR TITLE
DOC: use sphinx-audeering-theme>=1.0.12

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 docutils<0.17  # until https://github.com/sphinx-doc/sphinx/pull/9053 is released
 jupyter-sphinx
 sphinx >=3.5.1
-sphinx-audeering-theme
+sphinx-audeering-theme >=1.0.12
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinxcontrib-katex


### PR DESCRIPTION
Closes #57.

The underlying search javascript issue was solved in `sphinx-audeering-theme` 1.0.12, so we switch to it.