### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,6 @@ jobs:
         tasks: [ tests ]
         include:
           - os: ubuntu-latest
-            python-version: 3.7
-            tasks: tests
-          - os: ubuntu-latest
             python-version: 3.9
             tasks: tests
           - os: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
@@ -35,6 +34,7 @@ install_requires =
     audresample >=0.1.6
     filelock
     oyaml
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audformat <0.15.0
 audiofile >=1.1.0
 pytest
 pytest-cov


### PR DESCRIPTION
As version 0.15.0 of `audformat` no longer supports Python 3.7, we remove it here as well.