### PR TITLE
Update package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
 name = audb
 author = Johannes Wagner, Hagen Wierstorf
-author-email = jwagner@audeering.com, hwierstorf@audeering.com
+author_email = jwagner@audeering.com, hwierstorf@audeering.com
 url = https://audeering.github.io/audb/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/audb/
 description = Load and publish databases in audformat
-long-description = file: README.rst, CHANGELOG.rst
+long_description = file: README.rst, CHANGELOG.rst
 license = MIT
-license-file = LICENSE
+license_file = LICENSE
 keywords = audio, data, annotation, mlops, machine learning
 platforms= any
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def`.