### PR TITLE
Share more code between load() and load_to()

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -122,7 +122,7 @@ def _copy_file(
     audeer.mkdir(os.path.dirname(tmp_path))
     audeer.mkdir(os.path.dirname(dst_path))
     shutil.copy(src_path, tmp_path)
-    _move_file(root_tmp, root_dst, file)
+    utils.move_file(root_tmp, root_dst, file)
 
 
 def _database_check_complete(
@@ -150,7 +150,7 @@ def _database_check_complete(
         db_original = audformat.Database.load(db_root, load_data=False)
         db_original.meta['audb']['complete'] = True
         db_original.save(db_root_tmp, header_only=True)
-        _move_file(db_root_tmp, db_root, define.HEADER_FILE)
+        utils.move_file(db_root_tmp, db_root, define.HEADER_FILE)
 
 
 def _database_is_complete(
@@ -244,7 +244,7 @@ def _get_media_from_backend(
                 if src_path != dst_path:
                     os.remove(src_path)
 
-            _move_file(db_root_tmp, db_root, file)
+            utils.move_file(db_root_tmp, db_root, file)
 
     audeer.run_tasks(
         job,
@@ -325,7 +325,8 @@ def _get_tables_from_backend(
             audformat.define.TableStorageFormat.PICKLE,
             audformat.define.TableStorageFormat.CSV,
         ]:
-            _move_file(db_root_tmp, db_root, f'db.{table_id}.{storage_format}')
+            file = f'db.{table_id}.{storage_format}'
+            utils.move_file(db_root_tmp, db_root, file)
 
     audeer.run_tasks(
         job,
@@ -556,18 +557,6 @@ def _missing_tables(
         if not os.path.exists(path):
             missing_tables.append(file)
     return missing_tables
-
-
-def _move_file(
-        root_src: str,
-        root_dst: str,
-        file: str,
-):
-    r"""Move file to another directory."""
-    os.replace(
-        os.path.join(root_src, file),
-        os.path.join(root_dst, file),
-    )
 
 
 def _remove_media(
@@ -943,7 +932,7 @@ def load_header(
                 'complete': False,
             }
             db.save(db_root_tmp, header_only=True)
-            _move_file(db_root_tmp, db_root, define.HEADER_FILE)
+            utils.move_file(db_root_tmp, db_root, define.HEADER_FILE)
     return audformat.Database.load(db_root, load_data=False), backend
 
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -112,7 +112,7 @@ def _get_media(
         )
         files = backend.get_archive(archive, db_root_tmp, version)
         for file in files:
-            _move_file(db_root_tmp, db_root, file)
+            utils.move_file(db_root_tmp, db_root, file)
 
     audeer.run_tasks(
         job,
@@ -151,7 +151,7 @@ def _get_tables(
             deps.archive(table),
         )
         backend.get_archive(archive, db_root_tmp, deps.version(table))
-        _move_file(db_root_tmp, db_root, table)
+        utils.move_file(db_root_tmp, db_root, table)
 
     audeer.run_tasks(
         job,
@@ -159,19 +159,6 @@ def _get_tables(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description='Get tables',
-    )
-
-
-def _move_file(
-        root_src: str,
-        root_dst: str,
-        file: str,
-):
-    r"""Move file to another directory."""
-
-    os.replace(
-        os.path.join(root_src, file),
-        os.path.join(root_dst, file),
     )
 
 
@@ -207,12 +194,12 @@ def _save_database(
             num_workers=num_workers,
             verbose=verbose,
         )
-        _move_file(db_root_tmp, db_root, define.HEADER_FILE)
+        utils.move_file(db_root_tmp, db_root, define.HEADER_FILE)
         for path in glob.glob(
                 os.path.join(db_root_tmp, f'*.{storage_format}')
         ):
             file = os.path.relpath(path, db_root_tmp)
-            _move_file(db_root_tmp, db_root, file)
+            utils.move_file(db_root_tmp, db_root, file)
 
 
 def load_to(
@@ -288,7 +275,7 @@ def load_to(
     # load database
 
     # move header to root and load database ...
-    _move_file(db_root_tmp, db_root, define.HEADER_FILE)
+    utils.move_file(db_root_tmp, db_root, define.HEADER_FILE)
     try:
         db = audformat.Database.load(
             db_root,
@@ -313,7 +300,7 @@ def load_to(
 
     dep_path_tmp = os.path.join(db_root_tmp, define.DEPENDENCIES_FILE)
     deps.save(dep_path_tmp)
-    _move_file(db_root_tmp, db_root, define.DEPENDENCIES_FILE)
+    utils.move_file(db_root_tmp, db_root, define.DEPENDENCIES_FILE)
 
     # save database and remove the temporal directory
     # to signal all files were correctly loaded

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -35,6 +35,18 @@ def lookup_backend(
     return _lookup(name, version)[1]
 
 
+def move_file(
+        root_src: str,
+        root_dst: str,
+        file: str,
+):
+    r"""Move file to another directory."""
+    os.replace(
+        os.path.join(root_src, file),
+        os.path.join(root_dst, file),
+    )
+
+
 def mkdir_tree(
         files: typing.Sequence[str],
         root: str,


### PR DESCRIPTION
Closes #46 

This moves `_move_file` to `utils.move_file` as it is used in `audb.load()` and `audb.load_to()` and was implemented identically.