### PR TITLE
Set bit_depth to 0 instead of None in deps

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -396,7 +396,7 @@ class Dependencies:
             try:
                 path = os.path.join(root, file)
                 bit_depth = audiofile.bit_depth(path)
-                if bit_depth is None:  # pragme: nocover (non SND files)
+                if bit_depth is None:  # pragma: nocover (non SND files)
                     bit_depth = 0
                 channels = audiofile.channels(path)
                 duration = audiofile.duration(path)

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -396,6 +396,8 @@ class Dependencies:
             try:
                 path = os.path.join(root, file)
                 bit_depth = audiofile.bit_depth(path)
+                if bit_depth is None:  # pragme: nocover (non SND files)
+                    bit_depth = 0
                 channels = audiofile.channels(path)
                 duration = audiofile.duration(path)
                 sampling_rate = audiofile.sampling_rate(path)


### PR DESCRIPTION
`audiofile.bit_depth()` returns `None` for filetype where bit depth makes no sense (like MP3 files).
In the dependency table we always have set it to `0` in those cases. This fixes the current code to maintain the `0` behavior.