### PR TITLE
Only create tmp folder when needed in audb.load()

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -26,9 +26,26 @@ DB_ROOT_VERSION = {
 
 
 def clear_root(root: str):
-    root = audeer.path(root)
-    if os.path.exists(root):
-        shutil.rmtree(root)
+    audeer.rmdir(root)
+
+
+@pytest.fixture(
+    scope='function',
+    autouse=True,
+)
+def ensure_tmp_folder_deleted():
+    """Fixture to test that the ~ tmp folder gets deleted.
+
+    audb.load() first loads files to a folder
+    named after the database
+    and appended by ``'~'``.
+    This folder should be deleted in the end.
+
+    """
+    yield
+
+    dirs = audeer.list_dir_names(pytest.CACHE_ROOT, recursive=True)
+    assert len([d for d in dirs if d.endswith('~')]) == 0
 
 
 @pytest.fixture(


### PR DESCRIPTION
Closes #45.

This ensures `audb.load()` only creates the temporary data folder if needed.

Note, I remove this folder with `audeer.rmdir()` in `audb.load()` whereas in `audb.load_to()` we make an effort to first check if the folder is really empty, compare https://github.com/audeering/audb/blob/master/audb/core/load_to.py#L171-L181
Is there a reason we treat it differently in `audb.load_to()`?

I did not spend the effort to create tests that check that the tmp folder is only created if needed. I'm also not sure if this would be possible.