### PR TITLE
CI: use cache in all tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,6 @@ jobs:
       with:
         path: ~/audb
         key: emodb-1.1.1-1
-      if: matrix.os == 'ubuntu-18.04'
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -43,7 +42,6 @@ jobs:
 
     - name: Show cache content
       run: tree ~/audb
-      if: matrix.os == 'ubuntu-18.04'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
As `emodb` is also used in the doctests it makes sense to share the cache with all runners and not only the one building the documentation.