### PR TITLE
Fix looking for cached files

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -79,16 +79,17 @@ def _cached_files(
         file_version = LooseVersion(deps.version(file))
         for cache_version, cache_root, cache_deps in cached_versions:
             if cache_version >= file_version:
-                if deps.checksum(file) == cache_deps.checksum(file):
-                    path = os.path.join(cache_root, file)
-                    if flavor.format is not None:
-                        path = audeer.replace_file_extension(
-                            path,
-                            flavor.format,
-                        )
-                    if os.path.exists(path):
-                        found = True
-                        break
+                if file in cache_deps:
+                    if deps.checksum(file) == cache_deps.checksum(file):
+                        path = os.path.join(cache_root, file)
+                        if flavor and flavor.format is not None:
+                            path = audeer.replace_file_extension(
+                                path,
+                                flavor.format,
+                            )
+                        if os.path.exists(path):
+                            found = True
+                            break
         if found:
             if flavor.format is not None:
                 file = audeer.replace_file_extension(
@@ -258,7 +259,7 @@ def _get_media_from_backend(
         media: typing.Sequence[str],
         db_root: str,
         db_root_tmp: str,
-        flavor: typing.Optional[Flavor],
+        flavor: Flavor,
         deps: Dependencies,
         backend: audbackend.Backend,
         num_workers: typing.Optional[int],

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -91,7 +91,7 @@ def _cached_files(
                             found = True
                             break
         if found:
-            if flavor.format is not None:
+            if flavor and flavor.format is not None:
                 file = audeer.replace_file_extension(
                     file,
                     flavor.format,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -62,7 +62,7 @@ def _cached_files(
         cached_versions: typing.Sequence[
             typing.Tuple[LooseVersion, str, Dependencies],
         ],
-        flavor: Flavor,
+        flavor: typing.Optional[Flavor],
         verbose: bool,
 ) -> (typing.Sequence[typing.Union[str, str]], typing.Sequence[str]):
     r"""Find cached files."""
@@ -418,7 +418,6 @@ def _get_tables_from_cache(
         cached_versions: typing.Sequence[
             typing.Tuple[LooseVersion, str, Dependencies]
         ],
-        flavor: Flavor,
         num_workers: int,
         verbose: bool,
 ) -> typing.Sequence[str]:
@@ -428,7 +427,7 @@ def _get_tables_from_cache(
         tables,
         deps,
         cached_versions,
-        flavor,
+        None,
         verbose,
     )
 
@@ -679,7 +678,6 @@ def load(
                     db_root_tmp,
                     deps,
                     cached_versions,
-                    flavor,
                     num_workers,
                     verbose,
                 )

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -259,7 +259,7 @@ def _get_media_from_backend(
         media: typing.Sequence[str],
         db_root: str,
         db_root_tmp: str,
-        flavor: Flavor,
+        flavor: typing.Optional[Flavor],
         deps: Dependencies,
         backend: audbackend.Backend,
         num_workers: typing.Optional[int],

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -170,11 +170,11 @@ def fixture_publish_db():
 @pytest.mark.parametrize(
     'version',
     [
+        None,  # 3.0.0
         '1.0.0',
         '1.1.0',
         '1.1.1',
         '2.0.0',
-        None,  # 3.0.0
         pytest.param(
             '4.0.0',
             marks=pytest.mark.xfail(raises=RuntimeError),


### PR DESCRIPTION
Fixes two problems when `load()` is looking for cached files:

1. check if file is in dependencies of other version
2. do not replace extension when looking for tables

To verify that the problem is fixed, I changed the order in which versions are loaded in `tests/test_load`. This was raising an error before since a table was removed in `3.0.0` and when loading `1.0.0` afterwards it could not find the removed table in the dependencies of `3.0.0`.