### PR TITLE
WIP: DOC: use sphinx>=3.5.4 to fix docutils

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
-docutils<0.17  # until https://github.com/sphinx-doc/sphinx/pull/9053 is released
+docutils
 jupyter-sphinx
-sphinx >=3.5.1
+sphinx >=3.5.4
 sphinx-audeering-theme >=1.0.12
 sphinx-autodoc-typehints
 sphinx-copybutton


### PR DESCRIPTION
As the underlying problem using newer `docutils` with `sphinx` (https://github.com/audeering/sphinx-audeering-theme/pull/31) was fixed in `sphinx>3.5.4`, I will switch to that release and don't restrict `docutils` any longer.

Tested it locally.