### PR TITLE
Add audb.info.files()

### DIFF
--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -151,6 +151,32 @@ def duration(
     )
 
 
+def files(
+        name: str,
+        *,
+        version: str = None,
+        cache_root: str = None,
+) -> typing.List[str]:
+    """Media files included in the database.
+
+    Args:
+        name: name of database
+        version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
+
+    Returns:
+        media files
+
+    Example:
+        >>> files('emodb', version='1.2.0')[:2]
+        ['wav/03a01Fa.wav', 'wav/03a01Nc.wav']
+
+    """
+    deps = dependencies(name, version=version, cache_root=cache_root)
+    return deps.media
+
+
 def formats(
         name: str,
         *,

--- a/audb/info/__init__.py
+++ b/audb/info/__init__.py
@@ -61,6 +61,7 @@ from audb.core.info import (
     channels,
     description,
     duration,
+    files,
     formats,
     header,
     languages,

--- a/docs/api-info.rst
+++ b/docs/api-info.rst
@@ -28,6 +28,11 @@ duration
 
 .. autofunction:: duration
 
+files
+-----
+
+.. autofunction:: files
+
 formats
 -------
 


### PR DESCRIPTION
Closes #111 

This adds the utility function `audb.info.files()` to get a list of all files available in a database as this is not possible as a one-liner at the moment.

![image](https://user-images.githubusercontent.com/173624/167429358-4493947a-f36d-431f-bb63-835b42abf369.png)
