### PR TITLE
DOC: improve docstring for new load_tables arg

### DIFF
--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -269,8 +269,8 @@ def header(
         name: name of database
         version: version of database
         load_tables: if ``True``
-            it will download misc tables
-            used as labels in a scheme
+            downloads misc tables
+            used by schemes
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
 
@@ -598,8 +598,8 @@ def schemes(
         name: name of database
         version: version of database
         load_tables: if ``True``
-            it will download misc tables
-            used as labels in a scheme
+            downloads misc tables
+            used by schemes
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
 


### PR DESCRIPTION
As mentioned in https://github.com/audeering/audb/pull/222#discussion_r948874371 I forgot to push a fix to the docstrings of `audb.info.header` and `audb.info.schemes` for the new `load_tables` argument.