### PR TITLE
DOC: fix typo in audb.config.REPOSITORIES

### DIFF
--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -103,7 +103,7 @@ class config:
     containing the following attributes:
 
     * :attr:`audb.Repository.name`: repository name, e.g. ``'data-local'``
-    * :attr:`aub2.Repository.backend`: backend name, e.g. ``'artifactory'``
+    * :attr:`audb.Repository.backend`: backend name, e.g. ``'artifactory'``
     * :attr:`audb.Repository.host`: host name,
       e.g. ``'https://artifactory.audeering.com/artifactory'``
 


### PR DESCRIPTION
There was a small typo.