### PR TITLE
DOC: extend installation section with system deps

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,7 +29,7 @@ e.g.
 
 .. code-block:: bash
 
-    $ sudo apt-get install ffmpeg mediainfo sox
+    $ sudo apt-get install ffmpeg mediainfo sox libsox-fmt-mp3
 
 
 .. _libsndfile: https://github.com/libsndfile/libsndfile

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,9 +34,6 @@ Under Ubuntu this can be achieved with
 Under Windows you have to install those libraries manually,
 and ensure that they are added to the ``PATH`` variable.
 
-.. code-block:: bash
-
-    $ brew install sox ffmpeg 
 
 .. _libsndfile: https://github.com/libsndfile/libsndfile
 .. _ffmpeg: https://www.ffmpeg.org/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,3 +9,30 @@ To install :mod:`audb` run:
     $ # virtualenv --python=python3 ${HOME}/.envs/audb
     $ # source ${HOME}/.envs/audb/bin/activate
     $ pip install audb
+
+:mod:`audb` uses :mod:`audiofile` to access media files,
+which supports WAV, FLAC, OGG out of the box.
+:mod:`audiofile` requires the libsndfile_ C library,
+which should be installed on most systems.
+Under Ubuntu you can install it with
+
+.. code-block:: bash
+
+    $ sudo apt-get install libsndfile1
+
+In order to handle all possible audio files,
+please make sure ffmpeg_,
+sox_,
+and mediainfo_
+are installed on your system,
+e.g.
+
+.. code-block:: bash
+
+    $ sudo apt-get install ffmpeg mediainfo sox
+
+
+.. _libsndfile: https://github.com/libsndfile/libsndfile
+.. _ffmpeg: https://www.ffmpeg.org/
+.. _sox: http://sox.sourceforge.net/
+.. _mediainfo: https://mediaarea.net/en/MediaInfo/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -24,13 +24,19 @@ In order to handle all possible audio files,
 please make sure ffmpeg_,
 sox_,
 and mediainfo_
-are installed on your system,
-e.g.
+are installed on your system.
+Under Ubuntu this can be achieved with
 
 .. code-block:: bash
 
     $ sudo apt-get install ffmpeg mediainfo sox libsox-fmt-mp3
 
+Under Windows you have to install those libraries manually,
+and ensure that they are added to the ``PATH`` variable.
+
+.. code-block:: bash
+
+    $ brew install sox ffmpeg 
 
 .. _libsndfile: https://github.com/libsndfile/libsndfile
 .. _ffmpeg: https://www.ffmpeg.org/


### PR DESCRIPTION
Closes #91.

This extends the installation instructions by discussing system packages like `libsndfile` that are needed in order to import `audb` as it imports `audiofile`. In addition, during run time you might need `sox`, `ffmpeg` or `mediafile` to access files that are not stored as WAV, FLAC, or OGG.

![image](https://user-images.githubusercontent.com/173624/117780326-d1f35100-b23f-11eb-977b-9584ac637679.png)
