### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,29 @@
+name: Flake8
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+
+    - name: Install pre-commit hooks
+      run: |
+        pip install pre-commit
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit install
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,6 +30,39 @@ This way, your installation always stays up-to-date,
 even if you pull new changes from the Github repository.
 
 
+Coding Convention
+-----------------
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install -r tests/requirements.txt
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # you might consider system wide installation
+    flake8
+
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 --------------------------
 

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 import typing
 

--- a/audb/core/cache.py
+++ b/audb/core/cache.py
@@ -2,7 +2,6 @@ import os
 
 import audeer
 
-from audb.core import define
 from audb.core.config import config
 from audb.core.flavor import Flavor
 

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -6,8 +6,6 @@ import typing
 import pandas as pd
 
 import audeer
-import audformat
-import audiofile
 
 from audb.core import define
 

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -5,17 +5,12 @@ import pandas as pd
 import audformat
 
 from audb.core import define
-from audb.core.api import (
-    dependencies,
-    database_cache_root,
-    latest_version,
-)
+from audb.core.api import dependencies
 from audb.core.load import (
     filtered_dependencies,
     load_header,
     load_table,
 )
-from audb.core.lock import FolderLock
 
 
 def author(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1,5 +1,4 @@
 import os
-import re
 import shutil
 import typing
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -1,9 +1,7 @@
 import collections
 import os
 import shutil
-import sys
 import tempfile
-import time
 import typing
 
 import audbackend
@@ -14,7 +12,6 @@ import audiofile
 from audb.core import define
 from audb.core.api import dependencies
 from audb.core.dependencies import Dependencies
-from audb.core.load import load_media
 from audb.core.repository import Repository
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ setup_requires =
 
 [tool:pytest]
 addopts =
-    --flake8
     --doctest-plus
     --cov=audb
     --cov-fail-under=100
@@ -49,6 +48,12 @@ addopts =
 xfail_strict = true
 
 [flake8]
-ignore =
-    W503  # math, https://github.com/PyCQA/pycodestyle/issues/513
-    __init__.py F401  # ignore unused imports
+exclude =
+    .eggs,
+    build,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused imports
+    __init__.py: F401,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
 audiofile >=1.1.0
-# To avoid https://github.com/tholo/pytest-flake8/issues/87
-flake8 <5.0.0
+pre-commit
 pytest
 pytest-cov
 pytest-console-scripts

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2,7 +2,6 @@ import os
 import shutil
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import audformat.testing

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -4,8 +4,6 @@ import shutil
 import pandas as pd
 import pytest
 
-import audiofile
-
 import audformat.testing
 import audeer
 


### PR DESCRIPTION
This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.