### PR TITLE
DOC: remove katex sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'sphinx_copybutton',
-    'sphinxcontrib.katex',  # has to be before jupyter_sphinx
     'sphinxcontrib.programoutput',
     'jupyter_sphinx',
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,4 @@ sphinx >=3.5.4
 sphinx-audeering-theme >=1.0.12
 sphinx-autodoc-typehints
 sphinx-copybutton
-sphinxcontrib-katex
 sphinxcontrib-programoutput


### PR DESCRIPTION
As we do not use any math in the documentation, there is no need to include the [sphinxcontrib-katex](https://github.com/hagenw/sphinxcontrib-katex) extension.