### PR TITLE
Fix db.root of returned db for audb.load_to()

### DIFF
--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -325,4 +325,7 @@ def load_to(
             'This should not happen.'
         )
 
+    # Force root to not point to tmp folder
+    db._root = db_root
+
     return db

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -408,6 +408,7 @@ def test_load_to(version):
         num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
+    assert db.root == db_root
 
     if version is None:
         version = audb.latest_version(DB_NAME)


### PR DESCRIPTION
Closes #134 and https://github.com/audeering/audformat/issues/112

This adds a test to check that `db.root` equals `db_root` when calling
```python
db = audb.load_to(db_root, ...)
```
It also adds a fix to make sure the test does not fail.