### PR TITLE
Fix audb.cached() for empty/missing shared cache

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -91,7 +91,21 @@ def cached(
         cache_root or default_cache_root(shared=shared)
     )
 
-    data = {}
+    columns = [
+        'name',
+        'flavor_id',
+        'version',
+        'complete',
+        'bit_depth',
+        'channels',
+        'format',
+        'mixdown',
+        'sampling_rate',
+    ]
+    df = pd.DataFrame([], columns=columns)
+
+    if not os.path.exists(cache_root):
+        return df
 
     database_paths = audeer.list_dir_names(cache_root)
     for database_path in database_paths:
@@ -133,15 +147,18 @@ def cached(
                     )
                     flavor = db.meta['audb']['flavor']
                     complete = db.meta['audb']['complete']
-                    data[flavor_id_path] = {
-                        'name': database,
-                        'flavor_id': flavor_id,
-                        'version': version,
-                        'complete': complete,
-                    }
-                    data[flavor_id_path].update(flavor)
+                    df.loc[flavor_id_path] = [
+                        database,
+                        flavor_id,
+                        version,
+                        complete,
+                        flavor['bit_depth'],
+                        flavor['channels'],
+                        flavor['format'],
+                        flavor['mixdown'],
+                        flavor['sampling_rate'],
+                    ]
 
-    df = pd.DataFrame.from_dict(data, orient='index', dtype='object')
     # Replace NaN with None
     return df.where(pd.notnull(df), None)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -19,3 +19,16 @@ os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
 )
 def test_cache_root(shared, expected):
     assert audb.default_cache_root(shared=shared) == expected
+
+
+def test_empty_shared_cache():
+    # Handle non-existing cache folder
+    # See https://github.com/audeering/audb/issues/125
+    assert not os.path.exists(audeer.safe_path(pytest.SHARED_CACHE_ROOT))
+    df = audb.cached(shared=True)
+    assert len(df) == 0
+    # Handle empty shared cache folder
+    # See https://github.com/audeering/audb/issues/126
+    audeer.mkdir(pytest.SHARED_CACHE_ROOT)
+    df = audb.cached(shared=True)
+    assert 'name' in df.columns


### PR DESCRIPTION
Closes #126, closes #125 

It makes `audb.cached()` work if the shared cache folder does not exists and returns an empty dataframe with the correct column names if the folder does not exists or is empty.