### PR TITLE
DOC: fix margin of deps table example

### DIFF
--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -51,7 +51,8 @@ You can see all entries by calling the returned object.
 
 .. jupyter-execute::
 
-    deps()
+    df = deps()
+    df.head()
 
 You can also use it to request certain aspects, e.g.
 


### PR DESCRIPTION
With the newest version of `emodb` we have two tables with a large name leading to some margin overflow in the docs:

![image](https://user-images.githubusercontent.com/173624/167644924-c2acba75-d62e-4462-9e87-db716961660e.png)

this is fixed by this pull request, reducing it to

![image](https://user-images.githubusercontent.com/173624/167645022-3f970443-b4fc-4423-8d60-44f50443f2b0.png)

which makes more sense to me than reducing the visible columns even further.