### PR TITLE
DOC: use emodb 1.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/audb
-        key: emodb-1.1.1
+        key: emodb-1.1.1-1
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,8 @@ jobs:
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
 
     - name: Show cache content
-      run: tree ~/audb
+      run: |
+        tree ~/audb
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/audb
-        key: emodb-ubuntu
+        key: emodb-1.1.1
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
 
     - name: Show cache content
-      run: tree ~/audb
+      run: |
+        rm -rf ~/audb/emodb/1.1.0
+        tree ~/audb
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,9 +42,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
 
     - name: Show cache content
-      run: |
-        rm -rf ~/audb/emodb/1.1.0
-        tree ~/audb
+      run: tree ~/audb
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
 
     - name: Show cache content
-      run: |
-        tree ~/audb
+      run: tree ~/audb
       if: matrix.os == 'ubuntu-18.04'
 
     - name: Install dependencies

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -31,8 +31,8 @@ class Dependencies:
         Empty DataFrame
         Columns: [archive, bit_depth, channels, checksum, duration, format, removed, sampling_rate, type, version]
         Index: []
-        >>> # Request dependencies for emodb 1.1.0
-        >>> deps = audb.dependencies('emodb', version='1.1.0')
+        >>> # Request dependencies for emodb 1.1.1
+        >>> deps = audb.dependencies('emodb', version='1.1.1')
         >>> # List all files or archives
         >>> deps.files[:3]
         ['db.emotion.csv', 'db.files.csv', 'wav/03a01Fa.wav']

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -33,7 +33,7 @@ def author(
         author(s) of database
 
     Example:
-        >>> author('emodb', version='1.1.0')
+        >>> author('emodb', version='1.1.1')
         'Felix Burkhardt, Astrid Paeschke, Miriam Rolfes, Walter Sendlmeier, Benjamin Weiss'
 
     """  # noqa: E501
@@ -59,7 +59,7 @@ def bit_depths(
         bit depths
 
     Example:
-        >>> bit_depths('emodb', version='1.1.0')
+        >>> bit_depths('emodb', version='1.1.1')
         {16}
 
     """
@@ -86,7 +86,7 @@ def channels(
         channel numbers
 
     Example:
-        >>> channels('emodb', version='1.1.0')
+        >>> channels('emodb', version='1.1.1')
         {1}
 
     """
@@ -113,7 +113,7 @@ def description(
         description of database
 
     Example:
-        >>> desc = description('emodb', version='1.1.0')
+        >>> desc = description('emodb', version='1.1.1')
         >>> desc.split('.')[0]  # show first sentence
         'Berlin Database of Emotional Speech'
 
@@ -140,7 +140,7 @@ def duration(
         duration
 
     Example:
-        >>> duration('emodb', version='1.1.0')
+        >>> duration('emodb', version='1.1.1')
         Timedelta('0 days 00:24:47.092187500')
 
     """
@@ -170,7 +170,7 @@ def formats(
         format
 
     Example:
-        >>> formats('emodb', version='1.1.0')
+        >>> formats('emodb', version='1.1.1')
         {'wav'}
 
     """
@@ -197,7 +197,7 @@ def header(
         database object without table data
 
     Example:
-        >>> db = header('emodb', version='1.1.0')
+        >>> db = header('emodb', version='1.1.1')
         >>> db.name
         'emodb'
 
@@ -227,7 +227,7 @@ def languages(
         languages of database
 
     Example:
-        >>> languages('emodb', version='1.1.0')
+        >>> languages('emodb', version='1.1.1')
         ['deu']
 
     """
@@ -253,7 +253,7 @@ def license(
         license of database
 
     Example:
-        >>> license('emodb', version='1.1.0')
+        >>> license('emodb', version='1.1.1')
         'CC0-1.0'
 
     """
@@ -279,7 +279,7 @@ def license_url(
         license URL of database
 
     Example:
-        >>> license_url('emodb', version='1.1.0')
+        >>> license_url('emodb', version='1.1.1')
         'https://creativecommons.org/publicdomain/zero/1.0/'
 
     """
@@ -305,7 +305,7 @@ def media(
         media of database
 
     Example:
-        >>> media('emodb', version='1.1.0')
+        >>> media('emodb', version='1.1.1')
         microphone:
             {type: other, format: wav, channels: 1, sampling_rate: 16000}
 
@@ -332,9 +332,9 @@ def meta(
         meta information of database
 
     Example:
-        >>> meta('emodb', version='1.1.0')
+        >>> meta('emodb', version='1.1.1')
         pdf:
-            http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.130.8506&rep=rep1&type=pdf
+          http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.130.8506&rep=rep1&type=pdf
 
     """
     db = header(name, version=version, cache_root=cache_root)
@@ -359,7 +359,7 @@ def organization(
         organization responsible for database
 
     Example:
-        >>> organization('emodb', version='1.1.0')
+        >>> organization('emodb', version='1.1.1')
         'audEERING'
 
     """
@@ -385,7 +385,7 @@ def raters(
         raters of database
 
     Example:
-        >>> raters('emodb', version='1.1.0')
+        >>> raters('emodb', version='1.1.1')
         gold:
             {type: human}
 
@@ -412,7 +412,7 @@ def sampling_rates(
         sampling rates
 
     Example:
-        >>> sampling_rates('emodb', version='1.1.0')
+        >>> sampling_rates('emodb', version='1.1.1')
         {16000}
 
     """
@@ -439,7 +439,7 @@ def schemes(
         schemes of database
 
     Example:
-        >>> list(schemes('emodb', version='1.1.0'))
+        >>> list(schemes('emodb', version='1.1.1'))
         ['confidence', 'duration', 'emotion', 'speaker', 'transcription']
 
     """
@@ -465,7 +465,7 @@ def source(
         source of database
 
     Example:
-        >>> source('emodb', version='1.1.0')
+        >>> source('emodb', version='1.1.1')
         'http://emodb.bilderbar.info/download/download.zip'
 
     """
@@ -491,7 +491,7 @@ def splits(
         splits of database
 
     Example:
-        >>> splits('emodb', version='1.1.0')
+        >>> splits('emodb', version='1.1.1')
 
 
     """
@@ -517,7 +517,7 @@ def tables(
         tables of database
 
     Example:
-        >>> list(tables('emodb', version='1.1.0'))
+        >>> list(tables('emodb', version='1.1.1'))
         ['emotion', 'files']
 
     """
@@ -543,7 +543,7 @@ def usage(
         usage of database
 
     Example:
-        >>> usage('emodb', version='1.1.0')
+        >>> usage('emodb', version='1.1.1')
         'unrestricted'
 
     """

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -943,13 +943,13 @@ def load_media(
         >>> paths = load_media(
         ...     'emodb',
         ...     ['wav/03a01Fa.wav'],
-        ...     version='1.1.0',
+        ...     version='1.1.1',
         ...     format='flac',
         ...     verbose=False,
         ... )
         >>> cache_root = audb.default_cache_root()
         >>> [p[len(cache_root):] for p in paths]
-        ['/emodb/1.1.0/40bb2241/wav/03a01Fa.flac']
+        ['/emodb/1.1.1/40bb2241/wav/03a01Fa.flac']
 
     """
     media = audeer.to_list(media)

--- a/audb/info/__init__.py
+++ b/audb/info/__init__.py
@@ -23,7 +23,7 @@ r"""Get information from database headers.
 
     audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         only_metadata=True,
         verbose=False,
     )
@@ -39,7 +39,7 @@ So instead of running:
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         only_metadata=True,
         verbose=False,
     )
@@ -51,7 +51,7 @@ You can run:
 
     audb.info.tables(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
     )
 
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,25 +86,27 @@ audb.config.REPOSITORIES = [
         backend='artifactory',
     )
 ]
-if not audb.exists('emodb', version='1.1.0'):
-    print('Pre-caching emodb v1.1.0')
+name = 'emodb'
+version = '1.1.1'
+if not audb.exists(name, version=version):
+    print(f'Pre-caching {name} v{version}')
     audb.load(
-        'emodb',
-        version='1.1.0',
+        name,
+        version=version,
         num_workers=5,
         only_metadata=True,
         verbose=False,
     )
 if not audb.exists(
-        'emodb',
-        version='1.1.0',
+        name,
+        version=version,
         format='flac',
         sampling_rate=44100,
 ):
-    print('Pre-caching emodb v1.1.0 {flac, 44100Hz}')
+    print(f'Pre-caching {name} v{version} {{flac, 44100Hz}}')
     audb.load(
-        'emodb',
-        version='1.1.0',
+        name,
+        version=version,
         format='flac',
         sampling_rate=44100,
         num_workers=5,

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -45,7 +45,7 @@ You request a :class:`audb.Dependencies` object with
 
 .. jupyter-execute::
 
-    deps = audb.dependencies('emodb', version='1.1.0')
+    deps = audb.dependencies('emodb', version='1.1.1')
 
 You can see all entries by calling the returned object.
 

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -56,7 +56,7 @@ even if a new version of the database is published.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         only_metadata=True,
         verbose=False,
     )
@@ -65,7 +65,7 @@ even if a new version of the database is published.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         verbose=False,
     )
 
@@ -154,7 +154,7 @@ inside the :ref:`cache <caching>`.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         format='flac',
         sampling_rate=44100,
         only_metadata=True,
@@ -165,7 +165,7 @@ inside the :ref:`cache <caching>`.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         format='flac',
         sampling_rate=44100,
         verbose=False,
@@ -204,7 +204,7 @@ but all the tables and the header.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         only_metadata=True,
         verbose=False,
     )
@@ -222,7 +222,7 @@ It can list all table definitions.
 
     audb.info.tables(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
     )
 
 Or get the total duration of all media files.
@@ -231,7 +231,7 @@ Or get the total duration of all media files.
 
     audb.info.duration(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
     )
 
 See :mod:`audb.info` for a list of all available options.
@@ -261,7 +261,7 @@ about the speakers (here ``db['files']``):
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         tables=['files'],
         only_metadata=True,
         full_path=False,
@@ -301,7 +301,7 @@ only the data of this speaker.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         media=media,
         full_path=False,
         only_metadata=True,
@@ -312,7 +312,7 @@ only the data of this speaker.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         media=media,
         full_path=False,
         verbose=False,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -41,14 +41,14 @@ Let's load the database.
 
     db = audb.load(
         'emodb',
-        version='1.1.0',
+        version='1.1.1',
         only_metadata=True,
         verbose=False,
     )
 
 .. code-block:: python
 
-    db = audb.load('emodb', version='1.1.0', verbose=False)
+    db = audb.load('emodb', version='1.1.1', verbose=False)
 
 This downloads the database header,
 all the media files,


### PR DESCRIPTION
This switches to `emodb` 1.1.1.

I wanted to clear the Github CI cache (which stores the `audb` cache), so we don't cache both versions 1.1.0 and 1.1.1,
but interestingly there is no way to clear the cache at the moment (https://github.com/actions/cache/issues/2).

As only the metadata is cached at the moment it isn't a big issue, but something we need to have in mind when doing further changes.