### PR TITLE
Publish(): media files must not exist

### DIFF
--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -219,6 +219,7 @@ def load_to(
         name: str,
         *,
         version: str = None,
+        only_metadata: bool = False,
         cache_root: str = None,
         num_workers: typing.Optional[int] = 1,
         verbose: bool = True,
@@ -237,6 +238,7 @@ def load_to(
         root: target directory
         name: name of database
         version: version string, latest if ``None``
+        only_metadata: load only metadata
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used.
             Only used to read the dependencies of the requested version
@@ -266,7 +268,8 @@ def load_to(
         verbose=verbose,
     )
     if update:
-        for file in deps.files:
+        files = deps.tables if only_metadata else deps.files
+        for file in files:
             full_file = os.path.join(db_root, file)
             if os.path.exists(full_file):
                 checksum = audbackend.md5(full_file)
@@ -312,9 +315,10 @@ def load_to(
 
     # get altered and new media files
 
-    media = _find_media(db, db_root, deps, num_workers, verbose)
-    _get_media(media, db_root, db_root_tmp, name, deps, backend,
-               num_workers, verbose)
+    if not only_metadata:
+        media = _find_media(db, db_root, deps, num_workers, verbose)
+        _get_media(media, db_root, db_root_tmp, name, deps, backend,
+                   num_workers, verbose)
 
     # save dependencies
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -113,10 +113,11 @@ def _find_media(
 ) -> typing.Set[str]:
     r"""Find archives with new, altered or removed media files."""
 
-    # release dependencies to removed media
-    # and select according archives for upload
     media_archives = set()
     db_media = set(db.files)
+
+    # release dependencies to removed media
+    # and select according archives for upload
     for file in set(deps.media) - db_media:
         media_archives.add(deps.archive(file))
         deps._drop(file)
@@ -361,10 +362,8 @@ def publish(
     by adding labels for new media files to it
     and publish it as a new version.
     :func:`audb.publish` will then upload
-    only the altered table
-    and the new media files,
-    which will be added as new dependencies
-    to the already published files.
+    only the new and altered files
+    and update their dependencies.
 
     To update a database,
     you first have to load the version

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -372,7 +372,7 @@ def publish(
     with :func:`audb.load_to` to ``db_root``.
     Media files that are not altered can be omitted,
     so it recommended to set
-    ``only_metadata=True``.
+    ``only_metadata=True`` in :func:`audb.load_to`.
     Afterwards you make your changes to that folder
     and run :func:`audb.publish`.
     To remove media files from a database,

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -337,6 +337,10 @@ def publish(
     you first have to load the version of the database
     that the new version should depend on
     with :func:`audb.load_to` to ``db_root``.
+    Media files that are not altered can be omitted,
+    so consider to set
+    ``only_metadata=True``
+    for large databases.
     Afterwards you make your changes to that folder
     and run :func:`audb.publish`.
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -352,22 +352,28 @@ def publish(
     r"""Publish database.
 
     A database can have dependencies
-    to files of an older version of itself.
-    E.g. you might add a few new files to an existing database
-    and publish as a new version.
-    :func:`audb.publish` will upload then only the new files
-    and store dependencies on the already published files.
+    to media files and tables of an older version.
+    E.g. you might alter an existing table
+    by adding new media files to it
+    and publish it as a new version.
+    :func:`audb.publish` will then upload
+    only the altered table
+    and the new media files,
+    which will be added as new dependencies
+    to the already published files.
 
-    To allow for dependencies
-    you first have to load the version of the database
+    To update a database,
+    you first have to load the version
     that the new version should depend on
     with :func:`audb.load_to` to ``db_root``.
     Media files that are not altered can be omitted,
-    so consider to set
-    ``only_metadata=True``
-    for large databases.
+    so it recommended to set
+    ``only_metadata=True``.
     Afterwards you make your changes to that folder
     and run :func:`audb.publish`.
+    To remove media files from a database,
+    make sure they are no
+    longer referenced in the tables.
 
     Setting ``previous_version=None`` allows you
     to start from scratch and upload all files

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -393,7 +393,11 @@ def publish(
             but sox and/or mediafile is not installed
 
     """
-    db = audformat.Database.load(db_root, load_data=False)
+    db = audformat.Database.load(
+        db_root,
+        load_data=False,
+        verbose=verbose,
+    )
 
     backend = audbackend.create(
         repository.backend,
@@ -473,8 +477,12 @@ def publish(
                     f"or modified the file manually?"
                 )
 
-    # load database from folder
-    db = audformat.Database.load(db_root, load_data=True)
+    # load database with table data
+    db = audformat.Database.load(
+        db_root,
+        load_data=True,
+        verbose=verbose,
+    )
 
     # check all tables are conform with audformat
     if not db.is_portable:

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -43,15 +43,22 @@ def _check_for_missing_media(
         num_workers: int,
         verbose: bool,
 ):
-    r"""Check for media that is not on disk and not in dependencies."""
+    r"""Check for media that is not in root and not in dependencies."""
 
     def job(file):
-        path = os.path.join(db_root, file)
-        if not os.path.exists(path) and file not in media:
+        if (
+                file not in deps_files
+                and file not in root_files
+        ):
             missing_files.append(file)
 
     missing_files = []
-    media = deps.media
+    deps_files = deps.media
+    root_files = audeer.list_file_names(
+        db_root,
+        basenames=True,
+        recursive=True,
+    )
     audeer.run_tasks(
         job,
         params=[([file], {}) for file in db.files],

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -362,8 +362,8 @@ def publish(
     by adding labels for new media files to it
     and publish it as a new version.
     :func:`audb.publish` will then upload
-    only the new and altered files
-    and update their dependencies.
+    new and altered files and update
+    the dependencies accordingly.
 
     To update a database,
     you first have to load the version

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -358,7 +358,7 @@ def publish(
     A database can have dependencies
     to media files and tables of an older version.
     E.g. you might alter an existing table
-    by adding new media files to it
+    by adding labels for new media files to it
     and publish it as a new version.
     :func:`audb.publish` will then upload
     only the altered table

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -78,7 +78,7 @@ def _find_tables(
         deps: Dependencies,
         verbose: bool,
 ) -> typing.List[str]:
-    r"""Update tables."""
+    r"""Find altered, new or removed tables and update 'deps'."""
 
     # release dependencies to removed tables
 
@@ -111,7 +111,7 @@ def _find_media(
         num_workers: int,
         verbose: bool,
 ) -> typing.Set[str]:
-    r"""Find archives with new, altered or removed media files."""
+    r"""Find archives with new, altered or removed media and update 'deps'."""
 
     media_archives = set()
     db_media = set(db.files)

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -371,7 +371,7 @@ def publish(
     that the new version should depend on
     with :func:`audb.load_to` to ``db_root``.
     Media files that are not altered can be omitted,
-    so it recommended to set
+    so it is recommended to set
     ``only_metadata=True`` in :func:`audb.load_to`.
     Afterwards you make your changes to that folder
     and run :func:`audb.publish`.

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -40,11 +40,16 @@ def _check_for_missing_media(
         db: audformat.Database,
         db_root: str,
         deps: Dependencies,
+        verbose: bool,
 ):
     missing_files = []
     media = deps.media
 
-    for f in db.files:
+    for f in audeer.progress_bar(
+        db.files,
+        desc='Check media',
+        disable=not verbose,
+    ):
         path = os.path.join(db_root, f)
         if not os.path.exists(path) and f not in media:
             missing_files.append(f)
@@ -488,6 +493,7 @@ def publish(
         db,
         db_root,
         deps,
+        verbose,
     )
 
     # make sure all tables are stored in CSV format

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -151,14 +151,21 @@ Update a database
 In a next step we will add another file with age annotation
 to the database.
 As a first step we load
-the previous version
+the metadata of the
+previous version
 of the database
 to a new folder.
 
 .. jupyter-execute::
 
     build_dir = './age-test-1.1.0'
-    db = audb.load_to(build_dir, 'age-test', version='1.0.0', verbose=False)
+    db = audb.load_to(
+        build_dir,
+        'age-test',
+        version='1.0.0',
+        only_metadata=True,
+        verbose=False,
+    )
 
 Then we extend the age table by another file (:file:`audio/004.wav`)
 and add the age annotation of 22 to it.
@@ -238,6 +245,6 @@ to see how to load and use a database.
 .. jupyter-execute::
     :hide-code:
 
-    for folder in folders: 
+    for folder in folders:
         if os.path.exists(folder):
             shutil.rmtree(folder)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -585,7 +585,7 @@ def test_update_database_without_media(tmpdir):
     for file in rem_files:
         assert not os.path.exists(audeer.path(db_load.root, file))
     for file in new_files + alter_files:
-        filecmp.cmp(
+        assert filecmp.cmp(
             audeer.path(build_root, file),
             audeer.path(db_load.root, file),
         )

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,7 +1,9 @@
+import filecmp
 import os
 import re
 import shutil
 
+import numpy as np
 import pytest
 
 import audbackend
@@ -68,7 +70,7 @@ def fixture_publish_db():
     db['files'] = audformat.Table(db.files)
     db['files']['speaker'] = audformat.Column(scheme_id='speaker')
     db['files']['speaker'].set(
-        ['adam', 'adam', '11', '11'],
+        ['adam', 'adam', 'adam', '11'],
         index=audformat.filewise_index(db.files[:4]),
     )
     db.save(
@@ -117,7 +119,7 @@ def fixture_publish_db():
     db['files'] = audformat.Table(db.files)
     db['files']['speaker'] = audformat.Column(scheme_id='speaker')
     db['files']['speaker'].set(
-        ['adam', 'adam', '11', '11'],
+        ['adam', 'adam', 'adam', '11'],
         index=audformat.filewise_index(db.files[:4]),
     )
     db.save(DB_ROOT_VERSION['6.0.0'])
@@ -485,7 +487,7 @@ def test_update_database():
         verbose=False,
     )
 
-    # Check that depencies include previous and actual version only
+    # Check that dependencies include previous and actual version only
     versions = audeer.sort_versions([deps.version(f) for f in deps.files])
     assert versions[-1] == version
     assert versions[0] == previous_version
@@ -509,6 +511,84 @@ def test_update_database():
     db1.meta['audb'] = {}
     db2.meta['audb'] = {}
     assert db1 == db2
+
+
+def test_update_database_without_media(tmpdir):
+
+    build_root = tmpdir
+    previous_version = '1.0.0'
+    version = '1.1.0'
+
+    new_table = 'new'
+    new_files = [
+        'new/001.wav',
+        'new/002.wav',
+    ]
+    alter_files = [
+        'audio/001.wav',  # same archive as 'audio/00[2,3].wav'
+        'audio/005.wav',
+    ]
+    rem_files = [
+        'new/003.wav',  # same archive as 'audio/00[1,2].wav'
+    ]
+
+    # load without media
+    db = audb.load_to(
+        build_root,
+        DB_NAME,
+        only_metadata=True,
+        version=previous_version,
+        num_workers=pytest.NUM_WORKERS,
+        verbose=False,
+    )
+    for file in db.files:
+        assert not os.path.exists(audeer.path(build_root, file))
+
+    # update and save database
+
+    # remove files
+    for file in rem_files:
+        db.drop_files(file)
+
+    # create and alter files
+    sampling_rate = 16000
+    signal = np.ones((1, sampling_rate), np.float32)
+    for file in new_files + alter_files:
+        path = audeer.path(build_root, file)
+        audeer.mkdir(os.path.dirname(path))
+        audiofile.write(path, signal, sampling_rate)
+
+    # add new table
+    db[new_table] = audformat.Table(audformat.filewise_index(new_files))
+
+    db.save(build_root)
+
+    # publish database
+    audb.publish(
+        build_root,
+        version,
+        pytest.PUBLISH_REPOSITORY,
+        previous_version=previous_version,
+        verbose=False,
+    )
+
+    # check if missing archive files were downloaded during publish
+    assert os.path.exists(audeer.path(build_root, 'audio/002.wav'))
+
+    # load new version and check media
+    db_load = audb.load(
+        DB_NAME,
+        version=version,
+    )
+    for file in db.files:
+        assert os.path.exists(audeer.path(db_load.root, file))
+    for file in rem_files:
+        assert not os.path.exists(audeer.path(db_load.root, file))
+    for file in new_files + alter_files:
+        filecmp.cmp(
+            audeer.path(build_root, file),
+            audeer.path(db_load.root, file),
+        )
 
 
 def test_cached():


### PR DESCRIPTION
Closes #56

Allows it to publish a new version of a database without downloading all media files first. For media files referenced in a table it is sufficient that they exist in dependencies of the previous version. In that case it is assumed they remain unchanged. 

This should significantly speed up publishing, since we 

1. don't have to download all media files
2. don't have to calculate their checksum

Only for media files that exist in the build folder, the checksum is calculated to check if they were altered. When a media file is altered that shares the archive with other files, missing files are automatically downloaded to the build folder so that the archive can be created.

![image](https://user-images.githubusercontent.com/10383417/178922732-379d6128-c911-4367-ae50-de70925f448a.png)

To download only the metadata to the build folder, the argument `only_metadata` was added to `audb.load_to()`.

![image](https://user-images.githubusercontent.com/10383417/176696015-a030cd3b-d80a-4f1f-b482-e73066025d22.png)

The usage section was updated accordingly:

![image](https://user-images.githubusercontent.com/10383417/176696272-579a3ff2-16f0-434e-a689-44ae29724f47.png)

