### PR TITLE
DOC: extend docstring of audb.available()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -26,12 +26,18 @@ def available(
     r"""List all databases that are available to the user.
 
     Args:
-        only_latest: keep only latest version
+        only_latest: include only latest version of database
 
     Returns:
-        table with name, version and private flag
+        table with name, backend, host, repository, and version
 
-    """
+    Example:
+        >>> audb.available(only_latest=True)
+                   backend                                    host   repository version
+        name
+        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.1.1
+
+    """  # noqa: E501
     databases = []
     for repository in config.REPOSITORIES:
         backend = audbackend.create(

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -29,7 +29,8 @@ def available(
         only_latest: include only latest version of database
 
     Returns:
-        table with name, backend, host, repository, and version
+        table with database name as index,
+        and backend, host, repository, version as columns
 
     Example:
         >>> audb.available(only_latest=True)


### PR DESCRIPTION
This corrects and extends the `audb.available()` API doc to

![image](https://user-images.githubusercontent.com/173624/151179294-12b43af8-ab20-47b3-be35-3314ac67e74d.png)


Before, I thought it might be not a good idea to add an example here as the output might change over time. But as we are not planning to publish more public databases to that repo at the moment, I think the benefits of showing an example are larger than not doing it.