### PR TITLE
DOC: be more explicit when to use archives

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -289,7 +289,9 @@ def publish(
         version: version string
         repository: name of repository
         archives: dictionary mapping files to archive names.
-            Can be used to bundle files into archives.
+            Can be used to bundle files into archives,
+            which will speed up communication with the server
+            if the database contains millions of small files.
             Archive name must not include an extension
         previous_version: specifies the version
             this publication should be based on.

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -291,7 +291,7 @@ def publish(
         archives: dictionary mapping files to archive names.
             Can be used to bundle files into archives,
             which will speed up communication with the server
-            if the database contains millions of small files.
+            if the database contains many small files.
             Archive name must not include an extension
         previous_version: specifies the version
             this publication should be based on.


### PR DESCRIPTION
When publishing a database with >2,000,000 small files I realized that grouping them in archives was making the uploading part of `audb.publish()` around 5x faster.

So I think it is good to add this advice to the docstring of `audb.publish()` and gave a hint when to use the `archives` argument:

![image](https://user-images.githubusercontent.com/173624/147909544-8d06d237-5064-40fb-92de-285ff7b5a1bd.png)

