### PR TITLE
DOC: fix typo for release 1.4.1 in changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Version 1.4.1 (2022-10-17)
 * Changed: ``audb.load()`` and ``audb.load_to()``
   extract archives in the corresponding database folder
   inside the ``audb`` cache
-  instead of the system wide cache
+  instead of the system wide tmp folder
 
 
 Version 1.4.0 (2022-08-18)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Version 1.4.1 (2022-10-17)
 * Changed: ``audb.load()`` and ``audb.load_to()``
   extract archives in the corresponding database folder
   inside the ``audb`` cache
-  instead of the system wide tmp folder
+  instead of the system-wide temporary folder
 
 
 Version 1.4.0 (2022-08-18)


### PR DESCRIPTION
We had a small typo in the latest changelog stating that the archives were extracted in the system wide cache before. But it should be "system wide tmp  folder":

![image](https://user-images.githubusercontent.com/173624/203493586-c56e9266-4425-416b-9919-82b387014d26.png)
