### PR TITLE
DOC: add section on how to get database duration

### DIFF
--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -60,3 +60,65 @@ You can also use it to request certain aspects, e.g.
     deps.duration('wav/03a01Fa.wav')
 
 See :class:`audb.Dependencies` for all available methods.
+
+
+Duration of a database
+----------------------
+
+If your database contains only WAV or FLAC files,
+we store the duration in seconds of every file
+in the database dependency table.
+
+.. jupyter-execute::
+
+    deps = audb.dependencies('emodb', version='1.1.1')
+    df = deps()
+    df.duration[:10]
+
+For those databases
+you can get their overall duration with:
+
+.. jupyter-execute::
+
+    audb.info.duration('emodb', version='1.1.1')
+
+The duration of parts of a database
+can be calculated
+by first loading the dependency table
+and filter for the selected media files.
+The following calculates the duration
+of the first ten files in the *emotion* table
+of the emodb database.
+
+.. jupyter-execute::
+
+    import numpy as np
+
+    df = audb.load_table('emodb', 'emotion', version='1.1.1', verbose=False)
+    files = df.index[:10]
+    duration_in_sec = np.sum([deps.duration(f) for f in files])
+    pd.to_timedelta(duration_in_sec, unit='s')
+
+If your table is a segmented table,
+and you would like to get the duration of its segments
+you can use :func:`audformat.utils.duration`,
+which calculates the duration
+from the ``start`` and ``end`` entries.
+
+.. code-block:: python
+
+    df = audb.load('database-with-segmented-tables', 'segmented-table')
+    audformat.utils.duration(df)
+
+If your database contains files
+for which no duration information is stored
+in the dependency table of the database,
+like MP4 files,
+you have to download the database first
+and use :func:`audformat.utils.duration`
+to calculate the duration on the fly.
+
+.. code-block:: python
+
+    db = audb.load('database-with-videos')
+    audformat.utils.duration(db.files, num_workers=4)


### PR DESCRIPTION
Adds a section that discusses how to get information on the duration of a whole database or only parts of it.

![database-duration](https://user-images.githubusercontent.com/173624/127444650-f9cb790c-4e6d-4f3b-be69-5f1b9a41a253.png)
