### PR TITLE
Add audb.load_media()

### DIFF
--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -14,7 +14,10 @@ from audb.core.backward import get_default_cache_root
 from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor
-from audb.core.load import load
+from audb.core.load import (
+    load,
+    load_media,
+)
 from audb.core.load_to import load_to
 from audb.core.publish import publish
 from audb.core.repository import Repository

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -131,8 +131,6 @@ def cached(
                         flavor_id_path,
                         load_data=False,
                     )
-                    print(flavor_id_path)
-                    print(db)
                     flavor = db.meta['audb']['flavor']
                     complete = db.meta['audb']['complete']
                     data[flavor_id_path] = {

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -131,6 +131,8 @@ def cached(
                         flavor_id_path,
                         load_data=False,
                     )
+                    print(flavor_id_path)
+                    print(db)
                     flavor = db.meta['audb']['flavor']
                     complete = db.meta['audb']['complete']
                     data[flavor_id_path] = {

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -918,6 +918,7 @@ def load_media(
         name,
         version,
         flavor=flavor,
+        add_audb_meta=True,
     )
 
     db_is_complete = _database_is_complete(db)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -423,10 +423,6 @@ def _load_media(
     or are downloaded from the backend.
 
     """
-    print(db_root)
-    print(media)
-    print(flavor)
-    print(verbose)
     missing_media = _missing_media(
         db_root,
         media,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -896,6 +896,13 @@ def load_media(
     media = audeer.to_list(media)
     deps = dependencies(name, version=version, cache_root=cache_root)
 
+    available_files = deps.media
+    for media_file in media:
+        if media_file not in available_files:
+            raise ValueError(
+                f"Could not find '{media_file}' in {name} {version}"
+            )
+
     cached_versions = None
 
     flavor = Flavor(
@@ -905,7 +912,7 @@ def load_media(
         bit_depth=bit_depth,
         sampling_rate=sampling_rate,
     )
-    db_root = database_cache_folder(name, version, flavor, cache_root)
+    db_root = database_cache_folder(name, version, cache_root, flavor)
     db_root_tmp = database_tmp_folder(db_root)
 
     if verbose:  # pragma: no cover

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -911,8 +911,7 @@ def load_media(
 
     Args:
         name: name of database
-        media: load media files matching the regular expression
-            or provided in the list
+        media: load media files provided in the list
         version: version of database
         bit_depth: bit depth, one of ``16``, ``24``, ``32``
         channels: channel selection, see :func:`audresample.remix`.

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -903,6 +903,12 @@ def load_media(
 ) -> typing.List:
     r"""Load media file(s).
 
+    If you are only interested in media files
+    and not the corresponding tables,
+    you should use :func:`audb.load_media`
+    instead of :func:`audb.load`
+    as it is faster.
+
     Args:
         name: name of database
         media: load media files matching the regular expression

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -943,13 +943,13 @@ def load_media(
         >>> paths = load_media(
         ...     'emodb',
         ...     ['wav/03a01Fa.wav'],
-        ...     version='1.1.1',
+        ...     version='1.1.0',
         ...     format='flac',
         ...     verbose=False,
         ... )
         >>> cache_root = audb.default_cache_root()
         >>> [p[len(cache_root):] for p in paths]
-        ['/emodb/1.1.1/40bb2241/wav/03a01Fa.flac']
+        ['/emodb/1.1.0/40bb2241/wav/03a01Fa.flac']
 
     """
     media = audeer.to_list(media)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -203,7 +203,7 @@ def _full_path(
 
 
 def _get_media_from_backend(
-        db: audformat.Database,
+        name: str,
         media: typing.Sequence[str],
         db_root: str,
         db_root_tmp: str,
@@ -242,7 +242,7 @@ def _get_media_from_backend(
 
     def job(archive: str, version: str):
         archive = backend.join(
-            db.name,
+            name,
             define.DEPEND_TYPE_NAMES[define.DependType.MEDIA],
             archive,
         )
@@ -758,7 +758,7 @@ def load(
                 if backend is None:
                     backend = lookup_backend(name, version)
                 _get_media_from_backend(
-                    db,
+                    name,
                     missing_media,
                     db_root,
                     db_root_tmp,
@@ -953,7 +953,7 @@ def load_media(
                 if backend is None:
                     backend = lookup_backend(name, version)
                 _get_media_from_backend(
-                    db,
+                    name,
                     missing_media,
                     db_root,
                     db_root_tmp,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -939,6 +939,18 @@ def load_media(
         ValueError: if a media file is requested
             that is not part of the database
 
+    Example:
+        >>> paths = load_media(
+        ...     'emodb',
+        ...     ['wav/03a01Fa.wav'],
+        ...     version='1.1.1',
+        ...     format='flac',
+        ...     verbose=False,
+        ... )
+        >>> cache_root = audb.default_cache_root()
+        >>> [p[len(cache_root):] for p in paths]
+        ['/emodb/1.1.1/40bb2241/wav/03a01Fa.flac']
+
     """
     media = audeer.to_list(media)
     if len(media) == 0:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -990,4 +990,7 @@ def load_media(
             verbose,
         )
 
+    if format is not None:
+        media = [audeer.replace_file_extension(m, format) for m in media]
+
     return [os.path.join(db_root, m) for m in media]

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -935,6 +935,10 @@ def load_media(
     Returns:
         paths to media files
 
+    Raises:
+        ValueError: if a media file is requested
+            that is not part of the database
+
     """
     media = audeer.to_list(media)
     if len(media) == 0:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,6 +63,11 @@ load
 
 .. autofunction:: load
 
+load_media
+----------
+
+.. autofunction:: load_media
+
 load_to
 -------
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -261,6 +261,61 @@ def test_load(format, version):
 
 
 @pytest.mark.parametrize(
+    'version, media, format',
+    [
+        (
+            '1.0.0',
+            'audio/001.wav',
+            'wav',
+        ),
+        (
+            '1.0.0',
+            ['audio/001.flac', 'audio/002.flac'],
+            'flac',
+        ),
+        (
+            None,
+            ['audio/001.wav'],
+            None,
+        ),
+    ]
+)
+def test_load_media(version, media, format):
+
+    paths = audb.load_media(
+        DB_NAME,
+        media,
+        version=version,
+        format=format,
+        verbose=False,
+    )
+    if format is not None:
+        expected_paths = [
+            audeer.replace_file_extension(p, format)
+            for p in paths
+        ]
+    else:
+        expected_paths = paths
+    if format is None:
+        expected_paths = [
+            os.path.join(pytest.CACHE_ROOT, p)
+            for p in paths
+        ]
+    else:
+        expected_paths = [
+            os.path.join(
+                pytest.CACHE_ROOT,
+                audeer.replace_file_extension(p, format)
+            )
+            for p in paths
+        ]
+    assert paths == expected_paths
+
+    # Clear cache to force loading from other cache
+    cache_root = audb.core.load.database_cache_folder
+
+
+@pytest.mark.parametrize(
     'version',
     [
         None,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -265,6 +265,11 @@ def test_load(format, version):
     [
         (
             '1.0.0',
+            [],
+            None,
+        ),
+        (
+            '1.0.0',
             'audio/001.wav',
             'wav',
         ),

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -312,7 +312,21 @@ def test_load_media(version, media, format):
     assert paths == expected_paths
 
     # Clear cache to force loading from other cache
-    cache_root = audb.core.load.database_cache_folder
+    cache_root = audb.core.load.database_cache_folder(
+        DB_NAME,
+        version,
+        audb.Flavor(format=format),
+        cache_root=pytest.CACHE_ROOT,
+    )
+    shutil.rmtree(cache_root)
+    paths2 = audb.load_media(
+        DB_NAME,
+        media,
+        version=version,
+        format=format,
+        verbose=False,
+    )
+    assert path2 == path
 
 
 @pytest.mark.parametrize(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -304,6 +304,11 @@ def test_load_media(version, media, format):
         os.path.join(pytest.CACHE_ROOT, p)
         for p in paths
     ]
+    if format is not None:
+        expected_paths = [
+            audeer.replace_file_extension(p, format)
+            for p in expected_paths
+        ]
     assert paths == expected_paths
 
     # Clear cache to force loading from other cache

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -302,6 +302,8 @@ def test_load_media(version, media, format):
     assert paths == expected_paths
 
     # Clear cache to force loading from other cache
+    if version is None:
+        version = audb.latest_version(DB_NAME)
     cache_root = audb.core.load.database_cache_folder(
         DB_NAME,
         version,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -268,9 +268,15 @@ def test_load(format, version):
             'audio/001.wav',
             'wav',
         ),
-        (
+        pytest.param(
             '1.0.0',
             ['audio/001.flac', 'audio/002.flac'],
+            'flac',
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        (
+            '1.0.0',
+            ['audio/001.wav', 'audio/002.wav'],
             'flac',
         ),
         (
@@ -289,34 +295,18 @@ def test_load_media(version, media, format):
         format=format,
         verbose=False,
     )
-    if format is not None:
-        expected_paths = [
-            audeer.replace_file_extension(p, format)
-            for p in paths
-        ]
-    else:
-        expected_paths = paths
-    if format is None:
-        expected_paths = [
-            os.path.join(pytest.CACHE_ROOT, p)
-            for p in paths
-        ]
-    else:
-        expected_paths = [
-            os.path.join(
-                pytest.CACHE_ROOT,
-                audeer.replace_file_extension(p, format)
-            )
-            for p in paths
-        ]
+    expected_paths = [
+        os.path.join(pytest.CACHE_ROOT, p)
+        for p in paths
+    ]
     assert paths == expected_paths
 
     # Clear cache to force loading from other cache
     cache_root = audb.core.load.database_cache_folder(
         DB_NAME,
         version,
+        pytest.CACHE_ROOT,
         audb.Flavor(format=format),
-        cache_root=pytest.CACHE_ROOT,
     )
     shutil.rmtree(cache_root)
     paths2 = audb.load_media(
@@ -326,7 +316,7 @@ def test_load_media(version, media, format):
         format=format,
         verbose=False,
     )
-    assert path2 == path
+    assert paths2 == paths
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #63.

It adds `audb.load_media()` that allows you to load single media files without the need to download any table of a database, just the header is needed. The header is only needed to check if the database is complete.

Example:

```python
>>> audb.load_media('emodb', ['wav/03a01Fa.wav'], version='1.1.1', verbose=False)
['/home/audeering.local/hwierstorf/audb/emodb/1.1.1/d3b62a9b/wav/03a01Fa.wav']
```
or
```python
>>> audb.load_media('emodb', ['wav/03a01Fa.wav'], version='1.1.1', format='flac', verbose=False)
['/home/audeering.local/hwierstorf/audb/emodb/1.1.1/40bb2241/wav/03a01Fa.flac']
```

![image](https://user-images.githubusercontent.com/173624/117114839-9ca4ba00-ad8c-11eb-904a-5aea0e7f890b.png)

It makes loading media files easier and faster.
For example, loading from cache (10 repetitions):

```python
>>> timeit.timeit('audb.load("msppodcast", version="2.3.0", media=["Audios/MSP-PODCAST_0001_0008.wav"], full_path=False, verbose=False)', number=10, setup="import audb")
4.3233700249984395
>>> timeit.timeit('audb.load_media("msppodcast", ["Audios/MSP-PODCAST_0001_0008.wav"], version="2.3.0", verbose=False)', number=10, setup="import audb")
0.6363414400111651
```

Loading from backend (1 repetition):

```python
>>> timeit.timeit('audb.load("msppodcast", version="2.3.0", media=["Audios/MSP-PODCAST_0001_0008.wav"], full_path=False, verbose=False)', number=1, setup="import audb")
63.01021525000397
>>> timeit.timeit('audb.load_media("msppodcast", ["Audios/MSP-PODCAST_0001_0008.wav"], version="2.3.0", verbose=False)', number=1, setup="import audb")
22.10454593000759
```