### PR TITLE
Add name argument to audb.cached()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -74,6 +74,7 @@ def available(
 def cached(
         cache_root: str = None,
         *,
+        name: str = None,
         shared: bool = False,
 ) -> pd.DataFrame:
     r"""List available databases in the cache.
@@ -81,6 +82,9 @@ def cached(
     Args:
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
+        name: name of database.
+            If provided,
+            it will show only cached versions of that database
         shared: list shared databases
 
     Returns:
@@ -110,6 +114,11 @@ def cached(
     database_paths = audeer.list_dir_names(cache_root)
     for database_path in database_paths:
         database = os.path.basename(database_path)
+
+        # Limit to databases of given name
+        if name is not None and database != name:
+            continue
+
         version_paths = audeer.list_dir_names(database_path)
         for version_path in version_paths:
             version = os.path.basename(version_path)
@@ -281,7 +290,7 @@ def exists(
 
     .. code-block::
 
-        audb.cached().query('name == "emodb"')
+        audb.cached(name='emodb')
 
     Args:
         name: name of database

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -31,12 +31,12 @@ def _cached_versions(
 ) -> typing.Sequence[typing.Tuple[LooseVersion, str, Dependencies]]:
     r"""Find other cached versions of same flavor."""
 
-    df = cached(cache_root=cache_root)
+    df = cached(cache_root=cache_root, name=name)
     # If no explicit cache root is given,
     # we look into the private and shared one.
     # This fixes https://github.com/audeering/audb/issues/101
     if cache_root is None and os.path.exists(default_cache_root(shared=True)):
-        df = pd.concat((df, cached(shared=True)))
+        df = pd.concat((df, cached(name=name, shared=True)))
 
     df = df[df.name == name]
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -38,8 +38,6 @@ def _cached_versions(
     if cache_root is None and os.path.exists(default_cache_root(shared=True)):
         df = pd.concat((df, cached(name=name, shared=True)))
 
-    df = df[df.name == name]
-
     cached_versions = []
     for flavor_root, row in df.iterrows():
         if row['flavor_id'] == flavor.short_id:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -32,3 +32,11 @@ def test_empty_shared_cache():
     audeer.mkdir(pytest.SHARED_CACHE_ROOT)
     df = audb.cached(shared=True)
     assert 'name' in df.columns
+
+
+def test_cached_name():
+    df = audb.cached(name='emodb')
+    assert len(df) > 0
+    assert set(df['name']) == set(['emodb'])
+    df = audb.cached(name='non-existent')
+    assert len(df) == 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -35,6 +35,9 @@ def test_empty_shared_cache():
 
 
 def test_cached_name():
+    # Here we only have emodb available.
+    # A test using more published databases
+    # is executed in test_publish.py
     df = audb.cached(name='emodb')
     assert len(df) > 0
     assert set(df['name']) == set(['emodb'])

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -466,3 +466,12 @@ def test_update_database():
     db1.meta['audb'] = {}
     db2.meta['audb'] = {}
     assert db1 == db2
+
+
+def test_cached():
+    # Check first that we have different database names available
+    df = audb.cached()
+    names = list(set(df.name))
+    assert len(names) > 1
+    df = audb.cached(name=names[0])
+    assert set(df.name) == set([names[0]])


### PR DESCRIPTION
Closes #124

This provides the possibility to limit the search in cache for a particular database.
This is not only useful for a user, but it will also speed up `audb.load()` for certain cases when we are looking for a particular database in cache.