### PR TITLE
Raise ValueError if tables/media cannot be found

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -545,14 +545,15 @@ def _media(
         for m in db.files:
             if pattern.search(m):
                 requested_media.append(m)
+        if len(requested_media) == 0:
+            raise ValueError(f"Could not find a media file matching '{media}'")
     else:
         requested_media = media
-
-    if (
-            len(requested_media) == 0
-            or any([file not in db.files for file in requested_media])
-    ):
-        raise ValueError(f"Could not find media matching '{media}'")
+        for media in requested_media:
+            if media not in db.files:
+                raise ValueError(
+                    f"Could not find the media file '{media}'"
+                )
 
     return requested_media
 
@@ -626,14 +627,15 @@ def _tables(
         for table in deps.table_ids:
             if pattern.search(table):
                 requested_tables.append(table)
+        if len(requested_tables) == 0:
+            raise ValueError(f"Could not find a table matching '{tables}' ")
     else:
         requested_tables = tables
-
-    if (
-            len(requested_tables) == 0
-            or any([table not in deps.table_ids for table in requested_tables])
-    ):
-        raise ValueError(f"Could not find table(s) matching '{tables}' ")
+        for table in requested_tables:
+            if table not in deps.table_ids:
+                raise ValueError(
+                    f"Could not find the table '{table}'"
+                )
 
     return requested_tables
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -536,7 +536,7 @@ def _media(
 
     if media is None:
         return db.files
-    elif not media:
+    elif len(media) == 0:
         return []
 
     if isinstance(media, str):
@@ -549,7 +549,7 @@ def _media(
         requested_media = media
 
     if (
-            not requested_media
+            len(requested_media) == 0
             or any([file not in db.files for file in requested_media])
     ):
         raise ValueError(f"Could not find media matching '{media}'")
@@ -617,7 +617,7 @@ def _tables(
 
     if tables is None:
         return deps.table_ids
-    elif not tables:
+    elif len(tables) == 0:
         return []
 
     if isinstance(tables, str):
@@ -630,7 +630,7 @@ def _tables(
         requested_tables = tables
 
     if (
-            not requested_tables
+            len(requested_tables) == 0
             or any([table not in deps.table_ids for table in requested_tables])
     ):
         raise ValueError(f"Could not find table(s) matching '{tables}' ")

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -536,6 +536,8 @@ def _media(
 
     if media is None:
         return db.files
+    elif not media:
+        return []
 
     if isinstance(media, str):
         pattern = re.compile(media)
@@ -546,10 +548,13 @@ def _media(
     else:
         requested_media = media
 
-    if any([file not in db.files for file in requested_media]):
+    if (
+            not requested_media
+            or any([file not in db.files for file in requested_media])
+    ):
         raise ValueError(f"Could not find media matching '{media}'")
 
-    return media
+    return requested_media
 
 
 def _missing_media(
@@ -612,6 +617,8 @@ def _tables(
 
     if tables is None:
         return deps.table_ids
+    elif not tables:
+        return []
 
     if isinstance(tables, str):
         pattern = re.compile(tables)
@@ -622,7 +629,10 @@ def _tables(
     else:
         requested_tables = tables
 
-    if any([table not in deps.table_ids for table in requested_tables]):
+    if (
+            not requested_tables
+            or any([table not in deps.table_ids for table in requested_tables])
+    ):
         raise ValueError(f"Could not find table(s) matching '{tables}' ")
 
     return requested_tables

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -570,11 +570,11 @@ def _media(
             raise ValueError(msg)
     else:
         requested_media = media
-        for media in requested_media:
-            if media not in db.files:
+        for media_file in requested_media:
+            if media_file not in db.files:
                 msg = _error_message_missing_object(
                     'media file',
-                    [media],
+                    [media_file],
                     db.name,
                     version,
                 )

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -766,8 +766,8 @@ def load(
         database object
 
     Raises:
-        ValueError: if no table in the database matches the requested ones
-        ValueError: if no media in the database matches the requested ones
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> db = audb.load(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -535,13 +535,19 @@ def _media(
 ) -> typing.Sequence[str]:
 
     if media is None:
-        media = db.files
-    elif isinstance(media, str):
+        return db.files
+
+    if isinstance(media, str):
         pattern = re.compile(media)
-        media = []
+        requested_media = []
         for m in db.files:
             if pattern.search(m):
-                media.append(m)
+                requested_media.append(m)
+    else:
+        requested_media = media
+
+    if any([file not in db.files for file in requested_media]):
+        raise ValueError(f"Could not find media matching '{media}'")
 
     return media
 
@@ -603,15 +609,23 @@ def _tables(
         deps: Dependencies,
         tables: typing.Optional[typing.Union[str, typing.Sequence[str]]],
 ) -> typing.Sequence[str]:
+
     if tables is None:
-        tables = deps.table_ids
-    elif isinstance(tables, str):
+        return deps.table_ids
+
+    if isinstance(tables, str):
         pattern = re.compile(tables)
-        tables = []
+        requested_tables = []
         for table in deps.table_ids:
             if pattern.search(table):
-                tables.append(table)
-    return tables
+                requested_tables.append(table)
+    else:
+        requested_tables = tables
+
+    if any([table not in deps.table_ids for table in requested_tables]):
+        raise ValueError(f"Could not find table(s) matching '{tables}' ")
+
+    return requested_tables
 
 
 def _update_path(
@@ -740,6 +754,10 @@ def load(
 
     Returns:
         database object
+
+    Raises:
+        ValueError: if no table in the database matches the requested ones
+        ValueError: if no media in the database matches the requested ones
 
     Example:
         >>> db = audb.load(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -148,6 +148,18 @@ def fixture_clear_cache():
             None,
             ['audio/000.wav', 'audio/010.wav', 'audio/1/020.wav'],
         ),
+        pytest.param(
+            'non-existing',
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            ['non-existing'],
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
     ]
 )
 def test_media(media, format, expected_files):
@@ -202,10 +214,24 @@ def test_media(media, format, expected_files):
              'audio/1/020.flac', 'audio/2/021.flac'],
         ),
         (
-            'bad',
+            [],
             None,
             [],
             [],
+        ),
+        pytest.param(
+            'non-existing',
+            None,
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            ['non-existing'],
+            None,
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
         ),
     ]
 )

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -134,6 +134,11 @@ def fixture_clear_cache():
             [],
         ),
         (
+            '',
+            None,
+            [],
+        ),
+        (
             ['audio/000.wav', 'audio/001.wav'],
             None,
             ['audio/000.wav', 'audio/001.wav'],
@@ -215,6 +220,12 @@ def test_media(media, format, expected_files):
         ),
         (
             [],
+            None,
+            [],
+            [],
+        ),
+        (
+            '',
             None,
             [],
             [],


### PR DESCRIPTION
Closes #5

This raises a `ValueError` if you request a table or media that is not part of the database, e.g.

```python
>>> db = audb.load("emodb", tables="noise")
...
ValueError: Could not find a table matching 'noise' in emodb v1.2.0
>>> db = audb.load("emodb", tables=["noise"])
...
ValueError: Could not find the table 'noise' in emodb v1.2.0
>>> db = audb.load("emodb", media="f1")
...
ValueError: Could not find a media file matching 'f1' in emodb v1.2.0
>>> db = audb.load("emodb", media=["f1"])
...
ValueError: Could not find the media file 'f1' in emodb v1.2.0
```

To not break completely the API we still return a database when requesting `[]` as `media` or `tables`.

I realized that we did not even have a "raises" section in the docs yet. I'm sure we raise more errors, but in this pull request I just added the two cases related to it.

![image](https://user-images.githubusercontent.com/173624/167076086-91ddd040-9159-4389-8f6e-f460c0d6d9a9.png)
