### PR TITLE
DOC: fix typos in API

### DIFF
--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -73,10 +73,8 @@ class config:
     The configuration values are read in during module import
     from the :ref:`configuration file <configuration>`
     :file:`~/.audb.yaml`.
-
     You can change the configuration values after import,
     by setting the attributes directly.
-
     The :ref:`caching <caching>` related configuration values
     can be overwritten by environment variables.
 

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -13,8 +13,7 @@ from audb.core import define
 class Dependencies:
     r"""Dependencies of a database.
 
-    :class:`audb.Dependencies` gathers all files
-    a database contains
+    :class:`audb.Dependencies` gathers all database files
     and metadata about them
     in a single object.
     The metadata contains information
@@ -256,7 +255,7 @@ class Dependencies:
 
         Args:
             path: path to file.
-                File extension can be ``csv`` or ``pkl``.
+                File extension can be ``csv`` or ``pkl``
 
         Raises:
             ValueError: if file extension is not ``csv`` or ``pkl``
@@ -326,7 +325,7 @@ class Dependencies:
 
         Args:
             path: path to file.
-                File extension can be ``csv`` or ``pkl``.
+                File extension can be ``csv`` or ``pkl``
 
         """
         path = audeer.safe_path(path)

--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -21,7 +21,8 @@ class Flavor(audobject.Object):
     and offers a convenient way to convert files to it.
 
     As the following example shows,
-    it can also be used to convert files that are not part of database:
+    it can also be used to convert files
+    that are not part of a database:
 
     .. code-block::  python
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -733,19 +733,19 @@ def load(
     Loads meta and media files of a database to the local cache and returns
     a :class:`audformat.Database` object.
 
-    When working with data,
-    we often make assumptions about the media files.
-    For instance, we expect that audio files are
-    have a specific sampling rate.
     By setting
-    ``bit_depth``, ``channels``, ``format``, ``mixdown``, and ``sampling_rate``
+    ``bit_depth``,
+    ``channels``,
+    ``format``,
+    ``mixdown``,
+    and ``sampling_rate``
     we can request a specific flavor of the database.
     In that case media files are automatically converted to the desired
     properties (see also :class:`audb.Flavor`).
 
     It is possible to filter meta and media files with the arguments
     ``tables`` and ``media``.
-    Note that only media files with at least one reference are loaded.
+    Only media files with at least one reference are loaded.
     I.e. filtering meta files, may also remove media files.
     Likewise, references to missing media files will be removed, too.
     I.e. filtering media files, may also remove entries from the meta files.
@@ -761,7 +761,7 @@ def load(
             E.g. ``channels=[0, 1]`` upsamples all mono files to stereo,
             and ``channels=[1]`` returns the second channel
             of all multi-channel files
-            and all mono files.
+            and all mono files
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
@@ -982,7 +982,7 @@ def load_media(
             E.g. ``channels=[0, 1]`` upsamples all mono files to stereo,
             and ``channels=[1]`` returns the second channel
             of all multi-channel files
-            and all mono files.
+            and all mono files
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -274,9 +274,6 @@ def publish(
     with :func:`audb.load_to` to ``db_root``.
     Afterwards you make your changes to that folder
     and run :func:`audb.publish`.
-    :func:`audb.publish` will then check
-    that the version of the files inside that folder
-    match the version given by ``previous_version``.
 
     Setting ``previous_version=None`` allows you
     to start from scratch and upload all files
@@ -297,7 +294,7 @@ def publish(
             it will use automatically the latest published version
             or ``None``
             if no version was published.
-            If ``None`` it assumes you start from scratch.
+            If ``None`` it assumes you start from scratch
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used.
             Only used to read the dependencies of the previous version


### PR DESCRIPTION
This fixes a few typos and make text easier to understand in the API documentation.