### PR TITLE
Depend on audobject>=0.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     audeer >=1.14.0
     audformat >=0.13.3,<2.0.0
     audiofile >=1.0.0
-    audobject >=0.4.12
+    audobject >=0.5.0
     audresample >=0.1.5
     oyaml
 setup_requires =

--- a/tests/test_flavor.py
+++ b/tests/test_flavor.py
@@ -44,7 +44,7 @@ def test_init(bit_depth, channels, format, mixdown, sampling_rate):
         sampling_rate=sampling_rate,
     )
     flavor_s = flavor.to_yaml_s()
-    flavor_2 = audobject.Object.from_yaml_s(flavor_s)
+    flavor_2 = audobject.from_yaml_s(flavor_s)
     assert isinstance(flavor_2, audb.Flavor)
     assert flavor.id == flavor_2.id
 


### PR DESCRIPTION
Use `audobject>=0.5.0` to make sure `audobject.from_yaml*()` functions are available and we don't get deprecation warnings in the tests.

I could have required `>=0.5.0` only for the tests, but I think it is fine to require it for the whole package.