### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,17 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ 3.8 ]
+        python-version: [ '3.8' ]
         tasks: [ tests ]
         include:
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
             tasks: tests
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: '3.10'
+            tasks: tests
+          - os: ubuntu-latest
+            python-version: '3.8'
             tasks: docs
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,13 +27,12 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audbackend >=0.3.16
+    audbackend >=0.3.17
     audeer >=1.18.0
     audformat >=0.15.2,<2.0.0
     audiofile >=1.0.0
     audobject >=0.5.0
     audresample >=0.1.6
-    dohq-artifactory >=0.8.1
     filelock
     oyaml
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     audiofile >=1.0.0
     audobject >=0.5.0
     audresample >=0.1.6
+    dohq-artifactory >=0.8.1
     filelock
     oyaml
 python_requires = >=3.8


### PR DESCRIPTION
Closes #240 

Add test for Python 3.10 under Ubuntu and mention Python 3.10 as supported version in `setup.cfg`.
Require `audbackend >=0.3.17` for Python 3.10 support.