### PR TITLE
Calculate metadata when publishing non SND formats

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -393,14 +393,19 @@ class Dependencies:
             duration = self.duration(file)
             sampling_rate = self.sampling_rate(file)
         else:
-            bit_depth = channels = sampling_rate = 0
-            duration = 0.0
-            if format in define.FORMATS:
+            try:
                 path = os.path.join(root, file)
                 bit_depth = audiofile.bit_depth(path)
                 channels = audiofile.channels(path)
                 duration = audiofile.duration(path)
                 sampling_rate = audiofile.sampling_rate(path)
+            except FileNotFoundError:  # pragma: nocover
+                # If sox or mediafile are not installed
+                # we get a FileNotFoundError error
+                raise RuntimeError(
+                    f"sox and mediainfo have to be installed "
+                    f"to publish '{format}' media files."
+                )
 
         self._df.loc[file] = [
             archive,

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -228,6 +228,8 @@ def publish(
             as indicated by ``previous_version``
         RuntimeError: if database is not portable,
             see :meth:`audformat.Database.is_portable`
+        RuntimeError: if non-standard formats like MP3 and MP4 are published,
+            but sox and/or mediafile is not installed
 
     """
     db = audformat.Database.load(db_root, load_data=False)


### PR DESCRIPTION
Closes #29.

As it is important for gathering meta information about the published database (e.g. which sampling rate, duration),
I think we should force users to store that information when publishing the data.

I changed `audb.publish()` to raise an error if a non SND format file (e.g. MP3 or MP4) is published, but `sox` or `mediafile` are not installed. As it can differ from system to system which formats are supported by `sox` we cannot easily state if it would be sufficient for the user to just install `sox`, so we have to request always `sox` and `mediafile` to be installed.