### PR TITLE
Use emodb v1.2.0 for examples and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/audb
-        key: emodb-1.1.1-1
+        key: emodb-1.2.0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -37,7 +37,7 @@ def available(
         >>> audb.available(only_latest=True)
                    backend                                    host   repository version
         name
-        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.1.1
+        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.2.0
 
     """  # noqa: E501
     databases = []
@@ -121,7 +121,7 @@ def cached(
     Example:
         >>> db = audb.load(
         ...     'emodb',
-        ...     version='1.1.1',
+        ...     version='1.2.0',
         ...     only_metadata=True,
         ...     full_path=False,
         ...     verbose=False,
@@ -130,7 +130,7 @@ def cached(
         >>> print(df.iloc[0].to_string())
         name                emodb
         flavor_id        d3b62a9b
-        version             1.1.1
+        version             1.2.0
         complete            False
         bit_depth            None
         channels             None
@@ -276,7 +276,7 @@ def dependencies(
         dependency object
 
     Example:
-        >>> deps = dependencies('emodb', version='1.1.1')
+        >>> deps = dependencies('emodb', version='1.2.0')
         >>> deps.version('db.emotion.csv')
         '1.1.0'
 
@@ -361,13 +361,13 @@ def exists(
     Example:
         >>> db = audb.load(
         ...     'emodb',
-        ...     version='1.1.1',
+        ...     version='1.2.0',
         ...     only_metadata=True,
         ...     verbose=False,
         ... )
-        >>> audb.exists('emodb', version='1.1.1')
+        >>> audb.exists('emodb', version='1.2.0')
         True
-        >>> audb.exists('emodb', version='1.1.1', format='wav')
+        >>> audb.exists('emodb', version='1.2.0', format='wav')
         False
 
     """
@@ -437,8 +437,8 @@ def flavor_path(
         flavor path relative to cache folder
 
     Example:
-        >>> flavor_path('emodb', version='1.1.1').split(os.path.sep)
-        ['emodb', '1.1.1', 'd3b62a9b']
+        >>> flavor_path('emodb', version='1.2.0').split(os.path.sep)
+        ['emodb', '1.2.0', 'd3b62a9b']
 
     """
     flavor = Flavor(
@@ -465,7 +465,7 @@ def latest_version(
 
     Example:
         >>> latest_version('emodb')
-        '1.1.1'
+        '1.2.0'
 
     """
     vs = versions(name)
@@ -586,7 +586,7 @@ def repository(
         RuntimeError: if database is not found
 
     Example:
-        >>> audb.repository('emodb', '1.1.1')
+        >>> audb.repository('emodb', '1.2.0')
         Repository('data-public', 'https://audeering.jfrog.io/artifactory', 'artifactory')
 
     """  # noqa: E501
@@ -606,7 +606,7 @@ def versions(
 
     Example:
         >>> versions('emodb')
-        ['1.1.0', '1.1.1']
+        ['1.1.0', '1.1.1', '1.2.0']
 
     """
     vs = []

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -30,8 +30,8 @@ class Dependencies:
         Empty DataFrame
         Columns: [archive, bit_depth, channels, checksum, duration, format, removed, sampling_rate, type, version]
         Index: []
-        >>> # Request dependencies for emodb 1.1.1
-        >>> deps = audb.dependencies('emodb', version='1.1.1')
+        >>> # Request dependencies for emodb 1.2.0
+        >>> deps = audb.dependencies('emodb', version='1.2.0')
         >>> # List all files or archives
         >>> deps.files[:3]
         ['db.emotion.csv', 'db.files.csv', 'wav/03a01Fa.wav']

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -33,7 +33,7 @@ def author(
         author(s) of database
 
     Example:
-        >>> author('emodb', version='1.1.1')
+        >>> author('emodb', version='1.2.0')
         'Felix Burkhardt, Astrid Paeschke, Miriam Rolfes, Walter Sendlmeier, Benjamin Weiss'
 
     """  # noqa: E501
@@ -59,7 +59,7 @@ def bit_depths(
         bit depths
 
     Example:
-        >>> bit_depths('emodb', version='1.1.1')
+        >>> bit_depths('emodb', version='1.2.0')
         {16}
 
     """
@@ -86,7 +86,7 @@ def channels(
         channel numbers
 
     Example:
-        >>> channels('emodb', version='1.1.1')
+        >>> channels('emodb', version='1.2.0')
         {1}
 
     """
@@ -113,7 +113,7 @@ def description(
         description of database
 
     Example:
-        >>> desc = description('emodb', version='1.1.1')
+        >>> desc = description('emodb', version='1.2.0')
         >>> desc.split('.')[0]  # show first sentence
         'Berlin Database of Emotional Speech'
 
@@ -140,7 +140,7 @@ def duration(
         duration
 
     Example:
-        >>> duration('emodb', version='1.1.1')
+        >>> duration('emodb', version='1.2.0')
         Timedelta('0 days 00:24:47.092187500')
 
     """
@@ -170,7 +170,7 @@ def formats(
         format
 
     Example:
-        >>> formats('emodb', version='1.1.1')
+        >>> formats('emodb', version='1.2.0')
         {'wav'}
 
     """
@@ -197,7 +197,7 @@ def header(
         database object without table data
 
     Example:
-        >>> db = header('emodb', version='1.1.1')
+        >>> db = header('emodb', version='1.2.0')
         >>> db.name
         'emodb'
 
@@ -227,7 +227,7 @@ def languages(
         languages of database
 
     Example:
-        >>> languages('emodb', version='1.1.1')
+        >>> languages('emodb', version='1.2.0')
         ['deu']
 
     """
@@ -253,7 +253,7 @@ def license(
         license of database
 
     Example:
-        >>> license('emodb', version='1.1.1')
+        >>> license('emodb', version='1.2.0')
         'CC0-1.0'
 
     """
@@ -279,7 +279,7 @@ def license_url(
         license URL of database
 
     Example:
-        >>> license_url('emodb', version='1.1.1')
+        >>> license_url('emodb', version='1.2.0')
         'https://creativecommons.org/publicdomain/zero/1.0/'
 
     """
@@ -305,7 +305,7 @@ def media(
         media of database
 
     Example:
-        >>> media('emodb', version='1.1.1')
+        >>> media('emodb', version='1.2.0')
         microphone:
             {type: other, format: wav, channels: 1, sampling_rate: 16000}
 
@@ -332,7 +332,7 @@ def meta(
         meta information of database
 
     Example:
-        >>> meta('emodb', version='1.1.1')
+        >>> meta('emodb', version='1.2.0')
         pdf:
           http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.130.8506&rep=rep1&type=pdf
 
@@ -359,7 +359,7 @@ def organization(
         organization responsible for database
 
     Example:
-        >>> organization('emodb', version='1.1.1')
+        >>> organization('emodb', version='1.2.0')
         'audEERING'
 
     """
@@ -385,7 +385,7 @@ def raters(
         raters of database
 
     Example:
-        >>> raters('emodb', version='1.1.1')
+        >>> raters('emodb', version='1.2.0')
         gold:
             {type: human}
 
@@ -412,7 +412,7 @@ def sampling_rates(
         sampling rates
 
     Example:
-        >>> sampling_rates('emodb', version='1.1.1')
+        >>> sampling_rates('emodb', version='1.2.0')
         {16000}
 
     """
@@ -439,7 +439,7 @@ def schemes(
         schemes of database
 
     Example:
-        >>> list(schemes('emodb', version='1.1.1'))
+        >>> list(schemes('emodb', version='1.2.0'))
         ['confidence', 'duration', 'emotion', 'speaker', 'transcription']
 
     """
@@ -465,7 +465,7 @@ def source(
         source of database
 
     Example:
-        >>> source('emodb', version='1.1.1')
+        >>> source('emodb', version='1.2.0')
         'http://emodb.bilderbar.info/download/download.zip'
 
     """
@@ -491,10 +491,13 @@ def splits(
         splits of database
 
     Example:
-        >>> splits('emodb', version='1.1.1')
+        >>> splits('emodb', version='1.2.0')
+        test:
+          {description: Unofficial speaker-independent test split, type: test}
+        train:
+          {description: Unofficial speaker-independent train split, type: train}
 
-
-    """
+    """  # noqa: E501
     db = header(name, version=version, cache_root=cache_root)
     return db.splits
 
@@ -517,10 +520,10 @@ def tables(
         tables of database
 
     Example:
-        >>> list(tables('emodb', version='1.1.1'))
-        ['emotion', 'files']
+        >>> list(tables('emodb', version='1.2.0'))
+        ['emotion', 'emotion.categories.test.gold_standard', 'emotion.categories.train.gold_standard', 'files']
 
-    """
+    """  # noqa: E501
     db = header(name, version=version, cache_root=cache_root)
     return db.tables
 
@@ -543,7 +546,7 @@ def usage(
         usage of database
 
     Example:
-        >>> usage('emodb', version='1.1.1')
+        >>> usage('emodb', version='1.2.0')
         'unrestricted'
 
     """

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -798,7 +798,8 @@ def load(
     Example:
         >>> db = audb.load(
         ...     'emodb',
-        ...     version='1.1.1',
+        ...     version='1.2.0',
+        ...     tables=['emotion', 'files'],
         ...     only_metadata=True,
         ...     full_path=False,
         ...     verbose=False,
@@ -1023,12 +1024,12 @@ def load_media(
         >>> paths = load_media(
         ...     'emodb',
         ...     ['wav/03a01Fa.wav'],
-        ...     version='1.1.1',
+        ...     version='1.2.0',
         ...     format='flac',
         ...     verbose=False,
         ... )
         >>> paths[0].split(os.path.sep)[-5:]
-        ['emodb', '1.1.1', '40bb2241', 'wav', '03a01Fa.flac']
+        ['emodb', '1.2.0', '40bb2241', 'wav', '03a01Fa.flac']
 
     """
     media = audeer.to_list(media)
@@ -1136,7 +1137,7 @@ def load_table(
         >>> df = load_table(
         ...     'emodb',
         ...     'emotion',
-        ...     version='1.1.1',
+        ...     version='1.2.0',
         ...     verbose=False,
         ... )
         >>> df[:3]

--- a/audb/info/__init__.py
+++ b/audb/info/__init__.py
@@ -23,7 +23,7 @@ r"""Get information from database headers.
 
     audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         only_metadata=True,
         verbose=False,
     )
@@ -39,7 +39,7 @@ So instead of running:
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         only_metadata=True,
         verbose=False,
     )
@@ -51,7 +51,7 @@ You can run:
 
     audb.info.tables(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
     )
 
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ audb.config.REPOSITORIES = [
     )
 ]
 database_name = 'emodb'
-database_version = '1.1.1'
+database_version = '1.2.0'
 if not audb.exists(database_name, version=database_version):
     print(f'Pre-caching {database_name} v{database_version}')
     audb.load(

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -45,7 +45,7 @@ You request a :class:`audb.Dependencies` object with
 
 .. jupyter-execute::
 
-    deps = audb.dependencies('emodb', version='1.1.1')
+    deps = audb.dependencies('emodb', version='1.2.0')
 
 You can see all entries by calling the returned object.
 
@@ -71,7 +71,7 @@ in the database dependency table.
 
 .. jupyter-execute::
 
-    deps = audb.dependencies('emodb', version='1.1.1')
+    deps = audb.dependencies('emodb', version='1.2.0')
     df = deps()
     df.duration[:10]
 
@@ -80,7 +80,7 @@ you can get their overall duration with:
 
 .. jupyter-execute::
 
-    audb.info.duration('emodb', version='1.1.1')
+    audb.info.duration('emodb', version='1.2.0')
 
 The duration of parts of a database
 can be calculated
@@ -94,7 +94,7 @@ of the emodb database.
 
     import numpy as np
 
-    df = audb.load_table('emodb', 'emotion', version='1.1.1', verbose=False)
+    df = audb.load_table('emodb', 'emotion', version='1.2.0', verbose=False)
     files = df.index[:10]
     duration_in_sec = np.sum([deps.duration(f) for f in files])
     pd.to_timedelta(duration_in_sec, unit='s')

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -56,7 +56,7 @@ even if a new version of the database is published.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         only_metadata=True,
         verbose=False,
     )
@@ -65,7 +65,7 @@ even if a new version of the database is published.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         verbose=False,
     )
 
@@ -154,7 +154,7 @@ inside the :ref:`cache <caching>`.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         format='flac',
         sampling_rate=44100,
         only_metadata=True,
@@ -165,7 +165,7 @@ inside the :ref:`cache <caching>`.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         format='flac',
         sampling_rate=44100,
         verbose=False,
@@ -204,7 +204,7 @@ but all the tables and the header.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         only_metadata=True,
         verbose=False,
     )
@@ -222,7 +222,7 @@ It can list all table definitions.
 
     audb.info.tables(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
     )
 
 Or get the total duration of all media files.
@@ -231,7 +231,7 @@ Or get the total duration of all media files.
 
     audb.info.duration(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
     )
 
 See :mod:`audb.info` for a list of all available options.
@@ -261,7 +261,7 @@ about the speakers (here ``db['files']``):
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         tables=['files'],
         only_metadata=True,
         full_path=False,
@@ -301,7 +301,7 @@ only the data of this speaker.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         media=media,
         full_path=False,
         only_metadata=True,
@@ -312,7 +312,7 @@ only the data of this speaker.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         media=media,
         full_path=False,
         verbose=False,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -41,14 +41,14 @@ Let's load the database.
 
     db = audb.load(
         'emodb',
-        version='1.1.1',
+        version='1.2.0',
         only_metadata=True,
         verbose=False,
     )
 
 .. code-block:: python
 
-    db = audb.load('emodb', version='1.1.1', verbose=False)
+    db = audb.load('emodb', version='1.2.0', verbose=False)
 
 This downloads the database header,
 all the media files,


### PR DESCRIPTION
We updated `emodb` to version 1.2.0 in https://github.com/audeering/emodb/pull/4, so we also need to update some examples here (e.g. `audb.latest_version()`). To make it consistent, I updated all examples and tests to use the new version.

/cc @audeerington 