### PR TITLE
Use single archive per attachment ID

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -303,26 +303,35 @@ def _get_attachments_from_backend(
     utils.mkdir_tree(attachment_files, db_root)
     utils.mkdir_tree(attachment_files, db_root_tmp)
 
-    def job(file: str):
+    # find needed archives
+    archives = set()
+    for file in attachment_files:
+        archives.add((deps.archive(file), deps.version(file)))
+
+    def job(archive: str, version: str):
         archive = backend.join(
             db.name,
             define.DEPEND_TYPE_NAMES[define.DependType.ATTACHMENT],
-            deps.archive(file),
+            archive,
         )
-        backend.get_archive(
+        files = backend.get_archive(
             archive,
             db_root_tmp,
-            deps.version(file),
+            version,
             tmp_root=db_root_tmp,
         )
-        audeer.move_file(
-            os.path.join(db_root_tmp, file),
-            os.path.join(db_root, file),
-        )
+        for file in files:
+            if file in attachment_files:
+                audeer.move_file(
+                    os.path.join(db_root_tmp, file),
+                    os.path.join(db_root, file),
+                )
+            else:
+                os.remove(os.path.join(db_root_tmp, file))
 
     audeer.run_tasks(
         job,
-        params=[([file], {}) for file in attachment_files],
+        params=[([archive, version], {}) for archive, version in archives],
         num_workers=num_workers,
         progress_bar=verbose,
         task_description='Load attachments',

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -68,7 +68,7 @@ def _check_for_missing_media(
         raise RuntimeError(error_msg)
 
 
-def _find_attachment_files(
+def _find_attachments(
         db: audformat.Database,
         db_root: str,
         version: str,
@@ -85,25 +85,28 @@ def _find_attachment_files(
         deps._drop(file)
 
     # add dependencies to new attachment files
-    attachment_files = []
+    attachments = set()
     for attachment_id in audeer.progress_bar(
             list(db.attachments),
             desc='Find attachments',
             disable=not verbose,
     ):
+        # use one archive per attachment ID
         for file in db.attachments[attachment_id].files:
             checksum = audbackend.md5(audeer.path(db_root, file))
             if file not in deps or checksum != deps.checksum(file):
-                archive = audeer.uid(from_string=file.replace('\\', '/'))
+                attachments.add(attachment_id)
+        # update version number for all files in archive
+        if attachment_id in attachments:
+            for file in db.attachments[attachment_id].files:
                 deps._add_attachment_file(
                     file=file,
                     version=version,
-                    archive=archive,
+                    archive=attachment_id,
                     checksum=checksum,
                 )
-                attachment_files.append(file)
 
-    return attachment_files
+    return list(attachments)
 
 
 def _find_media(
@@ -272,26 +275,27 @@ def _media_values(
     )
 
 
-def _put_attachment_files(
-        attachment_files: typing.List[str],
+def _put_attachments(
+        attachments: typing.List[str],
         db_root: str,
-        db_name: str,
+        db: audformat.Database,
         version: str,
         backend: audbackend.Backend,
         num_workers: typing.Optional[int],
         verbose: bool,
 ):
-    def job(file: str):
+    def job(attachment_id: str):
         archive_file = backend.join(
-            db_name,
+            db.name,
             define.DEPEND_TYPE_NAMES[define.DependType.ATTACHMENT],
-            audeer.uid(from_string=file.replace('\\', '/')),
+            attachment_id,
         )
-        backend.put_archive(db_root, file, archive_file, version)
+        files = db.attachments[attachment_id].files
+        backend.put_archive(db_root, files, archive_file, version)
 
     audeer.run_tasks(
         job,
-        params=[([file], {}) for file in attachment_files],
+        params=[([attachment_id], {}) for attachment_id in attachments],
         num_workers=num_workers,
         progress_bar=verbose,
         task_description='Put attachments',
@@ -617,11 +621,10 @@ def publish(
     # check archives
     archives = archives or {}
 
-    # publish attachment files
-    attachment_files = _find_attachment_files(db, db_root, version, deps,
-                                              verbose)
-    _put_attachment_files(attachment_files, db_root, db.name, version, backend,
-                          num_workers, verbose)
+    # publish attachments
+    attachments = _find_attachments(db, db_root, version, deps, verbose)
+    _put_attachments(attachments, db_root, db, version, backend, num_workers,
+                     verbose)
 
     # publish tables
     tables = _find_tables(db, db_root, version, deps, verbose)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -397,10 +397,18 @@ def test_publish(version):
         verbose=False,
     )
     backend = audb.core.utils.lookup_backend(DB_NAME, version)
-    number_of_files = len(set(archives.keys()))
-    number_of_archives = len(set(archives.values()))
-    assert len(deps.files) - len(deps.archives) == (
-        number_of_files - number_of_archives
+    number_of_media_files_in_custom_archives = len(set(archives.keys()))
+    number_of_custom_archives = len(set(archives.values()))
+    number_of_media_files = len(deps.media)
+    number_of_media_archives = len(
+        set([deps.archive(file) for file in deps.media])
+    )
+    assert (
+        number_of_media_files_in_custom_archives
+        - number_of_custom_archives
+    ) == (
+        number_of_media_files
+        - number_of_media_archives
     )
     for archive in set(archives.values()):
         assert archive in deps.archives


### PR DESCRIPTION
NOTE: this pull request uses `attachment` as target branch, see #244 

---

Creates only a single archive per attachment ID.

It also changes the name of the archive from a random string to the ID of the attachment:

```
                                                                archive  ...  version
extra/file.txt                                                     file  ...    1.0.0
extra/folder/file1.txt                                           folder  ...    1.0.0
extra/folder/file2.txt                                           folder  ...    1.0.0
extra/folder/sub-folder/file3.txt                                folder  ...    1.0.0
db.emotion.csv                                                  emotion  ...    1.0.0
db.files.csv                                                      files  ...    1.0.0
db.misc-in-scheme.csv                                    misc-in-scheme  ...    1.0.0
db.misc-not-in-scheme.csv                            misc-not-in-scheme  ...    1.0.0
audio/005.wav                      1ddc5f46-8635-b031-2b75-41e4c2b0f222  ...    1.0.0
audio/003.wav                                                      adam  ...    1.0.0
audio/001.wav                                                      adam  ...    1.0.0
audio/002.wav                                                      adam  ...    1.0.0
audio/004.wav                                                        11  ...    1.0.0
```

This might be problematic when a user chooses an ID that contains chars that are not allowed on the backend, but for the tables we are also doing it this way.

