### PR TITLE
CI: use Python 3.8 for release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
We need to build the documentation with Python 3.8 for the release as with 3.10 it fails, compare https://github.com/audeering/audb/runs/4253551539?check_suite_focus=true