### PR TITLE
Use sloppy durations for non SND files

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -399,7 +399,7 @@ class Dependencies:
                 if bit_depth is None:  # pragma: nocover (non SND files)
                     bit_depth = 0
                 channels = audiofile.channels(path)
-                duration = audiofile.duration(path)
+                duration = audiofile.duration(path, sloppy=True)
                 sampling_rate = audiofile.sampling_rate(path)
             except FileNotFoundError:  # pragma: nocover
                 # If sox or mediafile are not installed

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     audbackend >=0.3.7
     audeer >=1.14.0
     audformat >=0.11.1,<2.0.0
-    audiofile >=0.4.0
+    audiofile >=1.0.0
     audobject >=0.4.12
     audresample >=0.1.5
     oyaml


### PR DESCRIPTION
To speed up processing of non SND files during publication we switch to use `audiofile.duration(.., sloppy=True)` when getting the duration for the dependency table.