### PR TITLE
audb.load() raise error for wrong keyword argument

### DIFF
--- a/audb/core/backward.py
+++ b/audb/core/backward.py
@@ -83,7 +83,14 @@ def parse_deprecated_load_arguments(
         mixdown: updated mixdown argument
         media: updated media argument
 
+    Raises:
+        TypeError: if a non-matching keyword argument was given
+
     """
+    for key in kwargs:
+        if key not in ['mix', 'include', 'exclude']:
+            raise TypeError(f"Got an unexpected keyword argument '{key}'")
+
     # Map 'mix'
     if (
             channels is None

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -177,6 +177,11 @@ def test_database_cache_folder():
     assert db_root == expected_db_root
 
 
+def test_load_wrong_argument():
+    with pytest.raises(TypeError):
+        audb.load(DB_NAME, typo='1.0.0')
+
+
 @pytest.mark.parametrize(
     'format',
     [


### PR DESCRIPTION
Closes #100.

Raise an error if a wrong keyword argument (e.g. `samlping_rate`) is given to `audb.load()`.
This would be normal behavior, but it was hidden by the fact that we were silently converting old keyword arguments and hence you wre allowed to pass any keyword argument before.