### PR TITLE
Add audb.load_table()

### DIFF
--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -17,6 +17,7 @@ from audb.core.flavor import Flavor
 from audb.core.load import (
     load,
     load_media,
+    load_table,
 )
 from audb.core.load_to import load_to
 from audb.core.publish import publish

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -945,11 +945,13 @@ def load_media(
 ) -> typing.List:
     r"""Load media file(s).
 
-    If you are only interested in media files
+    If you are interested in media files
     and not the corresponding tables,
-    you should use :func:`audb.load_media`
-    instead of :func:`audb.load`
-    as it is faster.
+    you can use :func:`audb.load_media`
+    to load them.
+    This will not download any table files
+    to your disk,
+    but share the cache with :func:`audb.load`.
 
     Args:
         name: name of database

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1070,10 +1070,13 @@ def load_table(
 ) -> pd.DataFrame:
     r"""Load a database table.
 
-    If you are only interested in an original table
+    If you are interested in a single table
     from a database
     you can use :func:`audb.load_table`
-    instead of :func:`audb.load`.
+    to directly load it.
+    This will not download any media files
+    to your disk,
+    but share the cache with :func:`audb.load`.
 
     Args:
         name: name of database

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1083,6 +1083,12 @@ def load_table(
     Args:
         name: name of database
         table: load table from database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
+        num_workers: number of parallel jobs or 1 for sequential
+            processing. If ``None`` will be set to the number of
+            processors on the machine multiplied by 5
+        verbose: show debug messages
 
     Returns:
         database table

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -4,6 +4,8 @@ import re
 import shutil
 import typing
 
+import pandas as pd
+
 import audbackend
 import audeer
 import audformat
@@ -464,6 +466,68 @@ def _load_media(
             )
 
 
+def _load_tables(
+        tables: typing.Sequence[str],
+        backend: audbackend.Backend,
+        db_root: str,
+        db_root_tmp: str,
+        db: audformat.Database,
+        version: str,
+        cached_versions: typing.Optional[
+            typing.Sequence[typing.Tuple[LooseVersion, str, Dependencies]]
+        ],
+        deps: Dependencies,
+        flavor: Flavor,
+        cache_root: str,
+        num_workers: int,
+        verbose: bool,
+):
+    r"""Load table files to cache.
+
+    All table files not existing in cache yet
+    are copied from the corresponding flavor cache
+    folder of other versions of the database
+    or are downloaded from the backend.
+
+    """
+    missing_tables = _missing_tables(
+        db_root,
+        tables,
+        verbose,
+    )
+    if missing_tables:
+        if cached_versions is None:
+            cached_versions = _cached_versions(
+                db.name,
+                version,
+                flavor,
+                cache_root,
+            )
+        if cached_versions:
+            missing_tables = _get_tables_from_cache(
+                missing_tables,
+                db_root,
+                db_root_tmp,
+                deps,
+                cached_versions,
+                num_workers,
+                verbose,
+            )
+        if missing_tables:
+            if backend is None:
+                backend = lookup_backend(db.name, version)
+            _get_tables_from_backend(
+                db,
+                missing_tables,
+                db_root,
+                db_root_tmp,
+                deps,
+                backend,
+                num_workers,
+                verbose,
+            )
+
+
 def _media(
         db: audformat.Database,
         media: typing.Optional[typing.Union[str, typing.Sequence[str]]],
@@ -744,42 +808,20 @@ def load(
 
     # load missing tables
     if not db_is_complete:
-        missing_tables = _missing_tables(
-            db_root,
+        _load_tables(
             requested_tables,
+            backend,
+            db_root,
+            db_root_tmp,
+            db,
+            version,
+            cached_versions,
+            deps,
+            flavor,
+            cache_root,
+            num_workers,
             verbose,
         )
-        if missing_tables:
-            if cached_versions is None:
-                cached_versions = _cached_versions(
-                    name,
-                    version,
-                    flavor,
-                    cache_root,
-                )
-            if cached_versions:
-                missing_tables = _get_tables_from_cache(
-                    missing_tables,
-                    db_root,
-                    db_root_tmp,
-                    deps,
-                    cached_versions,
-                    num_workers,
-                    verbose,
-                )
-            if missing_tables:
-                if backend is None:
-                    backend = lookup_backend(name, version)
-                _get_tables_from_backend(
-                    db,
-                    missing_tables,
-                    db_root,
-                    db_root_tmp,
-                    deps,
-                    backend,
-                    num_workers,
-                    verbose,
-                )
 
     # filter tables
     if tables is not None:
@@ -1015,3 +1057,96 @@ def load_media(
         media = [audeer.replace_file_extension(m, format) for m in media]
 
     return [os.path.join(db_root, m) for m in media]
+
+
+def load_table(
+        name: str,
+        table: str,
+        *,
+        version: str = None,
+        cache_root: str = None,
+        num_workers: typing.Optional[int] = 1,
+        verbose: bool = True,
+) -> pd.DataFrame:
+    r"""Load a database table.
+
+    If you are only interested in an original table
+    from a database
+    you can use :func:`audb.load_table`
+    instead of :func:`audb.load`.
+
+    Args:
+        name: name of database
+        table: load table from database
+
+    Returns:
+        database table
+
+    Raises:
+        ValueError: if a table is requested
+            that is not part of the database
+
+    Example:
+        >>> df = load_table(
+        ...     'emodb',
+        ...     'emotion',
+        ...     version='1.1.1',
+        ...     verbose=False,
+        ... )
+        >>> df[:3]
+                           emotion  emotion.confidence
+        file
+        wav/03a01Fa.wav  happiness                0.90
+        wav/03a01Nc.wav    neutral                1.00
+        wav/03a01Wa.wav      anger                0.95
+
+    """
+    if version is None:
+        version = latest_version(name)
+    deps = dependencies(name, version=version, cache_root=cache_root)
+
+    if table not in deps.table_ids:
+        raise ValueError(
+            f"Could not find table '{table}' in {name} {version}"
+        )
+
+    cached_versions = None
+
+    db_root = database_cache_folder(name, version, cache_root)
+    db_root_tmp = database_tmp_folder(db_root)
+
+    if verbose:  # pragma: no cover
+        print(f'Get:   {name} v{version}')
+        print(f'Cache: {db_root}')
+
+    # Start with database header without tables
+    db, backend = load_header(
+        db_root,
+        name,
+        version,
+    )
+
+    # Load table
+    table_file = os.path.join(db_root, f'db.{table}')
+    if not (
+            os.path.exists(f'{table_file}.csv')
+            or os.path.exists(f'{table_file}.pkl')
+    ):
+        _load_tables(
+            [table],
+            backend,
+            db_root,
+            db_root_tmp,
+            db,
+            version,
+            cached_versions,
+            deps,
+            Flavor(),
+            cache_root,
+            num_workers,
+            verbose,
+        )
+    table = audformat.Table()
+    table.load(table_file)
+
+    return table._df

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,11 @@ load_media
 
 .. autofunction:: load_media
 
+load_table
+----------
+
+.. autofunction:: load_table
+
 load_to
 -------
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -332,6 +332,51 @@ def test_load_media(version, media, format):
 
 
 @pytest.mark.parametrize(
+    'version, table',
+    [
+        (
+            '1.0.0',
+            'emotion',
+        ),
+        pytest.param(
+            '1.0.0',
+            'non-existing-table',
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        (
+            None,
+            'emotion',
+        ),
+    ]
+)
+def test_load_table(version, table):
+
+    df = audb.load_table(
+        DB_NAME,
+        table,
+        version=version,
+        verbose=False,
+    )
+    if version is None:
+        expected_files = [
+            'audio/001.wav',
+            'audio/002.wav',
+            'audio/003.wav',
+            'audio/004.wav',
+        ]
+    elif version == '1.0.0':
+        expected_files = [
+            'audio/001.wav',
+            'audio/002.wav',
+            'audio/003.wav',
+            'audio/004.wav',
+            'audio/005.wav',
+        ]
+    files = sorted(list(set(df.index.get_level_values('file'))))
+    assert files == expected_files
+
+
+@pytest.mark.parametrize(
     'version',
     [
         None,


### PR DESCRIPTION
Add `audb.load_table()` which enables us to load a single table from a database and returning it directly as dataframe.
This has of course the disadvantage that you can not map header entries, but it has the advantage that you can easily inspect the original table file of a database.

At the moment the implementation still needs to load the header file as this is needed by the shared `_load_tables()` function and there by `_get_tables_from_backend()`, but I think we don't have to solve this here as the overhead of loading the header is marginal in most cases.

![image](https://user-images.githubusercontent.com/173624/117141681-1f3e7100-adaf-11eb-8b6d-994d78c5cff5.png)
