### PR TITLE
WIP: audb.publish() requires db.author to be set

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -222,6 +222,7 @@ def publish(
         dependency object
 
     Raises:
+        ValueError: if database containes no author
         RuntimeError: if version already exists
         RuntimeError: if database tables reference non-existing files
         RuntimeError: if database in ``db_root`` depends on other version
@@ -229,6 +230,9 @@ def publish(
 
     """
     db = audformat.Database.load(db_root, load_data=False)
+
+    if db.author is None:
+        raise ValueError(f"The database '{db.name}' has to specify an author.")
 
     backend = audbackend.create(
         repository.backend,

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -50,6 +50,7 @@ with the :mod:`audformat.testing` module.
 
     db = audformat.testing.create_db(minimal=True)
     db.name = 'age-test'
+    db.author = 'J. Wagner, H. Wierstorf'
     db.license = 'CC0-1.0'
     db.schemes['age'] = audformat.Scheme('int', minimum=20, maximum=90)
     audformat.testing.add_table(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ pytest.ROOT = audeer.safe_path(
     )
 )
 
+pytest.AUTHOR = 'J. Wagner, H. Wierstorf'
 pytest.BACKEND = 'file-system'
 pytest.CACHE_ROOT = os.path.join(pytest.ROOT, 'cache')
 pytest.FILE_SYSTEM_HOST = os.path.join(pytest.ROOT, 'repo')

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -61,6 +61,7 @@ def fixture_publish_db():
 
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
+    db.author = pytest.AUTHOR
     db['files'] = audformat.Table(audformat.filewise_index(list(DB_FILES)))
     db['files']['original'] = audformat.Column()
     db['files']['original'].set(list(DB_FILES))

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -37,6 +37,7 @@ def fixture_publish_db():
 
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
+    db.author = pytest.AUTHOR
     db.schemes['scheme'] = audformat.Scheme(
         labels=['some', 'test', 'labels']
     )

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -19,6 +19,7 @@ DB_NAME = f'test_info-{pytest.ID}'
 DB_VERSION = '1.0.0'
 DB = audformat.Database(
     DB_NAME,
+    author=pytest.AUTHOR,
     source='https://audeering.github.io/audb/',
     usage=audformat.define.Usage.UNRESTRICTED,
     languages=['de', 'English'],

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -44,6 +44,7 @@ def fixture_publish_db():
 
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
+    db.author = pytest.AUTHOR
     db.schemes['scheme'] = audformat.Scheme(
         labels=['positive', 'neutral', 'negative']
     )

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -41,6 +41,7 @@ def fixture_publish_db():
 
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
+    db.author = pytest.AUTHOR
     db.schemes['scheme'] = audformat.Scheme()
     audformat.testing.add_table(
         db,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -92,7 +92,7 @@ def fixture_publish_db():
     assert len(db.files) > 20
     db.save(DB_ROOT_VERSION['5.0.0'])
 
-    # Safe version without author
+    # Store version without author
     db.author = None
     db.save(DB_ROOT_VERSION['5.1.0'])
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -21,7 +21,7 @@ DB_NAME = f'test_publish-{pytest.ID}'
 DB_ROOT = os.path.join(pytest.ROOT, 'db')
 DB_ROOT_VERSION = {
     version: os.path.join(DB_ROOT, version) for version in
-    ['1.0.0', '2.0.0', '2.1.0', '3.0.0', '4.0.0', '5.0.0']
+    ['1.0.0', '2.0.0', '2.1.0', '3.0.0', '4.0.0', '5.0.0', '5.1.0']
 }
 
 
@@ -43,6 +43,7 @@ def fixture_publish_db():
     # create db
 
     db = audformat.testing.create_db(minimal=True)
+    db.author = pytest.AUTHOR
     db.name = DB_NAME
     db.schemes['scheme'] = audformat.Scheme(
         labels=['positive', 'neutral', 'negative']
@@ -90,6 +91,10 @@ def fixture_publish_db():
     )
     assert len(db.files) > 20
     db.save(DB_ROOT_VERSION['5.0.0'])
+
+    # Safe version without author
+    db.author = None
+    db.save(DB_ROOT_VERSION['5.1.0'])
 
     yield
 
@@ -139,6 +144,13 @@ def test_invalid_archives(name):
             marks=pytest.mark.xfail(
                 raises=RuntimeError,
                 reason='Files missing (more than 20)',
+            ),
+        ),
+        pytest.param(
+            '5.1.0',
+            marks=pytest.mark.xfail(
+                raises=ValueError,
+                reason='db.author missing',
             ),
         ),
     ]

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -44,6 +44,7 @@ def publish_db():
 
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
+    db.author = pytest.AUTHOR
     db['files'] = audformat.Table(audformat.filewise_index(DB_FILES['1.0.0']))
 
     # publish 1.0.0


### PR DESCRIPTION
Closes #75.

`audb.publish()` now raises a ValueError if `db.author` is not specified.

![image](https://user-images.githubusercontent.com/173624/117768366-93a36500-b232-11eb-91c0-72175d903b0d.png)
