### PR TITLE
TST: remove broken Microsoft apt repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ jobs:
         python setup.py sdist bdist_wheel
         python -m twine upload dist/*
 
+    # Remove apt repos that are known to break from time to time
+    # See https://github.com/actions/virtual-environments/issues/323
+    - name: Remove broken apt repos
+      run: |
+        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+
     # Docuemntation
     - name: Install doc dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    # Remove apt repos that are known to break from time to time
+    # See https://github.com/actions/virtual-environments/issues/323
+    - name: Remove broken apt repos [Ubuntu]
+      run: |
+        for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
+
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update


### PR DESCRIPTION
It seems to be that the Microsoft apt repository can be broken from time to time, leading to the following errors: https://github.com/audeering/audb/pull/92/checks?check_run_id=2608311667

This removes the repo as proposed in https://github.com/actions/virtual-environments/issues/323#issuecomment-578392268