### PR TITLE
Use pickle protocol-4 for caching dependencies

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -304,7 +304,9 @@ def dependencies(
     deps_path = os.path.join(deps_root, define.CACHED_DEPENDENCIES_FILE)
 
     deps = Dependencies()
-    if not os.path.exists(deps_path):
+    try:
+        deps.load(deps_path)
+    except (FileNotFoundError, ValueError, EOFError):
         backend = lookup_backend(name, version)
         with tempfile.TemporaryDirectory() as tmp_root:
             archive = backend.join(name, define.DB)
@@ -315,8 +317,6 @@ def dependencies(
             )
             deps.load(os.path.join(tmp_root, define.DEPENDENCIES_FILE))
             deps.save(deps_path)
-    else:
-        deps.load(deps_path)
 
     return deps
 

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -278,7 +278,6 @@ class Dependencies:
             )
         if extension == 'pkl':
             self._df = pd.read_pickle(path)
-
         elif extension == 'csv':
             # Data type of dependency columns
             dtype_mapping = {

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -277,7 +277,10 @@ class Dependencies:
                 path,
             )
         if extension == 'pkl':
-            self._df = pd.read_pickle(path)
+            self._df = pd.read_pickle(
+                path,
+                protocol=4,  # supported by Python >= 3.4
+            )
         elif extension == 'csv':
             # Data type of dependency columns
             dtype_mapping = {

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -277,10 +277,8 @@ class Dependencies:
                 path,
             )
         if extension == 'pkl':
-            self._df = pd.read_pickle(
-                path,
-                protocol=4,  # supported by Python >= 3.4
-            )
+            self._df = pd.read_pickle(path)
+
         elif extension == 'csv':
             # Data type of dependency columns
             dtype_mapping = {
@@ -335,7 +333,10 @@ class Dependencies:
         if path.endswith('csv'):
             self._df.to_csv(path)
         elif path.endswith('pkl'):
-            self._df.to_pickle(path)
+            self._df.to_pickle(
+                path,
+                protocol=4,  # supported by Python >= 3.4
+            )
 
     def type(self, file: str) -> int:
         r"""Type of file.


### PR DESCRIPTION
Similar to https://github.com/audeering/audformat/pull/142/ this ensures compatibility of cache between different pickle versions.

One problem is that we cannot easily fix existing protocol-5 caching files by reading the CSv file instead as the `load()` function is exposed to the user and it accepts the whole file path as input. So you can have an CSV file with the same name unrelated from the PKL in a folder.