### PR TITLE
WIP: Add media and tables arguments to audb.info

### DIFF
--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -2,7 +2,6 @@ from audb import info
 from audb.core.api import (
     available,
     cached,
-    dependencies,
     exists,
     flavor_path,
     latest_version,
@@ -15,6 +14,7 @@ from audb.core.config import config
 from audb.core.dependencies import Dependencies
 from audb.core.flavor import Flavor
 from audb.core.load import (
+    dependencies,
     load,
     load_media,
     load_table,

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -68,6 +68,10 @@ def bit_depths(
     Returns:
         bit depths
 
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
+
     Example:
         >>> bit_depths('emodb', version='1.2.0')
         {16}
@@ -99,6 +103,10 @@ def channels(
 
     Returns:
         channel numbers
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> channels('emodb', version='1.2.0')
@@ -158,6 +166,10 @@ def duration(
 
     Returns:
         duration
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> duration('emodb', version='1.2.0')
@@ -221,6 +233,10 @@ def formats(
 
     Returns:
         format
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> formats('emodb', version='1.2.0')
@@ -472,6 +488,10 @@ def sampling_rates(
 
     Returns:
         sampling rates
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> sampling_rates('emodb', version='1.2.0')

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -644,7 +644,7 @@ def _filter_dependencies(
 ) -> pd.DataFrame:
     """Filter dependencies.
 
-    Return dependencies as dataframe
+    Return dependencies as a :class:`pandas.DataFrame`
     containing only files
     selected by ``tables`` and ``media`` arguments.
 

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -162,6 +162,8 @@ def duration(
     Example:
         >>> duration('emodb', version='1.2.0')
         Timedelta('0 days 00:24:47.092187500')
+        >>> duration('emodb', version='1.2.0', media=['wav/03a01Fa.wav'])
+        Timedelta('0 days 00:00:01.898250')
 
     """
     df = _filter_dependencies(name, version, tables, media, cache_root)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -213,7 +213,7 @@ def _files_duration(
 
 
 def _filter_media(
-        available_media: typing.Sequence,
+        available_media: typing.Sequence[str],
         requested_media: typing.Optional[
             typing.Union[str, typing.Sequence[str]]
         ],

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -240,7 +240,7 @@ def _filter_media(
             )
             raise ValueError(msg)
     else:
-        filtered_media = requested_media
+        filtered_media = list(requested_media)
         for media in filtered_media:
             if media not in available_media:
                 msg = _error_message_missing_object(
@@ -282,7 +282,7 @@ def _filter_tables(
             )
             raise ValueError(msg)
     else:
-        filtered_tables = requested_tables
+        filtered_tables = list(requested_tables)
         for table in filtered_tables:
             if table not in available_tables:
                 msg = _error_message_missing_object(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -563,38 +563,39 @@ def _load_tables(
 
 
 def _media(
-        db: audformat.Database,
+        media_files: typing.Sequence,
         media: typing.Optional[typing.Union[str, typing.Sequence[str]]],
+        name: str,
         version: str,
 ) -> typing.Sequence[str]:
 
     if media is None:
-        return db.files
+        return media_files
     elif len(media) == 0:
         return []
 
     if isinstance(media, str):
         pattern = re.compile(media)
         requested_media = []
-        for m in db.files:
+        for m in media_files:
             if pattern.search(m):
                 requested_media.append(m)
         if len(requested_media) == 0:
             msg = _error_message_missing_object(
                 'media file',
                 media,
-                db.name,
+                name,
                 version,
             )
             raise ValueError(msg)
     else:
         requested_media = media
         for media_file in requested_media:
-            if media_file not in db.files:
+            if media_file not in media_files:
                 msg = _error_message_missing_object(
                     'media file',
                     [media_file],
-                    db.name,
+                    name,
                     version,
                 )
                 raise ValueError(msg)
@@ -907,7 +908,7 @@ def load(
                 db[table].load(os.path.join(db_root, f'db.{table}'))
 
             # filter media
-            requested_media = _media(db, media, version)
+            requested_media = _media(db.files, media, name, version)
 
             # load missing media
             if not db_is_complete and not only_metadata:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -255,7 +255,7 @@ def _filter_media(
 
 
 def _filter_tables(
-        available_tables: Dependencies,
+        available_tables: typing.Sequence[str],
         requested_tables: typing.Optional[
             typing.Union[str, typing.Sequence[str]]
         ],

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -762,6 +762,10 @@ def dependencies(
     Returns:
         dependency object
 
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
+
     Example:
         >>> deps = dependencies('emodb', version='1.2.0')
         >>> deps.version('db.emotion.csv')

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -9,11 +9,11 @@ import audformat
 from audb.core import define
 from audb.core import utils
 from audb.core.api import (
-    dependencies,
     latest_version,
 )
 from audb.core.dependencies import Dependencies
 from audb.core.load import (
+    dependencies,
     database_tmp_root,
     load_header,
 )

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -9,7 +9,7 @@ import audformat
 import audiofile
 
 from audb.core import define
-from audb.core.api import dependencies
+from audb.core.load import dependencies
 from audb.core.dependencies import Dependencies
 from audb.core.repository import Repository
 

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -302,7 +302,7 @@ only the data of this speaker.
     db = audb.load(
         'emodb',
         version='1.2.0',
-        media=media,
+        media=list(media),
         full_path=False,
         only_metadata=True,
         verbose=False,
@@ -313,7 +313,7 @@ only the data of this speaker.
     db = audb.load(
         'emodb',
         version='1.2.0',
-        media=media,
+        media=list(media),
         full_path=False,
         verbose=False,
     )

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -161,12 +161,7 @@ def test_description():
         ('table1', None),
         (None, ['f11.wav', 'f12.wav']),
         ('table1', ['f11.wav', 'f12.wav']),
-        # Error as tables and media do not overlap
-        pytest.param(
-            'table2',
-            ['f11.wav', 'f12.wav'],
-            marks=pytest.mark.xfail(raises=ValueError),
-        ),
+        ('table2', ['f11.wav', 'f12.wav']),
     ]
 )
 def test_duration(tables, media):
@@ -180,7 +175,6 @@ def test_duration(tables, media):
         full_path=False,
         verbose=False,
     )
-    print(db.files)
     expected_duration = pd.to_timedelta(
         sum(
             [

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -332,16 +332,6 @@ def test_dependencies(tables, media, expected):
         media=media,
     )
     df = deps()
-    # db = audb.load(
-    #     DB_NAME,
-    #     version='1.0.0',
-    #     full_path=False,
-    #     tables=tables,
-    #     media=media,
-    # )
-    # print(db['files'].df)
-    # print(db['emotion'].df)
-    # print(deps())
     assert sorted(list(df.index)) == sorted(list(expected))
 
 


### PR DESCRIPTION
Closes #106

This adds `tables` and `media` arguments to all functions for which it makes sense in `audb.info`, namely:
* `audb.info.bit_depths()`
* `audb.info.channels()`
* `audb.info.duration()`
* `audb.info.formats()`
* `audb.info.sampling_rates()`

It internally reuses the `_tables()` and `_media()` functions from `audb.core.load`, which I renamed to `filter_tables()` and `filter_media()`.
The performance of the the info functions are not affected if you don't provide `tables` or `media` as argument. If you request `media` performance is slightly slower. If you request `tables` performance is >2 x slower as it needs to load the tables.
But overall it is still fast, e.g. for `emodb` we need 43s when repeating it 100 times.

I added one example to a docstring where it makes the most sense:

![image](https://user-images.githubusercontent.com/173624/167784345-2ff752da-8846-4edd-807c-a8ad75588e7d.png)

---

This also "fixes" some of the tests in `tests/test_info.py` as we only tested on a database without any files before, meaning tests for sampling rate etc. were not that meaningful besides ensuring that we get `{}` back.