### PR TITLE
Fix failing load when searching for other tables

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -31,10 +31,15 @@ def _cached_versions(
 ) -> typing.Sequence[typing.Tuple[LooseVersion, str, Dependencies]]:
     r"""Find other cached versions of same flavor."""
 
+    cached_versions = []
+
     df = cached(cache_root=cache_root)
+    if df.empty:
+        return cached_versions
+
+    # Limit to the requested database
     df = df[df.name == name]
 
-    cached_versions = []
     for flavor_root, row in df.iterrows():
         if row['flavor_id'] == flavor.short_id:
             if row['version'] == version:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -318,3 +318,33 @@ def test_sampling_rate(sampling_rate):
                 audiofile.sampling_rate(original_file)
         else:
             assert audiofile.sampling_rate(converted_file) == sampling_rate
+
+
+def test_empty_cache():
+    # Avoid failing searching for other versions
+    # if cache is empty
+    # https://github.com/audeering/audb/issues/101
+    # First load to shared cache
+    audb.load(
+        DB_NAME,
+        sampling_rate=8000,
+        full_path=False,
+        num_workers=pytest.NUM_WORKERS,
+        verbose=False,
+        only_metadata=True,
+        tables='files',
+        cache_root=pytest.SHARED_CACHE_ROOT,
+    )
+    # Now try to load same version to private cache
+    # to force audb.cached() to return empty dataframe
+    clear_root(pytest.CACHE_ROOT)
+    audeer.mkdir(pytest.CACHE_ROOT)
+    audb.load(
+        DB_NAME,
+        sampling_rate=8000,
+        full_path=False,
+        num_workers=pytest.NUM_WORKERS,
+        verbose=False,
+        only_metadata=True,
+        tables='segments',
+    )


### PR DESCRIPTION
If you had a databases containing only some tables loaded to the shared folder and try to download the same database, but requesting another table it was failing as `audb.cahced()` returned an empty dataframe, see https://github.com/audeering/audb/issues/101

This implements the first proposed solution to https://github.com/audeering/audb/issues/101.