### PR TITLE
Lock folders when copying files from cached versions

### DIFF
--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -91,17 +91,6 @@ class config:
     CACHE_ROOT = global_config['cache_root']
     r"""Default user cache folder."""
 
-    CACHED_VERSIONS_TIMEOUT = 10
-    r"""Timeout to acquire access to cached versions.
-
-    Maximum wait time to acquire access to cached versions
-    if they are currently blocked by another thread or process.
-    If timeout is reached,
-    all missing files will be downloaded from backend instead.
-    If timeout < 0 will wait until the cache folders can be accessed.
-
-    """
-
     REPOSITORIES = [
         Repository(r['name'], r['host'], r['backend'])
         for r in global_config['repositories']

--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -91,6 +91,17 @@ class config:
     CACHE_ROOT = global_config['cache_root']
     r"""Default user cache folder."""
 
+    CACHED_VERSIONS_TIMEOUT = 10
+    r"""Timeout to acquire access to cached versions.
+
+    Maximum wait time to acquire access to cached versions
+    if they are currently blocked by another thread or process.
+    If timeout is reached,
+    all missing files will be downloaded from backend instead.
+    If timeout < 0 will wait until the cache folders can be accessed.
+
+    """
+
     REPOSITORIES = [
         Repository(r['name'], r['host'], r['backend'])
         for r in global_config['repositories']

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -8,12 +8,15 @@ USER_CONFIG_FILE = '~/.audb.yaml'
 # Database
 DB = 'db'
 HEADER_FILE = f'{DB}.yaml'
-LOCK_FILE = '.lock'
-TIMEOUT_MSG = 'Lock could not be acquired. Timeout exceeded.'
 
 # Dependencies
 DEPENDENCIES_FILE = f'{DB}.csv'
 CACHED_DEPENDENCIES_FILE = f'{DB}.pkl'
+
+# Cache lock
+CACHED_VERSIONS_TIMEOUT = 10  # Timeout to acquire access to cached versions
+LOCK_FILE = '.lock'
+TIMEOUT_MSG = 'Lock could not be acquired. Timeout exceeded.'
 
 
 class DependField:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -22,7 +22,6 @@ from audb.core.cache import (
     database_tmp_root,
     default_cache_root,
 )
-from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor
 from audb.core.lock import FolderLock
@@ -298,7 +297,7 @@ def _get_media_from_cache(
     try:
         with FolderLock(
                 db_root_cached,
-                timeout=config.CACHED_VERSIONS_TIMEOUT,
+                timeout=define.CACHED_VERSIONS_TIMEOUT,
         ):
 
             cached_media, missing_media = _cached_files(
@@ -395,7 +394,7 @@ def _get_tables_from_cache(
     try:
         with FolderLock(
                 db_root_cached,
-                timeout=config.CACHED_VERSIONS_TIMEOUT,
+                timeout=define.CACHED_VERSIONS_TIMEOUT,
         ):
 
             cached_tables, missing_tables = _cached_files(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -325,7 +325,7 @@ def _get_media_from_cache(
             audeer.rmdir(db_root_tmp)
 
     except filelock.Timeout:
-        pass
+        missing_media = media
 
     return missing_media
 
@@ -427,7 +427,7 @@ def _get_tables_from_cache(
             audeer.rmdir(db_root_tmp)
 
     except filelock.Timeout:
-        pass
+        missing_tables = tables
 
     return missing_tables
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -10,6 +10,7 @@ import audbackend
 import audeer
 import audformat
 
+
 from audb.core import define
 from audb.core import utils
 from audb.core.api import (
@@ -22,6 +23,7 @@ from audb.core.cache import (
     database_tmp_root,
     default_cache_root,
 )
+from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor
 from audb.core.lock import FolderLock
@@ -286,7 +288,6 @@ def _get_media_from_cache(
         db_root: str,
         deps: Dependencies,
         cached_versions: CachedVersions,
-        timeout: float,
         flavor: Flavor,
         num_workers: int,
         verbose: bool,
@@ -296,7 +297,10 @@ def _get_media_from_cache(
     db_root_cached = [x[1] for x in cached_versions]
 
     try:
-        with FolderLock(db_root_cached, timeout=timeout):
+        with FolderLock(
+                db_root_cached,
+                timeout=config.CACHED_VERSIONS_TIMEOUT,
+        ):
 
             cached_media, missing_media = _cached_files(
                 media,
@@ -382,7 +386,6 @@ def _get_tables_from_cache(
         db_root: str,
         deps: Dependencies,
         cached_versions: CachedVersions,
-        timeout: float,
         num_workers: int,
         verbose: bool,
 ) -> typing.Sequence[str]:
@@ -391,7 +394,10 @@ def _get_tables_from_cache(
     db_root_cached = [x[1] for x in cached_versions]
 
     try:
-        with FolderLock(db_root_cached, timeout=timeout):
+        with FolderLock(
+                db_root_cached,
+                timeout=config.CACHED_VERSIONS_TIMEOUT,
+        ):
 
             cached_tables, missing_tables = _cached_files(
                 tables,
@@ -433,7 +439,6 @@ def _load_media(
         name: str,
         version: str,
         cached_versions: typing.Optional[CachedVersions],
-        timeout: float,
         deps: Dependencies,
         flavor: Flavor,
         cache_root: str,
@@ -468,7 +473,6 @@ def _load_media(
                 db_root,
                 deps,
                 cached_versions,
-                timeout,
                 flavor,
                 num_workers,
                 verbose,
@@ -497,7 +501,6 @@ def _load_tables(
         db: audformat.Database,
         version: str,
         cached_versions: typing.Optional[CachedVersions],
-        timeout: float,
         deps: Dependencies,
         flavor: Flavor,
         cache_root: str,
@@ -531,7 +534,6 @@ def _load_tables(
                 db_root,
                 deps,
                 cached_versions,
-                timeout,
                 num_workers,
                 verbose,
             )
@@ -827,7 +829,6 @@ def load(
                     db,
                     version,
                     cached_versions,
-                    timeout,
                     deps,
                     flavor,
                     cache_root,
@@ -855,7 +856,6 @@ def load(
                     name,
                     version,
                     cached_versions,
-                    timeout,
                     deps,
                     flavor,
                     cache_root,
@@ -1090,7 +1090,6 @@ def load_media(
                     name,
                     version,
                     None,
-                    -1,
                     deps,
                     flavor,
                     cache_root,
@@ -1206,7 +1205,6 @@ def load_table(
                 db,
                 version,
                 None,
-                -1,
                 deps,
                 Flavor(),
                 cache_root,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -10,7 +10,6 @@ import audbackend
 import audeer
 import audformat
 
-
 from audb.core import define
 from audb.core import utils
 from audb.core.api import (

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -330,7 +330,8 @@ def test_lock_load_crash(fixture_set_repositories):
 def test_lock_load_from_cached_versions(fixture_set_repositories):
 
     # ensure immediate timeout if cache folder is locked
-    audb.config.CACHED_VERSIONS_TIMEOUT = 0
+    cached_version_timeout = audb.core.define.CACHED_VERSIONS_TIMEOUT
+    audb.core.define.CACHED_VERSIONS_TIMEOUT = 0
 
     # load version 1.0.0
     db_v1 = audb.load(
@@ -412,6 +413,9 @@ def test_lock_load_from_cached_versions(fixture_set_repositories):
         version=DB_VERSIONS[1],
         verbose=False,
     )
+
+    # reset timeout
+    audb.core.define.CACHED_VERSIONS_TIMEOUT = cached_version_timeout
 
 
 def load_media(timeout):


### PR DESCRIPTION
Closes #108 

Finally adds the logic to lock cache folders when trying to copy tables / media from cached versions.

The timeout to access cached versions is defined at `define.CACHED_VERSIONS_TIMEOUT`:

If timeout is reached, the attempt to copy files from cached versions is aborted and all missing files will be downloaded from backend instead. The timeout is set to 10 seconds cause if we have to wait very long to access the cache folders it might be faster to download the files from the backend instead.