### PR TITLE
When loading database download archives to ~ folder

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -248,7 +248,12 @@ def _get_media_from_backend(
         )
         # extract and move all files that are stored in the archive,
         # even if only a single file from the archive was requested
-        files = backend.get_archive(archive, db_root_tmp, version)
+        files = backend.get_archive(
+            archive,
+            db_root_tmp,
+            version,
+            tmp_root=db_root_tmp,
+        )
         for file in files:
             if flavor is not None:
                 bit_depth = deps.bit_depth(file)
@@ -352,6 +357,7 @@ def _get_tables_from_backend(
             archive,
             db_root_tmp,
             deps.version(table),
+            tmp_root=db_root_tmp,
         )
         table_id = table[3:-4]
         table_path = os.path.join(db_root_tmp, f'db.{table_id}')

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -110,7 +110,12 @@ def _get_media(
             define.DEPEND_TYPE_NAMES[define.DependType.MEDIA],
             archive,
         )
-        files = backend.get_archive(archive, db_root_tmp, version)
+        files = backend.get_archive(
+            archive,
+            db_root_tmp,
+            version,
+            tmp_root=db_root_tmp,
+        )
         for file in files:
             audeer.move_file(
                 os.path.join(db_root_tmp, file),
@@ -153,7 +158,12 @@ def _get_tables(
             define.DEPEND_TYPE_NAMES[define.DependType.META],
             deps.archive(table),
         )
-        backend.get_archive(archive, db_root_tmp, deps.version(table))
+        backend.get_archive(
+            archive,
+            db_root_tmp,
+            deps.version(table),
+            tmp_root=db_root_tmp,
+        )
         audeer.move_file(
             os.path.join(db_root_tmp, table),
             os.path.join(db_root, table),

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audbackend >=0.3.15
+    audbackend >=0.3.16
     audeer >=1.18.0
     audformat >=0.15.2,<2.0.0
     audiofile >=1.0.0


### PR DESCRIPTION
Closes https://github.com/audeering/audb/issues/172

As discussed in https://github.com/audeering/audb/issues/172 when loading a database it makes sense to download archives to the temporal database folder instead of the temporary folder of the system.