### PR TITLE
DOC: clarify archive names in audb.publish()

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -202,7 +202,7 @@ def publish(
         repository: name of repository
         archives: dictionary mapping files to archive names.
             Can be used to bundle files into archives.
-            Name must not include an extension
+            Archive name must not include an extension
         previous_version: specifies the version
             this publication should be based on.
             If ``'latest'``


### PR DESCRIPTION
I made a mistake as the current description for the `archives` argument in `audb.publish()` is slightly ambiguous which names (file or archive) should not contain a file ending. This clarifies it, by stating that the archive name is meant.