### PR TITLE
Speedup audb.available()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -34,23 +34,32 @@ def available(
     """
     databases = []
     for repository in config.REPOSITORIES:
-        pattern = f'*/{define.DB}/*/{define.DB}-*.yaml'
         backend = audbackend.create(
             repository.backend,
             repository.host,
             repository.name,
         )
-        for p in backend.glob(pattern):
-            name, _, version, _ = p.split('/')[-4:]
-            databases.append(
-                [
-                    name,
-                    repository.backend,
-                    repository.host,
-                    repository.name,
-                    version,
-                ]
-            )
+        try:
+            names = backend.ls('')
+        except FileNotFoundError:  # pragma: nocover
+            # Handle missing repos
+            continue
+        for name in names:
+            try:
+                versions = backend.ls(f'{name}/{define.DB}')
+                for version in versions:
+                    databases.append(
+                        [
+                            name,
+                            repository.backend,
+                            repository.host,
+                            repository.name,
+                            version,
+                        ]
+                    )
+            except FileNotFoundError:  # pragma: nocover
+                # Handle broken databases
+                continue
 
     df = pd.DataFrame.from_records(
         databases,

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -41,7 +41,7 @@ def available(
         )
         try:
             names = backend.ls('')
-        except FileNotFoundError:  # pragma: nocover
+        except FileNotFoundError:
             # Handle missing repos
             continue
         for name in names:
@@ -57,7 +57,7 @@ def available(
                             version,
                         ]
                     )
-            except FileNotFoundError:  # pragma: nocover
+            except FileNotFoundError:
                 # Handle broken databases
                 continue
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audbackend >=0.3.7
+    audbackend >=0.3.10
     audeer >=1.14.0
     audformat >=0.11.1,<2.0.0
     audiofile >=1.0.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,34 @@
+import os
+
+import pytest
+
+import audb
+import audeer
+
+
+def test_available():
+
+    # Non existing repo
+    name = 'non-existing-repo'
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name=name,
+            host=pytest.FILE_SYSTEM_HOST,
+            backend=pytest.BACKEND,
+        )
+    ]
+    df = audb.available()
+    assert len(df) == 0
+
+    # Borken database in repo
+    name = 'non-existing-database'
+    audb.config.REPOSITORIES = pytest.REPOSITORIES
+    path = os.path.join(
+        audb.config.REPOSITORIES[0].host,
+        audb.config.REPOSITORIES[0].name,
+        name,
+    )
+    path = audeer.mkdir(path)
+    audb.available()
+    os.rmdir(path)
+    assert len(df) == 0


### PR DESCRIPTION
Speedup the call to `audb.available()`.

So far we have used `backend.glob()` to get a list of all databases.
As the structure how we store the data is fixed, we can instead simply list the content of the folder.

This improves execution times on our internal repos.
E.g. over the VPN I get for calling `df = audb.available()`:

* Before: 237s
* After: 100s

I repeated the measurement internally on our compute servers and get:

* Before: 8.1s
* After: 3.9s

/cc @ChristianGeng 