### PR TITLE
TST: switch default Python from 3.6 to 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macOS-latest ]
-        python-version: [3.6]
+        os: [ ubuntu-20.04, macOS-latest ]
+        python-version: [3.8]
         include:
           - os: ubuntu-latest
             python-version: 3.7
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2
@@ -39,13 +39,13 @@ jobs:
     - name: Remove broken apt repos [Ubuntu]
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
 
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
 
     - name: Prepare OSX
       run: brew install sox
@@ -53,7 +53,7 @@ jobs:
 
     - name: Show cache content
       run: tree ~/audb
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04'
 
     - name: Install dependencies
       run: |
@@ -72,11 +72,11 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'
 
     - name: Test building documentation
       run: |
         sudo apt-get install --yes graphviz
         python -m sphinx docs/ docs/_build/ -b html -W
         # python -m sphinx docs/ build/sphinx/html -b linkcheck
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-20.04'

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,9 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
 
 [options]


### PR DESCRIPTION
* Remove Python 3.6 from tests
* Use Python 3.8 for building documentation
* Add Python 3.9 to tests
* Switch from Ubuntu 18.04 to 20.04
* Update setup.cfg to include Python 3.7, 3.8, 3.9 as supported versions