### PR TITLE
TST: use main as default branch name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ linkcheck_ignore = [
         'https://github.com/audeering/audbackend/blob/'
         'edd23462799ae9052a43cdd045698f78e19dbcaf'
     ),
+    'http://emodb.bilderbar.info/start.html',
 ]
 # Ignore package dependencies during building the docs
 # This fixes URL link issues with pandas and sphinx_autodoc_typehints


### PR DESCRIPTION
Use `main` as name for default branch in tests.