### PR TITLE
Add media and tables arguments to audb.info

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -261,6 +261,8 @@ def dependencies(
     deps_path = os.path.join(db_root, define.CACHED_DEPENDENCIES_FILE)
 
     deps = Dependencies()
+    deps._name = name
+    deps._version = version
 
     with FolderLock(db_root):
         try:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -261,8 +261,6 @@ def dependencies(
     deps_path = os.path.join(db_root, define.CACHED_DEPENDENCIES_FILE)
 
     deps = Dependencies()
-    deps._name = name
-    deps._version = version
 
     with FolderLock(db_root):
         try:

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -26,10 +26,6 @@ class Dependencies:
     The dependencies of a database can be requested with
     :func:`audb.dependencies`.
 
-    Args:
-        name: name of database associated with dependencies
-        version: version of database associated with dependencies
-
     Example:
         >>> deps = Dependencies()
         >>> deps()
@@ -532,15 +528,12 @@ class Dependencies:
             tables: include only tables
                 matching the regular expression
                 or provided in the list
-            name: name of database
-            version: version of database
 
         Returns:
             list of table IDs inside the dependency object
                 matching the requested ``tables``
 
         """
-
         if tables is None:
             return self.table_ids
         elif len(tables) == 0:

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -231,7 +231,7 @@ def formats(
             If not set :meth:`audb.default_cache_root` is used
 
     Returns:
-        format
+        formats
 
     Raises:
         ValueError: if table or media is requested

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -68,6 +68,10 @@ def bit_depths(
     Returns:
         bit depths
 
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
+
     Example:
         >>> bit_depths('emodb', version='1.2.0')
         {16}
@@ -99,6 +103,10 @@ def channels(
 
     Returns:
         channel numbers
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> channels('emodb', version='1.2.0')
@@ -158,6 +166,10 @@ def duration(
 
     Returns:
         duration
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> duration('emodb', version='1.2.0')
@@ -221,6 +233,10 @@ def formats(
 
     Returns:
         format
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> formats('emodb', version='1.2.0')
@@ -472,6 +488,10 @@ def sampling_rates(
 
     Returns:
         sampling rates
+
+    Raises:
+        ValueError: if table or media is requested
+            that is not part of the database
 
     Example:
         >>> sampling_rates('emodb', version='1.2.0')

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -11,8 +11,7 @@ from audb.core.api import (
     latest_version,
 )
 from audb.core.load import (
-    filter_media,
-    filter_tables,
+    filtered_dependencies,
     load_header,
     load_table,
 )
@@ -77,7 +76,7 @@ def bit_depths(
         {16}
 
     """
-    df = _filter_dependencies(name, version, tables, media, cache_root)
+    df = filtered_dependencies(name, version, media, tables, cache_root)
     return set(df[df.type == define.DependType.MEDIA].bit_depth)
 
 
@@ -113,7 +112,7 @@ def channels(
         {1}
 
     """
-    df = _filter_dependencies(name, version, tables, media, cache_root)
+    df = filtered_dependencies(name, version, media, tables, cache_root)
     return set(df[df.type == define.DependType.MEDIA].channels)
 
 
@@ -178,7 +177,7 @@ def duration(
         Timedelta('0 days 00:00:01.898250')
 
     """
-    df = _filter_dependencies(name, version, tables, media, cache_root)
+    df = filtered_dependencies(name, version, media, tables, cache_root)
     return pd.to_timedelta(
         df[df.type == define.DependType.MEDIA].duration.sum(),
         unit='s',
@@ -243,7 +242,7 @@ def formats(
         {'wav'}
 
     """
-    df = _filter_dependencies(name, version, tables, media, cache_root)
+    df = filtered_dependencies(name, version, media, tables, cache_root)
     return set(df[df.type == define.DependType.MEDIA].format)
 
 
@@ -498,7 +497,7 @@ def sampling_rates(
         {16000}
 
     """
-    df = _filter_dependencies(name, version, tables, media, cache_root)
+    df = filtered_dependencies(name, version, media, tables, cache_root)
     return set(df[df.type == define.DependType.MEDIA].sampling_rate)
 
 
@@ -633,66 +632,3 @@ def usage(
     """
     db = header(name, version=version, cache_root=cache_root)
     return db.usage
-
-
-def _filter_dependencies(
-        name: str,
-        version: str,
-        tables: typing.Sequence,
-        media: typing.Sequence,
-        cache_root: str,
-) -> pd.DataFrame:
-    """Filter dependencies.
-
-    Return dependencies as a :class:`pandas.DataFrame`
-    containing only files
-    selected by ``tables`` and ``media`` arguments.
-
-    Args:
-        name: name of database
-        version: version of database
-        tables: include only tables matching the regular expression or
-            provided in the list
-        media: include only media matching the regular expression or
-            provided in the list
-        cache_root: cache folder where databases are stored.
-            If not set :meth:`audb.default_cache_root` is used
-
-    Returns:
-        filtered dependency table
-
-    """
-    if version is None:
-        version = latest_version(name)
-
-    requested_files = None
-    deps = dependencies(name, version=version, cache_root=cache_root)
-
-    if tables is not None or media is not None:
-        media_files = files(name, version=version, cache_root=cache_root)
-
-    if tables is not None:
-        requested_files = []
-        requested_tables = filter_tables(deps, tables, name, version)
-        if len(requested_tables) != 0:
-            for table in requested_tables:
-                df = load_table(
-                    name,
-                    table,
-                    version=version,
-                    cache_root=cache_root,
-                    verbose=False,
-                )
-                requested_files += [f for f in media_files if f in df.index]
-
-    if media is not None:
-        if tables is None:
-            requested_files = media_files
-        requested_media = filter_media(media_files, media, name, version)
-        requested_files = [f for f in requested_files if f in requested_media]
-
-    df = deps()
-    if requested_files is not None:
-        df = df.loc[requested_files]
-
-    return df

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -644,7 +644,7 @@ def _filter_dependencies(
 ) -> pd.DataFrame:
     """Filter dependencies.
 
-    Return dependencies as dataframe
+    Return dependencies as a :class:`pandas.DataFrame`
     containing only files
     selected by ``tables`` and ``media`` arguments.
 

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -162,6 +162,8 @@ def duration(
     Example:
         >>> duration('emodb', version='1.2.0')
         Timedelta('0 days 00:24:47.092187500')
+        >>> duration('emodb', version='1.2.0', media=['wav/03a01Fa.wav'])
+        Timedelta('0 days 00:00:01.898250')
 
     """
     df = _filter_dependencies(name, version, tables, media, cache_root)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -666,10 +666,9 @@ def filtered_dependencies(
     r"""Filter media by tables.
 
     Return all media files from ``media``
-    that are mentioned in at least one table
+    that are referenced in at least one table
     from ``tables``.
-    This has to download every table
-    for doing the check.
+    This will download all tables.
 
     Args:
         name: name of database
@@ -685,7 +684,7 @@ def filtered_dependencies(
     """
     deps = dependencies(name, version=version, cache_root=cache_root)
     if tables is None and media is None:
-        df = deps._df
+        df = deps()
     else:
         available_media = []
         tables = filter_tables(tables, deps.table_ids)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -563,38 +563,39 @@ def _load_tables(
 
 
 def _media(
-        db: audformat.Database,
+        media_files: typing.Sequence,
         media: typing.Optional[typing.Union[str, typing.Sequence[str]]],
+        name: str,
         version: str,
 ) -> typing.Sequence[str]:
 
     if media is None:
-        return db.files
+        return media_files
     elif len(media) == 0:
         return []
 
     if isinstance(media, str):
         pattern = re.compile(media)
         requested_media = []
-        for m in db.files:
+        for m in media_files:
             if pattern.search(m):
                 requested_media.append(m)
         if len(requested_media) == 0:
             msg = _error_message_missing_object(
                 'media file',
                 media,
-                db.name,
+                name,
                 version,
             )
             raise ValueError(msg)
     else:
         requested_media = media
         for media_file in requested_media:
-            if media_file not in db.files:
+            if media_file not in media_files:
                 msg = _error_message_missing_object(
                     'media file',
                     [media_file],
-                    db.name,
+                    name,
                     version,
                 )
                 raise ValueError(msg)
@@ -907,7 +908,7 @@ def load(
                 db[table].load(os.path.join(db_root, f'db.{table}'))
 
             # filter media
-            requested_media = _media(db, media, version)
+            requested_media = _media(db.files, media, name, version)
 
             # load missing media
             if not db_is_complete and not only_metadata:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -187,7 +187,7 @@ def _files_duration(
         format: typing.Optional[str],
 ):
     field = define.DEPEND_FIELD_NAMES[define.DependField.DURATION]
-    durs = deps._df.loc[files][field]
+    durs = deps().loc[files][field]
     durs = durs[durs > 0]
     durs = pd.to_timedelta(durs, unit='s')
     durs.index.name = 'file'
@@ -702,7 +702,7 @@ def filtered_dependencies(
 
         media = filter_media(media, deps.media, name, version)
         available_media = [m for m in media if m in list(set(available_media))]
-        df = deps._df.loc[available_media]
+        df = deps().loc[available_media]
 
     return df
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -180,7 +180,6 @@ def test_duration(tables, media):
         full_path=False,
         verbose=False,
     )
-    print(db.files)
     expected_duration = pd.to_timedelta(
         sum(
             [


### PR DESCRIPTION
Closes #106

Alternative implementation to https://github.com/audeering/audb/pull/210

This adds `tables` and `media` arguments to all functions for which it makes sense in `audb.info`, namely:

* `audb.info.bit_depths()`
* `audb.info.channels()`
* `audb.info.duration()`
* `audb.info.formats()`
* `audb.info.sampling_rates()`

Internally, I moved `audb.core.load._tables()` and `audb.core.load._media()` functions as helper functions to `audb.core.dependencies.filter_tables()` and `audb.core.dependencies.filter_media()`. At this stage, I don't need to load any tables. For the functions under `audb.info` that need then to filter `media` further by the `tables` I added `audb.core.load.filtered_dependencies()`, which then in a last step downloads the required tables.

I added one example to a docstring where it makes the most sense:

![image](https://user-images.githubusercontent.com/173624/174620573-b4485a8a-9d15-494f-bbfc-00406f605615.png)


