### PR TITLE
DOC: fix version shown in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,27 +86,27 @@ audb.config.REPOSITORIES = [
         backend='artifactory',
     )
 ]
-name = 'emodb'
-version = '1.1.1'
-if not audb.exists(name, version=version):
-    print(f'Pre-caching {name} v{version}')
+database_name = 'emodb'
+database_version = '1.1.1'
+if not audb.exists(database_name, version=database_version):
+    print(f'Pre-caching {database_name} v{database_version}')
     audb.load(
-        name,
-        version=version,
+        database_name,
+        version=database_version,
         num_workers=5,
         only_metadata=True,
         verbose=False,
     )
 if not audb.exists(
-        name,
-        version=version,
+        database_name,
+        version=database_version,
         format='flac',
         sampling_rate=44100,
 ):
-    print(f'Pre-caching {name} v{version} {{flac, 44100Hz}}')
+    print(f'Pre-caching {database_name} v{database_version} {{flac, 44100Hz}}')
     audb.load(
-        name,
-        version=version,
+        database_name,
+        version=database_version,
         format='flac',
         sampling_rate=44100,
         num_workers=5,


### PR DESCRIPTION
Closes #98.

This is a nasty one. One has to make sure to not use sphinx related variables like `title` and `version` inside the custom code in `docs/conf.py`.

Now, we are getting the right version number:

![image](https://user-images.githubusercontent.com/173624/118801955-dd7af380-b8a1-11eb-9d9c-9bb2f4c22783.png)
