### PR TITLE
DOC: add missing exceptions to docstrings

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -426,6 +426,9 @@ def latest_version(
     Returns:
         version string
 
+    Raises:
+        RuntimeError: if no version exists for the requested database
+
     Example:
         >>> latest_version('emodb')
         '1.2.0'

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -399,6 +399,12 @@ def flavor_path(
     Returns:
         flavor path relative to cache folder
 
+    Raises:
+        ValueError: if a non-supported ``bit_depth``,
+            ``format``,
+            or ``sampling_rate``
+            is requested
+
     Example:
         >>> flavor_path('emodb', version='1.2.0').split(os.path.sep)
         ['emodb', '1.2.0', 'd3b62a9b']

--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -41,6 +41,12 @@ class Flavor(audobject.Object):
         sampling_rate: sampling rate in Hz, one of
             ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
 
+    Raises:
+        ValueError: if a non-supported ``bit_depth``,
+            ``format``,
+            or ``sampling_rate``
+            is requested
+
     """
     def __init__(
             self,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -826,6 +826,10 @@ def load(
     Raises:
         ValueError: if table or media is requested
             that is not part of the database
+        ValueError: if a non-supported ``bit_depth``,
+            ``format``,
+            or ``sampling_rate``
+            is requested
 
     Example:
         >>> db = audb.load(
@@ -1081,6 +1085,10 @@ def load_media(
     Raises:
         ValueError: if a media file is requested
             that is not part of the database
+        ValueError: if a non-supported ``bit_depth``,
+            ``format``,
+            or ``sampling_rate``
+            is requested
 
     Example:
         >>> paths = load_media(


### PR DESCRIPTION
Closes #206 

This adds missing documentation on all exceptions raised by `audb`:

* `audb.latest_version()`
* `audb.Flavor.__init__()`
* `audb.load()`
* `audb.load_media()`
* `audb.flavor_path()`

---

`audb.latest_version()`

![image](https://user-images.githubusercontent.com/173624/168228647-51f1a791-1416-4077-b5af-61bcbbd81852.png)

and all the others

![image](https://user-images.githubusercontent.com/173624/168228691-9c1c0fb3-027c-4594-add7-ca56f1844126.png)
