### PR TITLE
Replace FileLock with SoftFileLock

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -264,7 +264,7 @@ def dependencies(
 
     deps = Dependencies()
 
-    with filelock.FileLock(db_lock_path):
+    with filelock.SoftFileLock(db_lock_path):
         try:
             deps.load(deps_path)
         except (AttributeError, FileNotFoundError, ValueError, EOFError):

--- a/audb/core/cache.py
+++ b/audb/core/cache.py
@@ -66,10 +66,7 @@ def database_lock_path(
         path to lock file
 
     """
-    lock_path = audeer.path(root, define.LOCK_FILE)
-    if not os.path.exists(lock_path):
-        audeer.touch(lock_path)
-    return lock_path
+    return audeer.path(root, define.LOCK_FILE)
 
 
 def database_tmp_root(

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -208,7 +208,7 @@ def header(
     db_root = database_cache_root(name, version, cache_root)
     db_lock_path = database_lock_path(db_root)
 
-    with filelock.FileLock(db_lock_path):
+    with filelock.SoftFileLock(db_lock_path):
         db, _ = load_header(db_root, name, version)
 
     return db

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -781,7 +781,7 @@ def load(
     )
 
     try:
-        with filelock.FileLock(db_lock_path, timeout=timeout):
+        with filelock.SoftFileLock(db_lock_path, timeout=timeout):
 
             # Start with database header without tables
             db, backend = load_header(
@@ -1046,7 +1046,7 @@ def load_media(
             )
 
     try:
-        with filelock.FileLock(db_lock_path, timeout=timeout):
+        with filelock.SoftFileLock(db_lock_path, timeout=timeout):
 
             # Start with database header without tables
             db, backend = load_header(
@@ -1162,7 +1162,7 @@ def load_table(
             f"Could not find table '{table}' in {name} {version}"
         )
 
-    with filelock.FileLock(db_lock_path):
+    with filelock.SoftFileLock(db_lock_path):
 
         # Start with database header without tables
         db, backend = load_header(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -40,7 +40,7 @@ def clear_root(root: str):
     scope='function',
     autouse=True,
 )
-def ensure_tmp_folder_deleted():
+def fixture_ensure_tmp_folder_deleted():
     """Fixture to test that the ~ tmp folder gets deleted.
 
     audb.load() first loads files to a folder

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -304,16 +304,6 @@ def test_lock_load(fixture_set_repositories, multiprocessing, num_workers,
 )
 def test_lock_load_crash(fixture_set_repositories):
 
-    repositories_tmp = audb.config.REPOSITORIES
-
-    audb.config.REPOSITORIES = [
-        audb.Repository(
-            name=pytest.REPOSITORY_NAME,
-            host=pytest.FILE_SYSTEM_HOST,
-            backend='crash-file-system',
-        ),
-    ]
-
     assert not os.path.exists(DB_LOCK_PATH)
     assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
@@ -322,8 +312,6 @@ def test_lock_load_crash(fixture_set_repositories):
 
     assert not os.path.exists(DB_LOCK_PATH)
     assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
-    audb.config.REPOSITORIES = repositories_tmp
 
 
 def load_media(timeout):

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -58,6 +58,18 @@ os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
     scope='function',
     autouse=True,
 )
+def fixture_ensure_lock_file_deleted():
+    assert not os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
+    yield
+    assert not os.path.exists(DB_LOCK_PATH)
+    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
+
+
+@pytest.fixture(
+    scope='function',
+    autouse=True,
+)
 def fixture_set_repositories(request):
     audb.config.REPOSITORIES = [
         audb.Repository(
@@ -172,9 +184,6 @@ def test_lock_dependencies(fixture_set_repositories, multiprocessing,
     if multiprocessing and sys.platform in ['win32', 'darwin']:
         return
 
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
     result = audeer.run_tasks(
         load_deps,
         [([], {})] * num_workers,
@@ -183,9 +192,6 @@ def test_lock_dependencies(fixture_set_repositories, multiprocessing,
     )
 
     assert len(result) == num_workers
-
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_header():
@@ -221,9 +227,6 @@ def test_lock_header(fixture_set_repositories, multiprocessing, num_workers):
     if multiprocessing and sys.platform in ['win32', 'darwin']:
         return
 
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
     result = audeer.run_tasks(
         load_header,
         [([], {})] * num_workers,
@@ -232,9 +235,6 @@ def test_lock_header(fixture_set_repositories, multiprocessing, num_workers):
     )
 
     assert len(result) == num_workers
-
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_db(timeout):
@@ -275,9 +275,6 @@ def test_lock_load(fixture_set_repositories, multiprocessing, num_workers,
     if multiprocessing and sys.platform in ['win32', 'darwin']:
         return
 
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
     warns = not multiprocessing and num_workers != expected
     with pytest.warns(
             UserWarning if warns else None,
@@ -293,9 +290,6 @@ def test_lock_load(fixture_set_repositories, multiprocessing, num_workers,
 
     assert len(result) == expected
 
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
 
 @pytest.mark.parametrize(
     'fixture_set_repositories',
@@ -304,14 +298,8 @@ def test_lock_load(fixture_set_repositories, multiprocessing, num_workers,
 )
 def test_lock_load_crash(fixture_set_repositories):
 
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
     with pytest.raises(RuntimeError):
         load_db(-1)
-
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_media(timeout):
@@ -353,9 +341,6 @@ def test_lock_load_media(fixture_set_repositories, multiprocessing,
     if multiprocessing and sys.platform in ['win32', 'darwin']:
         return
 
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
     warns = not multiprocessing and num_workers != expected
     with pytest.warns(
             UserWarning if warns else None,
@@ -370,9 +355,6 @@ def test_lock_load_media(fixture_set_repositories, multiprocessing,
     result = [x for x in result if x is not None]
 
     assert len(result) == expected
-
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
 
 
 def load_table():
@@ -411,9 +393,6 @@ def test_lock_load_table(fixture_set_repositories, multiprocessing,
     if multiprocessing and sys.platform in ['win32', 'darwin']:
         return
 
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)
-
     result = audeer.run_tasks(
         load_table,
         [([], {})] * num_workers,
@@ -422,6 +401,3 @@ def test_lock_load_table(fixture_set_repositories, multiprocessing,
     )
 
     assert len(result) == num_workers
-
-    assert not os.path.exists(DB_LOCK_PATH)
-    assert not os.path.exists(DB_FLAVOR_LOCK_PATH)


### PR DESCRIPTION
Closes #201 

As discussed #201 the current solution based on `FileLock` will not work when sharing the cache folder across different platforms. This implements a solution using `SoftFileLock` to overcome this limitation. It also adds a test that let's the current process crash and ensures that the lock is removed in that case. What we cannot guarantee, though, is that it this will work in all situations, e.g. out-of-memory. Though, we also don't know if `FileLock` will properly work in this situation (e.g. if lock file will be properly released in that case), `SoftFileLock` still has the disadvantage that it will permanently lock the folder until the lock file is manually removed.