### PR TITLE
Create folder tree more efficiently when loading

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -11,6 +11,7 @@ import audeer
 import audformat
 
 from audb.core import define
+from audb.core import utils
 from audb.core.api import (
     cached,
     default_cache_root,
@@ -214,9 +215,8 @@ def _get_media_from_backend(
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
     # using multi-processing
-    for file in media:
-        audeer.mkdir(os.path.dirname(os.path.join(db_root, file)))
-        audeer.mkdir(os.path.dirname(os.path.join(db_root_tmp, file)))
+    utils._mkdir_tree(media, db_root)
+    utils._mkdir_tree(media, db_root_tmp)
 
     def job(archive: str, version: str):
         archive = backend.join(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -215,8 +215,8 @@ def _get_media_from_backend(
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
     # using multi-processing
-    utils._mkdir_tree(media, db_root)
-    utils._mkdir_tree(media, db_root_tmp)
+    utils.mkdir_tree(media, db_root)
+    utils.mkdir_tree(media, db_root_tmp)
 
     def job(archive: str, version: str):
         archive = backend.join(

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -94,8 +94,8 @@ def _get_media(
 
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
-    utils._mkdir_tree(media, db_root)
-    utils._mkdir_tree(media, db_root_tmp)
+    utils.mkdir_tree(media, db_root)
+    utils.mkdir_tree(media, db_root_tmp)
 
     # figure out archives
     archives = set()

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -7,6 +7,7 @@ import audeer
 import audformat
 
 from audb.core import define
+from audb.core import utils
 from audb.core.api import (
     dependencies,
     latest_version,
@@ -93,9 +94,8 @@ def _get_media(
 
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
-    for file in media:
-        audeer.mkdir(os.path.dirname(os.path.join(db_root, file)))
-        audeer.mkdir(os.path.dirname(os.path.join(db_root_tmp, file)))
+    utils._mkdir_tree(media, db_root)
+    utils._mkdir_tree(media, db_root_tmp)
 
     # figure out archives
     archives = set()

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -81,6 +81,18 @@ def mix_mapping(
     return channels, mixdown
 
 
+def mkdir_tree(
+        files: typing.Sequence[str],
+        root: str,
+):
+    r"""Helper function to create folder tree."""
+    folders = set()
+    for file in files:
+        folders.add(os.path.dirname(file))
+    for folder in folders:
+        audeer.mkdir(os.path.join(root, folder))
+
+
 def _lookup(
         name: str,
         version: str,
@@ -108,15 +120,3 @@ def _lookup(
         f'for database '
         f"'{name}'."
     )
-
-
-def _mkdir_tree(
-        files: typing.Sequence[str],
-        root: str,
-):
-    r"""Helper function to create folder tree."""
-    folders = set()
-    for file in files:
-        folders.add(os.path.dirname(file))
-    for folder in folders:
-        audeer.mkdir(os.path.join(root, folder))

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -1,7 +1,9 @@
+import os
 import typing
 import warnings
 
 import audbackend
+import audeer
 
 from audb.core.config import config
 from audb.core.repository import Repository
@@ -106,3 +108,15 @@ def _lookup(
         f'for database '
         f"'{name}'."
     )
+
+
+def _mkdir_tree(
+        files: typing.Sequence[str],
+        root: str,
+):
+    r"""Helper function to create folder tree."""
+    folders = set()
+    for file in files:
+        folders.add(os.path.dirname(file))
+    for folder in folders:
+        audeer.mkdir(os.path.join(root, folder))


### PR DESCRIPTION
Avoid unnecessary operations on the file system by first figuring out which folders we need to create.