### PR TITLE
DOC: remove programoutput extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'sphinx_copybutton',
-    'sphinxcontrib.programoutput',
     'jupyter_sphinx',
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,3 @@ sphinx >=3.5.4
 sphinx-audeering-theme >=1.0.12
 sphinx-autodoc-typehints
 sphinx-copybutton
-sphinxcontrib-programoutput


### PR DESCRIPTION
As we removed the command line interface from `audb` we also do no longer need the [sphinxcontrib-programoutput](https://github.com/NextThought/sphinxcontrib-programoutput) extension for building the docs.