### PR TITLE
Fix future warnings of pandas

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -212,8 +212,9 @@ def _full_path(
             table.df.index = root + table.df.index
             table.df.index.name = 'file'
         elif len(table.df.index) > 0:
-            table.df.index.set_levels(
-                root + table.df.index.levels[0], 'file', inplace=True,
+            table.df.index = table.df.index.set_levels(
+                root + table.df.index.levels[0],
+                level='file',
             )
 
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -177,12 +177,19 @@ def _fix_media_ext(
         cur_ext = r'\.[a-zA-Z0-9]+$'  # match file extension
         new_ext = f'.{format}'
         if table.is_filewise:
-            table.df.index = table.df.index.str.replace(cur_ext, new_ext)
+            table.df.index = table.df.index.str.replace(
+                cur_ext,
+                new_ext,
+                regex=True,
+            )
         else:
-            table.df.index.set_levels(
-                table.df.index.levels[0].str.replace(cur_ext, new_ext),
-                'file',
-                inplace=True,
+            table.df.index = table.df.index.set_levels(
+                table.df.index.levels[0].str.replace(
+                    cur_ext,
+                    new_ext,
+                    regex=True,
+                ),
+                level='file',
             )
 
     audeer.run_tasks(


### PR DESCRIPTION
When building the docs with Python 3.8 we are getting:

```
audb/core/load.py:180: FutureWarning: The default value of regex will change from True to False in a future version.
audb/core/load.py:183: FutureWarning: The default value of regex will change from True to False in a future version.
audb/core/load.py:182: FutureWarning: In a future version of pandas all arguments of MultiIndex.set_levels except for the argument 'levels' will be keyword-only
audb/core/load.py:182: FutureWarning: inplace is deprecated and will be removed in a future version.
audb/core/load.py:208: FutureWarning: In a future version of pandas all arguments of MultiIndex.set_levels except for the argument 'levels' will be keyword-only
audb/core/load.py:208: FutureWarning: inplace is deprecated and will be removed in a future version.
```

And when running the tests with Python 3.8 we also get:

```
audb/core/load.py:215: FutureWarning: In a future version of pandas all arguments of MultiIndex.set_levels except for the argument 'levels' will be keyword-only
```

All of these warnings are fixed by this pull request.