### PR TITLE
CI: update Github Action versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
 
@@ -72,10 +72,10 @@ jobs:
 
     - name: Create release on Github
       id: create_release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        release_name: Release ${{ github.ref_name }}
         body: ${{ steps.changelog.outputs.body }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,16 @@ jobs:
             tasks: docs
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Cache emodb
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/audb
         key: emodb-1.2.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -72,7 +72,7 @@ jobs:
       if: matrix.tasks == 'tests'
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml


### PR DESCRIPTION
Several of our Github Actions used versions that are deprecated now or no longer maintained.
This updates all related Actions:

* `actions/checkout@v2` -> `actions/checkout@v3`
* `actions/setup-python@v2` -> `actions/setup-python@v4`
* `actions/create-release@v1` -> `softprops/action-gh-release@v1`
* `codecov/codecov-action@v1` -> `codecov/codecov-action@v3`
* `actions/cache@v2` -> `actions/cache@v3`