### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04 ]
+        os: [ ubuntu-18.04, macOS-latest ]
         python-version: [3.6]
         include:
           - os: ubuntu-latest
@@ -46,6 +46,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
+
+    - name: Prepare OSX
+      run: brew install sox
+      if: matrix.os == 'macOS-latest'
 
     - name: Show cache content
       run: tree ~/audb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
 
     - name: Show cache content
       run: tree ~/audb
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
 
     - name: Install dependencies
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     audformat >=0.11.1,<2.0.0
     audiofile >=0.4.0
     audobject >=0.4.12
-    audresample >=0.1.4
+    audresample >=0.1.5
     oyaml
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
Closes #33.

This switches to the new `audresample` that added macOS support and adds tests for macOS.