### PR TITLE
Depend on audbackend>=0.3.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audbackend >=0.3.14
+    audbackend >=0.3.15
     audeer >=1.18.0
     audformat >=0.14.1,<2.0.0
     audiofile >=1.0.0


### PR DESCRIPTION
To avoid the issue described in https://github.com/audeering/audbackend/issues/34 we will depend on a version of `audbackend` that ensures the error is fixed.