### PR TITLE
Lock dependencies and header

### DIFF
--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -2,7 +2,6 @@ from audb import info
 from audb.core.api import (
     available,
     cached,
-    default_cache_root,
     dependencies,
     exists,
     flavor_path,
@@ -11,6 +10,7 @@ from audb.core.api import (
     repository,
     versions,
 )
+from audb.core.cache import default_cache_root
 from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -11,6 +11,11 @@ import audeer
 import audformat
 
 from audb.core import define
+from audb.core.cache import (
+    database_cache_folder,
+    database_lock_path,
+    default_cache_root,
+)
 from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor
@@ -219,128 +224,6 @@ def cached(
 
     # Replace NaN with None
     return df.where(pd.notnull(df), None)
-
-
-def database_cache_folder(
-        name: str,
-        version: str,
-        cache_root: str = None,
-        flavor: Flavor = None,
-) -> str:
-    r"""Create and return database cache folder.
-
-    Args:
-        name: name of database
-        version: version of database
-        cache_root: path to cache folder
-        flavor: flavor of database
-
-    Returns:
-        path to cache folder
-
-    """
-    if cache_root is None:
-        cache_roots = [
-            default_cache_root(True),  # check shared cache first
-            default_cache_root(False),
-        ]
-    else:
-        cache_roots = [cache_root]
-    for cache_root in cache_roots:
-        if flavor is None:
-            db_root = audeer.path(
-                cache_root,
-                name,
-                version,
-            )
-        else:
-            db_root = audeer.path(
-                cache_root,
-                flavor.path(name, version),
-            )
-        if os.path.exists(db_root):
-            break
-
-    audeer.mkdir(db_root)
-    return db_root
-
-
-def database_lock_path(
-        root: str,
-) -> str:
-    r"""Create and return path to lock file.
-
-    If it does not exist yet,
-    creates a file ``.lock`` under ``root``.
-
-    Args:
-        root: path to folder
-
-    Returns:
-        path to lock file
-
-    """
-    lock_path = audeer.path(root, define.LOCK_FILE)
-    if not os.path.exists(lock_path):
-        audeer.touch(lock_path)
-    return lock_path
-
-
-def database_tmp_folder(
-        db_root: str,
-) -> str:
-    r"""Create and return temporary database cache folder.
-
-    The temporary cache folder is created under ``db_root + '~'``.
-
-    Args:
-        db_root: path to database cache folder
-
-    Returns:
-        path to temporary cache folder
-
-    """
-    tmp_root = db_root + '~'
-    tmp_root = audeer.mkdir(tmp_root)
-    return tmp_root
-
-
-def default_cache_root(
-        shared=False,
-) -> str:
-    r"""Default cache folder.
-
-    If ``shared`` is ``True``,
-    returns the path specified
-    by the environment variable
-    ``AUDB_SHARED_CACHE_ROOT``
-    or
-    ``audb.config.SHARED_CACHE_ROOT``.
-    If ``shared`` is ``False``,
-    returns the path specified
-    by the environment variable
-    ``AUDB_CACHE_ROOT``
-    or
-    ``audb.config.CACHE_ROOT``.
-
-    Args:
-        shared: if ``True`` returns path to shared cache folder
-
-    Returns:
-        path normalized by :func:`audeer.path`
-
-    """
-    if shared:
-        cache = (
-            os.environ.get('AUDB_SHARED_CACHE_ROOT')
-            or config.SHARED_CACHE_ROOT
-        )
-    else:
-        cache = (
-            os.environ.get('AUDB_CACHE_ROOT')
-            or config.CACHE_ROOT
-        )
-    return audeer.path(cache)
 
 
 def dependencies(

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -220,6 +220,90 @@ def cached(
     return df.where(pd.notnull(df), None)
 
 
+def database_cache_folder(
+        name: str,
+        version: str,
+        cache_root: str = None,
+        flavor: Flavor = None,
+) -> str:
+    r"""Create and return database cache folder.
+
+    Args:
+        name: name of database
+        version: version of database
+        cache_root: path to cache folder
+        flavor: flavor of database
+
+    Returns:
+        path to cache folder
+
+    """
+    if cache_root is None:
+        cache_roots = [
+            default_cache_root(True),  # check shared cache first
+            default_cache_root(False),
+        ]
+    else:
+        cache_roots = [cache_root]
+    for cache_root in cache_roots:
+        if flavor is None:
+            db_root = audeer.path(
+                cache_root,
+                name,
+                version,
+            )
+        else:
+            db_root = audeer.path(
+                cache_root,
+                flavor.path(name, version),
+            )
+        if os.path.exists(db_root):
+            break
+
+    audeer.mkdir(db_root)
+    return db_root
+
+
+def database_lock_path(
+        root: str,
+) -> str:
+    r"""Create and return path to lock file.
+
+    If it does not exist yet,
+    creates a file ``.lock`` under ``root``.
+
+    Args:
+        root: path to folder
+
+    Returns:
+        path to lock file
+
+    """
+    lock_path = audeer.path(root, define.LOCK_FILE)
+    if not os.path.exists(lock_path):
+        audeer.touch(lock_path)
+    return lock_path
+
+
+def database_tmp_folder(
+        db_root: str,
+) -> str:
+    r"""Create and return temporary database cache folder.
+
+    The temporary cache folder is created under ``db_root + '~'``.
+
+    Args:
+        db_root: path to database cache folder
+
+    Returns:
+        path to temporary cache folder
+
+    """
+    tmp_root = db_root + '~'
+    tmp_root = audeer.mkdir(tmp_root)
+    return tmp_root
+
+
 def default_cache_root(
         shared=False,
 ) -> str:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -368,21 +368,12 @@ def dependencies(
     if version is None:
         version = latest_version(name)
 
-    cache_roots = [
-        default_cache_root(True),  # check shared cache first
-        default_cache_root(False),
-    ] if cache_root is None else [cache_root]
-    for cache_root in cache_roots:
-        deps_root = audeer.path(
-            cache_root,
-            name,
-            version,
-        )
-        if os.path.exists(deps_root):
-            break
-
-    audeer.mkdir(deps_root)
-    deps_path = os.path.join(deps_root, define.CACHED_DEPENDENCIES_FILE)
+    db_root = database_cache_folder(
+        name,
+        version,
+        cache_root=cache_root,
+    )
+    deps_path = os.path.join(db_root, define.CACHED_DEPENDENCIES_FILE)
 
     deps = Dependencies()
     try:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -12,7 +12,7 @@ import audformat
 
 from audb.core import define
 from audb.core.cache import (
-    database_cache_folder,
+    database_cache_root,
     database_lock_path,
     default_cache_root,
 )
@@ -252,7 +252,7 @@ def dependencies(
     if version is None:
         version = latest_version(name)
 
-    db_root = database_cache_folder(
+    db_root = database_cache_root(
         name,
         version,
         cache_root=cache_root,

--- a/audb/core/cache.py
+++ b/audb/core/cache.py
@@ -1,0 +1,129 @@
+import os
+
+import audeer
+
+from audb.core import define
+from audb.core.config import config
+from audb.core.flavor import Flavor
+
+
+def database_cache_folder(
+        name: str,
+        version: str,
+        cache_root: str = None,
+        flavor: Flavor = None,
+) -> str:
+    r"""Create and return database cache folder.
+
+    Args:
+        name: name of database
+        version: version of database
+        cache_root: path to cache folder
+        flavor: flavor of database
+
+    Returns:
+        path to cache folder
+
+    """
+    if cache_root is None:
+        cache_roots = [
+            default_cache_root(True),  # check shared cache first
+            default_cache_root(False),
+        ]
+    else:
+        cache_roots = [cache_root]
+    for cache_root in cache_roots:
+        if flavor is None:
+            db_root = audeer.path(
+                cache_root,
+                name,
+                version,
+            )
+        else:
+            db_root = audeer.path(
+                cache_root,
+                flavor.path(name, version),
+            )
+        if os.path.exists(db_root):
+            break
+
+    audeer.mkdir(db_root)
+    return db_root
+
+
+def database_lock_path(
+        root: str,
+) -> str:
+    r"""Create and return path to lock file.
+
+    If it does not exist yet,
+    creates a file ``.lock`` under ``root``.
+
+    Args:
+        root: path to folder
+
+    Returns:
+        path to lock file
+
+    """
+    lock_path = audeer.path(root, define.LOCK_FILE)
+    if not os.path.exists(lock_path):
+        audeer.touch(lock_path)
+    return lock_path
+
+
+def database_tmp_folder(
+        db_root: str,
+) -> str:
+    r"""Create and return temporary database cache folder.
+
+    The temporary cache folder is created under ``db_root + '~'``.
+
+    Args:
+        db_root: path to database cache folder
+
+    Returns:
+        path to temporary cache folder
+
+    """
+    tmp_root = db_root + '~'
+    tmp_root = audeer.mkdir(tmp_root)
+    return tmp_root
+
+
+def default_cache_root(
+        shared=False,
+) -> str:
+    r"""Default cache folder.
+
+    If ``shared`` is ``True``,
+    returns the path specified
+    by the environment variable
+    ``AUDB_SHARED_CACHE_ROOT``
+    or
+    ``audb.config.SHARED_CACHE_ROOT``.
+    If ``shared`` is ``False``,
+    returns the path specified
+    by the environment variable
+    ``AUDB_CACHE_ROOT``
+    or
+    ``audb.config.CACHE_ROOT``.
+
+    Args:
+        shared: if ``True`` returns path to shared cache folder
+
+    Returns:
+        path normalized by :func:`audeer.path`
+
+    """
+    if shared:
+        cache = (
+            os.environ.get('AUDB_SHARED_CACHE_ROOT')
+            or config.SHARED_CACHE_ROOT
+        )
+    else:
+        cache = (
+            os.environ.get('AUDB_CACHE_ROOT')
+            or config.CACHE_ROOT
+        )
+    return audeer.path(cache)

--- a/audb/core/cache.py
+++ b/audb/core/cache.py
@@ -7,7 +7,7 @@ from audb.core.config import config
 from audb.core.flavor import Flavor
 
 
-def database_cache_folder(
+def database_cache_root(
         name: str,
         version: str,
         cache_root: str = None,
@@ -72,7 +72,7 @@ def database_lock_path(
     return lock_path
 
 
-def database_tmp_folder(
+def database_tmp_root(
         db_root: str,
 ) -> str:
     r"""Create and return temporary database cache folder.

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -8,7 +8,7 @@ import audformat
 from audb.core import define
 from audb.core.api import (
     dependencies,
-    database_cache_folder,
+    database_cache_root,
     database_lock_path,
     latest_version,
 )
@@ -205,7 +205,7 @@ def header(
     if version is None:
         version = latest_version(name)
 
-    db_root = database_cache_folder(name, version, cache_root)
+    db_root = database_cache_root(name, version, cache_root)
     db_lock_path = database_lock_path(db_root)
 
     with filelock.FileLock(db_lock_path):

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -1,5 +1,6 @@
 import typing
 
+import filelock
 import pandas as pd
 
 import audformat
@@ -7,12 +8,11 @@ import audformat
 from audb.core import define
 from audb.core.api import (
     dependencies,
+    database_cache_folder,
+    database_lock_path,
     latest_version,
 )
-from audb.core.load import (
-    database_cache_folder,
-    load_header,
-)
+from audb.core.load import load_header
 
 
 def author(
@@ -204,8 +204,13 @@ def header(
     """
     if version is None:
         version = latest_version(name)
+
     db_root = database_cache_folder(name, version, cache_root)
-    db, _ = load_header(db_root, name, version)
+    db_lock_path = database_lock_path(db_root)
+
+    with filelock.FileLock(db_lock_path):
+        db, _ = load_header(db_root, name, version)
+
     return db
 
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -18,9 +18,9 @@ from audb.core.api import (
     latest_version,
 )
 from audb.core.cache import (
-    database_cache_folder,
+    database_cache_root,
     database_lock_path,
-    database_tmp_folder,
+    database_tmp_root,
     default_cache_root,
 )
 from audb.core.dependencies import Dependencies
@@ -153,7 +153,7 @@ def _database_check_complete(
         return complete
 
     if check():
-        db_root_tmp = database_tmp_folder(db_root)
+        db_root_tmp = database_tmp_root(db_root)
         db.meta['audb']['complete'] = True
         db_original = audformat.Database.load(db_root, load_data=False)
         db_original.meta['audb']['complete'] = True
@@ -231,7 +231,7 @@ def _get_media_from_backend(
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
     # using multi-processing
-    db_root_tmp = database_tmp_folder(db_root)
+    db_root_tmp = database_tmp_root(db_root)
     utils.mkdir_tree(media, db_root)
     utils.mkdir_tree(media, db_root_tmp)
 
@@ -298,7 +298,7 @@ def _get_media_from_cache(
         flavor,
         verbose,
     )
-    db_root_tmp = database_tmp_folder(db_root)
+    db_root_tmp = database_tmp_root(db_root)
 
     def job(cache_root: str, file: str):
         _copy_file(file, cache_root, db_root_tmp, db_root)
@@ -326,7 +326,7 @@ def _get_tables_from_backend(
         verbose: bool,
 ):
     r"""Load tables from backend."""
-    db_root_tmp = database_tmp_folder(db_root)
+    db_root_tmp = database_tmp_root(db_root)
 
     def job(table: str):
         archive = backend.join(
@@ -386,7 +386,7 @@ def _get_tables_from_cache(
         None,
         verbose,
     )
-    db_root_tmp = database_tmp_folder(db_root)
+    db_root_tmp = database_tmp_root(db_root)
 
     def job(cache_root: str, file: str):
         file_pkl = audeer.replace_file_extension(
@@ -772,7 +772,7 @@ def load(
         bit_depth=bit_depth,
         sampling_rate=sampling_rate,
     )
-    db_root = database_cache_folder(name, version, cache_root, flavor)
+    db_root = database_cache_root(name, version, cache_root, flavor)
     db_lock_path = database_lock_path(db_root)
     db = None
 
@@ -917,7 +917,7 @@ def load_header(
         backend = lookup_backend(name, version)
         remote_header = backend.join(name, define.HEADER_FILE)
         if add_audb_meta:
-            db_root_tmp = database_tmp_folder(db_root)
+            db_root_tmp = database_tmp_root(db_root)
             local_header = os.path.join(db_root_tmp, define.HEADER_FILE)
         backend.get_file(remote_header, local_header, version)
         if add_audb_meta:
@@ -1033,7 +1033,7 @@ def load_media(
         bit_depth=bit_depth,
         sampling_rate=sampling_rate,
     )
-    db_root = database_cache_folder(name, version, cache_root, flavor)
+    db_root = database_cache_root(name, version, cache_root, flavor)
     db_lock_path = database_lock_path(db_root)
     files = None
 
@@ -1147,7 +1147,7 @@ def load_table(
 
     cached_versions = None
 
-    db_root = database_cache_folder(name, version, cache_root)
+    db_root = database_cache_root(name, version, cache_root)
     db_lock_path = database_lock_path(db_root)
 
     with filelock.FileLock(db_lock_path):

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -14,12 +14,14 @@ from audb.core import define
 from audb.core import utils
 from audb.core.api import (
     cached,
+    dependencies,
+    latest_version,
+)
+from audb.core.cache import (
     database_cache_folder,
     database_lock_path,
     database_tmp_folder,
     default_cache_root,
-    dependencies,
-    latest_version,
 )
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -14,6 +14,9 @@ from audb.core import define
 from audb.core import utils
 from audb.core.api import (
     cached,
+    database_cache_folder,
+    database_lock_path,
+    database_tmp_folder,
     default_cache_root,
     dependencies,
     latest_version,
@@ -662,89 +665,6 @@ def _update_path(
         progress_bar=verbose,
         task_description='Update file path',
     )
-
-
-def database_cache_folder(
-        name: str,
-        version: str,
-        cache_root: str = None,
-        flavor: Flavor = None,
-) -> str:
-    r"""Create and return database cache folder.
-
-    Args:
-        name: name of database
-        version: version of database
-        cache_root: path to cache folder
-        flavor: flavor of database
-
-    Returns:
-        path to cache folder
-
-    """
-    if cache_root is None:
-        cache_roots = [
-            default_cache_root(True),  # check shared cache first
-            default_cache_root(False),
-        ]
-    else:
-        cache_roots = [cache_root]
-    for cache_root in cache_roots:
-        if flavor is None:
-            db_root = audeer.path(
-                cache_root,
-                name,
-                version,
-            )
-        else:
-            db_root = audeer.path(
-                cache_root,
-                flavor.path(name, version),
-            )
-        if os.path.exists(db_root):
-            break
-
-    audeer.mkdir(db_root)
-    return db_root
-
-
-def database_tmp_folder(
-        db_root: str,
-) -> str:
-    r"""Create and return temporary database cache folder.
-
-    The temporary cache folder is created under ``db_root + '~'``.
-
-    Args:
-        db_root: path to database cache folder
-
-    Returns:
-        path to temporary cache folder
-
-    """
-    tmp_root = db_root + '~'
-    tmp_root = audeer.mkdir(tmp_root)
-    return tmp_root
-
-
-def database_lock_path(
-        db_root: str,
-) -> str:
-    r"""Create and return path to database lock file.
-
-    The lock file ``.lock`` is created under ``db_root``.
-
-    Args:
-        db_root: path to database cache folder
-
-    Returns:
-        path to lock file
-
-    """
-    lock_path = audeer.path(db_root, define.LOCK_FILE)
-    if not os.path.exists(lock_path):
-        audeer.touch(lock_path)
-    return lock_path
 
 
 def load(

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -14,7 +14,7 @@ from audb.core.api import (
 )
 from audb.core.dependencies import Dependencies
 from audb.core.load import (
-    database_tmp_folder,
+    database_tmp_root,
     load_header,
 )
 
@@ -253,7 +253,7 @@ def load_to(
         version = latest_version(name)
 
     db_root = audeer.path(root)
-    db_root_tmp = database_tmp_folder(db_root)
+    db_root_tmp = database_tmp_root(db_root)
 
     # remove files with a wrong checksum
     # to ensure we load correct version

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -188,7 +188,7 @@ def fixture_publish_db():
 def test_database_cache_folder():
     cache_root = os.path.join(pytest.CACHE_ROOT, 'cache')
     version = '1.0.0'
-    db_root = audb.core.load.database_cache_folder(
+    db_root = audb.core.load.database_cache_root(
         DB_NAME,
         version,
         cache_root,
@@ -359,7 +359,7 @@ def test_load_media(version, media, format):
     # Clear cache to force loading from other cache
     if version is None:
         version = audb.latest_version(DB_NAME)
-    cache_root = audb.core.load.database_cache_folder(
+    cache_root = audb.core.load.database_cache_root(
         DB_NAME,
         version,
         pytest.CACHE_ROOT,

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -159,8 +159,11 @@ def test_lock_dependencies(multiprocessing, num_workers):
     )
 
     assert len(result) == num_workers
-    assert os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
+
+    # Windows removes the lock files
+    if not sys.platform == 'win32':
+        assert os.path.exists(DB_LOCK_PATH)
+        assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_header():
@@ -202,8 +205,11 @@ def test_lock_header(multiprocessing, num_workers):
     )
 
     assert len(result) == num_workers
-    assert os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
+
+    # Windows removes the lock files
+    if not sys.platform == 'win32':
+        assert os.path.exists(DB_LOCK_PATH)
+        assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_db(timeout):
@@ -255,8 +261,11 @@ def test_lock_load(multiprocessing, num_workers, timeout, expected):
     result = [x for x in result if x is not None]
 
     assert len(result) == expected
-    assert os.path.exists(DB_LOCK_PATH)
-    assert os.path.exists(DB_FLAVOR_LOCK_PATH)
+
+    # Windows removes the lock files
+    if not sys.platform == 'win32':
+        assert os.path.exists(DB_LOCK_PATH)
+        assert os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_media(timeout):
@@ -309,8 +318,11 @@ def test_lock_load_media(multiprocessing, num_workers, timeout, expected):
     result = [x for x in result if x is not None]
 
     assert len(result) == expected
-    assert os.path.exists(DB_LOCK_PATH)
-    assert os.path.exists(DB_FLAVOR_LOCK_PATH)
+
+    # Windows removes the lock files
+    if not sys.platform == 'win32':
+        assert os.path.exists(DB_LOCK_PATH)
+        assert os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_table():
@@ -354,5 +366,8 @@ def test_lock_load_table(multiprocessing, num_workers):
     )
 
     assert len(result) == num_workers
-    assert os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
+
+    # Windows removes the lock files
+    if not sys.platform == 'win32':
+        assert os.path.exists(DB_LOCK_PATH)
+        assert not os.path.exists(DB_FLAVOR_LOCK_PATH)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -149,6 +149,7 @@ def test_lock_dependencies(multiprocessing, num_workers):
         return
 
     assert not os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
     result = audeer.run_tasks(
         load_deps,
@@ -159,6 +160,7 @@ def test_lock_dependencies(multiprocessing, num_workers):
 
     assert len(result) == num_workers
     assert os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_header():
@@ -190,6 +192,7 @@ def test_lock_header(multiprocessing, num_workers):
         return
 
     assert not os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
     result = audeer.run_tasks(
         load_header,
@@ -200,6 +203,7 @@ def test_lock_header(multiprocessing, num_workers):
 
     assert len(result) == num_workers
     assert os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_db(timeout):
@@ -340,6 +344,7 @@ def test_lock_load_table(multiprocessing, num_workers):
         return
 
     assert not os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
     result = audeer.run_tasks(
         load_table,
@@ -350,3 +355,4 @@ def test_lock_load_table(multiprocessing, num_workers):
 
     assert len(result) == num_workers
     assert os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)


### PR DESCRIPTION
This is a follow up of #188 and adds another lock when accessing dependencies and header in the root folder (e.g. `emodb/1.2.0`) of a cached database (not the flavor folder on which `db.load()` and `db.load_media()` operate, e.g. `emodb/1.2.0/fe182b91`).

I did not add a `timeout` argument since loading dependencies / header should usually not take that long. During the implementation I then realized that `db.load_table()` also uses the root folder and not the flavor folder, so I removed the `timeout` argument from it.

I extended the tests to check that the `.lock` files are created in the expected locations.

Moves `database_cache_root()` (former `database_cache_folder()`), `database_lock_path()`, `database_tmp_root()` (former `database_tmp_folder()`) and `default_cache_root()` to `cache.py` as `dependencies()` needs `database_lock_path()` and also relies on `database_cache_root()` now to figure out the correct cache location (avoids duplicated code).