### PR TITLE
Forward verbose argument in remove_media()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -442,7 +442,7 @@ def remove_media(
         name: str,
         files: typing.Union[str, typing.Sequence[str]],
         *,
-        verbose: bool = False,
+        verbose: bool = True,
 ):
     r"""Remove media from all versions.
 
@@ -472,6 +472,7 @@ def remove_media(
                 archive,
                 db_root,
                 version,
+                verbose=verbose,
             )[0]
             deps_path = os.path.join(db_root, deps_path)
             deps = Dependencies()
@@ -498,6 +499,7 @@ def remove_media(
                             remote_archive,
                             db_root,
                             version,
+                            verbose=verbose,
                         )
                         # skip if file was already deleted
                         if file in files_in_archive:
@@ -508,6 +510,7 @@ def remove_media(
                                 files_in_archive,
                                 remote_archive,
                                 version,
+                                verbose=verbose,
                             )
 
                     # mark file as removed
@@ -523,6 +526,7 @@ def remove_media(
                     define.DEPENDENCIES_FILE,
                     remote_archive,
                     version,
+                    verbose=verbose,
                 )
 
 

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -479,7 +479,11 @@ def remove_media(
             deps.load(deps_path)
             upload = False
 
-            for file in files:
+            for file in audeer.progress_bar(
+                files,
+                disable=not verbose,
+                desc='Remove media',
+            ):
                 if file in deps.media:
                     archive = deps.archive(file)
 
@@ -499,7 +503,6 @@ def remove_media(
                             remote_archive,
                             db_root,
                             version,
-                            verbose=verbose,
                         )
                         # skip if file was already deleted
                         if file in files_in_archive:
@@ -510,7 +513,6 @@ def remove_media(
                                 files_in_archive,
                                 remote_archive,
                                 version,
-                                verbose=verbose,
                             )
 
                     # mark file as removed

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -482,7 +482,7 @@ def remove_media(
             for file in audeer.progress_bar(
                 files,
                 disable=not verbose,
-                desc='Remove media',
+                desc=f'Remove media from v{version}',
             ):
                 if file in deps.media:
                     archive = deps.archive(file)

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -442,7 +442,7 @@ def remove_media(
         name: str,
         files: typing.Union[str, typing.Sequence[str]],
         *,
-        verbose: bool = True,
+        verbose: bool = False,
 ):
     r"""Remove media from all versions.
 


### PR DESCRIPTION
We had a `verbose` argument in `remove_media()`, but it actually wasn't used. ~~This also changes the default value from `False` to `True`, which is also the default in all other functions.~~