### PR TITLE
Speed up audb.load_to() storing of CSV files

### DIFF
--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -201,8 +201,11 @@ def _save_database(
         audformat.define.TableStorageFormat.PICKLE,
     ]:
         db.save(
-            db_root_tmp, storage_format=storage_format,
-            num_workers=num_workers, verbose=verbose,
+            db_root_tmp,
+            storage_format=storage_format,
+            update_other_formats=False,
+            num_workers=num_workers,
+            verbose=verbose,
         )
         _move_file(db_root_tmp, db_root, define.HEADER_FILE)
         for path in glob.glob(


### PR DESCRIPTION
In `audb.load_to()` we store tables first as CSV file and then as PKL files. As we have called `db.save()` with the default `update_other_formats=True`, this means it had stored the CSV file again when storing the PKL file.

This is fixed here by explicitly setting `update_other_formats=False`.