### PR TITLE
CI: store audb cache for building documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
 
     - name: Test with pytest
       run: |
+        ls ~/audb
         python -m pytest
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache emodb
+      uses: actions/cache@v2
+      with:
+        path: ~/audb
+        key: emodb-ubuntu
+      if: matrix.os == 'ubuntu-18.04'
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
 
+    - name: Show cache content
+      run: tree ~/audb
+      if: matrix.os == 'ubuntu-18.04'
+
     - name: Install dependencies
       run: |
         python -V
@@ -51,7 +55,6 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ls ~/audb
         python -m pytest
 
     - name: Upload coverage to Codecov


### PR DESCRIPTION
As we use `emodb` and `age-test` (which we publish ourselves) for building the documentation and processing is much faster if we start from cache, it makes sense to store the cache on Github.