### PR TITLE
Move repository() to audb.core.api

### DIFF
--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -8,6 +8,7 @@ from audb.core.api import (
     flavor_path,
     latest_version,
     remove_media,
+    repository,
     versions,
 )
 from audb.core.backward import get_default_cache_root
@@ -22,7 +23,6 @@ from audb.core.load import (
 from audb.core.load_to import load_to
 from audb.core.publish import publish
 from audb.core.repository import Repository
-from audb.core.utils import repository
 
 
 __all__ = []

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -13,9 +13,11 @@ from audb.core import define
 from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor
+from audb.core.repository import Repository
 from audb.core.utils import (
     lookup_backend,
     mix_mapping,
+    _lookup,
 )
 
 
@@ -574,6 +576,35 @@ def remove_media(
                     remote_archive,
                     version,
                 )
+
+
+def repository(
+        name: str,
+        version: str,
+) -> Repository:
+    r"""Return repository that stores the requested database.
+
+    If the database is stored in several repositories,
+    only the first one is returned.
+    The order of the repositories to look for the database
+    is given by :attr:`config.REPOSITORIES`.
+
+    Args:
+        name: database name
+        version: version string
+
+    Returns:
+        repository that contains the database
+
+    Raises:
+        RuntimeError: if database is not found
+
+    Example:
+        >>> audb.repository('emodb', '1.1.1')
+        Repository('data-public', 'https://audeering.jfrog.io/artifactory', 'artifactory')
+
+    """  # noqa: E501
+    return _lookup(name, version)[0]
 
 
 def versions(

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -33,35 +33,6 @@ def lookup_backend(
     return _lookup(name, version)[1]
 
 
-def repository(
-        name: str,
-        version: str,
-) -> Repository:
-    r"""Return repository that stores the requested database.
-
-    If the database is stored in several repositories,
-    only the first one is returned.
-    The order of the repositories to look for the database
-    is given by :attr:`config.REPOSITORIES`.
-
-    Args:
-        name: database name
-        version: version string
-
-    Returns:
-        repository that contains the database
-
-    Raises:
-        RuntimeError: if database is not found
-
-    Example:
-        >>> audb.repository('emodb', '1.1.1')
-        Repository('data-public', 'https://audeering.jfrog.io/artifactory', 'artifactory')
-
-    """  # noqa: E501
-    return _lookup(name, version)[0]
-
-
 def mix_mapping(
         mix: str,
         warn: bool = True,


### PR DESCRIPTION
To avoid circular imports we have not defined `repository()` in `audb.core.repository`, but do it inside `audb.core.utils`. As we expose the function to the API, I think it makes more sense to move it to `audb.core.api`.