### PR TITLE
Look also in shared cache for partial db versions

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -32,6 +32,12 @@ def _cached_versions(
     r"""Find other cached versions of same flavor."""
 
     df = cached(cache_root=cache_root)
+    # If no explicit cache root is given,
+    # we look into the private and shared one.
+    # This fixes https://github.com/audeering/audb/issues/101
+    if cache_root is None and os.path.exists(default_cache_root(shared=True)):
+        df = pd.concat((df, cached(shared=True)))
+
     df = df[df.name == name]
 
     cached_versions = []

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -318,3 +318,35 @@ def test_sampling_rate(sampling_rate):
                 audiofile.sampling_rate(original_file)
         else:
             assert audiofile.sampling_rate(converted_file) == sampling_rate
+
+
+def test_mixed_cache():
+    # Avoid failing searching for other versions
+    # if databases a stored accross private and shared cache
+    # and the private one is empty, see
+    # https://github.com/audeering/audb/issues/101
+
+    # First load to shared cache
+    audb.load(
+        DB_NAME,
+        sampling_rate=8000,
+        full_path=False,
+        num_workers=pytest.NUM_WORKERS,
+        verbose=False,
+        only_metadata=True,
+        tables='files',
+        cache_root=pytest.SHARED_CACHE_ROOT,
+    )
+    # Now try to load same version to private cache
+    # to force audb.cached() to return empty dataframe
+    clear_root(pytest.CACHE_ROOT)
+    audeer.mkdir(pytest.CACHE_ROOT)
+    audb.load(
+        DB_NAME,
+        sampling_rate=8000,
+        full_path=False,
+        num_workers=pytest.NUM_WORKERS,
+        verbose=False,
+        only_metadata=True,
+        tables='segments',
+    )


### PR DESCRIPTION
Closes #101.

If no cache root is given by the user, we now also look for already existing versions of a table or media files in the shared cache folder. 