### PR TITLE
Replace pd.append() with pd.concat() to avoid warning

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -391,7 +391,7 @@ class Dependencies:
             columns=['file'] + list(define.DEPEND_FIELD_NAMES.values()),
         ).set_index('file')
 
-        self._df = self._df.append(df)
+        self._df = pd.concat([self._df, df])
 
     def _add_meta(
             self,


### PR DESCRIPTION
Avoid warning, which currently let our tests fail, e.g.: https://github.com/audeering/audb/runs/6257889301?check_suite_focus=true#step:15:50