### PR TITLE
WIP: Support uppercase letters in file extension

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -126,6 +126,7 @@ def cached(
         >>> db = audb.load(
         ...     'emodb',
         ...     version='1.3.0',
+        ...     format='flac',
         ...     only_metadata=True,
         ...     full_path=False,
         ...     verbose=False,
@@ -133,12 +134,12 @@ def cached(
         >>> df = cached()
         >>> print(df.iloc[0].to_string())
         name                emodb
-        flavor_id        d3b62a9b
+        flavor_id        40bb2241
         version             1.3.0
         complete            False
         bit_depth            None
         channels             None
-        format               None
+        format               flac
         mixdown             False
         sampling_rate        None
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -668,7 +668,6 @@ def _update_path(
     Args:
         db: database object
         root: root to add to path
-        deps: dependency object
         full_path: if ``True`` expand file path with ``root``
         format: file extension to change to in path
         num_workers: number of workers to use

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -384,6 +384,13 @@ def publish(
     In this case you don't call :func:`audb.load_to`
     before running :func:`audb.publish`.
 
+    Handling of audio formats
+    is based on the file extension
+    in :mod:`audb`.
+    This means you should only publish WAV files
+    that end with ``.wav``
+    or any upper or mixed case version of that string.
+
     When canceling :func:`audb.publish`
     during publication
     you can restart it afterwards.

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -207,11 +207,13 @@ def test_format(format):
     df = audb.cached()
     assert df['format'].values[0] == format
 
+    print(f'{db.files=}')
     for converted_file, original_file in zip(db.files, original_files):
 
         converted_file = os.path.join(db.meta['audb']['root'], converted_file)
         original_file = os.path.join(DB_ROOT, original_file)
 
+        print(f'{format=}')
         if format is None:
             assert converted_file[-4:] == original_file[-4:]
         else:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -33,7 +33,7 @@ DB_FILES = {
         'format': 'wav',
         'sampling_rate': 8000,
     },
-    'audio/file2.wav': {
+    'audio/file2.WAV': {
         'bit_depth': 24,
         'channels': 2,
         'format': 'wav',
@@ -42,6 +42,12 @@ DB_FILES = {
     'audio/file3.flac': {
         'bit_depth': 8,
         'channels': 3,
+        'format': 'flac',
+        'sampling_rate': 44100,
+    },
+    'audio/file4.Flac': {
+        'bit_depth': 8,
+        'channels': 1,
         'format': 'flac',
         'sampling_rate': 44100,
     },
@@ -207,17 +213,15 @@ def test_format(format):
     df = audb.cached()
     assert df['format'].values[0] == format
 
-    print(f'{db.files=}')
     for converted_file, original_file in zip(db.files, original_files):
 
         converted_file = os.path.join(db.meta['audb']['root'], converted_file)
         original_file = os.path.join(DB_ROOT, original_file)
 
-        print(f'{format=}')
         if format is None:
             assert converted_file[-4:] == original_file[-4:]
         else:
-            assert converted_file.endswith(format)
+            assert converted_file.lower().endswith(format)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -224,8 +224,8 @@ def test_database_cache_folder():
 @pytest.mark.parametrize(
     'format, expected',
     [
-        ('wav', r'\.[^w^W][^a^A]?[^v^V]?[^\.]*$'),
-        ('flac', r'\.[^f^F][^l^L]?[^a^A]?[^c^C]?[^\.]*$'),
+        ('wav', r'(?P<before>.*)\.((?![wW][aA][vV]).)*$'),
+        ('flac', r'(?P<before>.*)\.((?![fF][lL][aA][cC]).)*$'),
     ]
 )
 def test_format_replace_pattern(format, expected):
@@ -235,17 +235,17 @@ def test_format_replace_pattern(format, expected):
 @pytest.mark.parametrize(
     'format, file_extension, expected',
     [
-        ('wav', 'Wav', False),
-        ('wav', 'wAv', False),
-        ('wav', 'waV', False),
-        ('wav', 'WAv', False),
-        ('wav', 'wAV', False),
-        ('wav', 'WAV', False),
-        ('wav', 'wa1', True),
-        ('wav', 'gav', True),
-        ('wav', 'wbv', True),
-        ('wav', 'gz', True),
-        ('wav', 'flac', True),
+        ('wav', '.Wav', False),
+        ('wav', '.wAv', False),
+        ('wav', '.waV', False),
+        ('wav', '.WAv', False),
+        ('wav', '.wAV', False),
+        ('wav', '.WAV', False),
+        ('wav', '.wa1', True),
+        ('wav', '.gav', True),
+        ('wav', '.wbv', True),
+        ('wav', '.gz', True),
+        ('wav', '.flac', True),
     ]
 )
 def test_format_replace(format, file_extension, expected):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shutil
 
 import pandas as pd
@@ -229,6 +230,30 @@ def test_database_cache_folder():
 )
 def test_format_replace_pattern(format, expected):
     assert audb.core.load._format_replace_pattern(format) == expected
+
+
+@pytest.mark.parametrize(
+    'format, file_extension, expected',
+    [
+        ('wav', 'Wav', False),
+        ('wav', 'wAv', False),
+        ('wav', 'waV', False),
+        ('wav', 'WAv', False),
+        ('wav', 'wAV', False),
+        ('wav', 'WAV', False),
+        ('wav', 'wa1', True),
+        ('wav', 'gav', True),
+        ('wav', 'wbv', True),
+        ('wav', 'gz', True),
+        ('wav', 'flac', True),
+    ]
+)
+def test_format_replace(format, file_extension, expected):
+    pattern = audb.core.load._format_replace_pattern(format)
+    if re.match(pattern, file_extension):
+        assert expected is True
+    else:
+        assert expected is False
 
 
 def test_load_wrong_argument():

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -155,14 +155,17 @@ def fixture_publish_db():
 
     # publish 2.0.0, alter, remove, add media
 
-    db['files'].extend_index(audformat.filewise_index(['audio/006.WAV']))
+    db['files'].extend_index(
+        audformat.filewise_index(['audio/006.WAV']),
+        inplace=True,
+    )
     db.save(DB_ROOT_VERSION['2.0.0'])
     audformat.testing.create_audio_files(db)
     file = os.path.join(DB_ROOT_VERSION['2.0.0'], db.files[0])
     y, sr = audiofile.read(file)
     y[0] = 1
     audiofile.write(file, y, sr)
-    file = db.files[-1]
+    file = db.files[-2]
     db.pick_files(lambda x: x != file)
     os.remove(audeer.path(DB_ROOT_VERSION['2.0.0'], file))
     db.save(DB_ROOT_VERSION['2.0.0'])

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -220,6 +220,17 @@ def test_database_cache_folder():
     assert db_root == expected_db_root
 
 
+@pytest.mark.parametrize(
+    'format, expected',
+    [
+        ('wav', r'\.[^w^W][^a^A]?[^v^V]?[^\.]*$'),
+        ('flac', r'\.[^f^F][^l^L]?[^a^A]?[^c^C]?[^\.]*$'),
+    ]
+)
+def test_format_replace_pattern(format, expected):
+    assert audb.core.load._format_replace_pattern(format) == expected
+
+
 def test_load_wrong_argument():
     with pytest.raises(TypeError):
         audb.load(DB_NAME, typo='1.0.0')

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -153,8 +153,9 @@ def fixture_publish_db():
         verbose=False,
     )
 
-    # publish 2.0.0, alter and remove media
+    # publish 2.0.0, alter, remove, add media
 
+    db['files'].extend_index(audformat.filewise_index(['audio/006.WAV']))
     db.save(DB_ROOT_VERSION['2.0.0'])
     audformat.testing.create_audio_files(db)
     file = os.path.join(DB_ROOT_VERSION['2.0.0'], db.files[0])

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -280,7 +280,7 @@ def test_load(format, version):
         resolved_version = version
     db_original = audformat.Database.load(DB_ROOT_VERSION[resolved_version])
 
-    if format is not None:
+    if format is not None and format != 'wav':
         db_original.map_files(
             lambda x: audeer.replace_file_extension(x, format)
         )


### PR DESCRIPTION
Closes #103 

This fixes the problem that the current implementation of `audb` does not fully supported mixed/upper case letter in file names.

Suppose you have a file named `audio.WAV` in your database, if you load it with `format='wav'` it would not change the audio file and not rename table entries, e.g. `db.files` will contain `audio.WAV`.

I updated the docstring of `audb.publish()` with the following text at the end:

![image](https://user-images.githubusercontent.com/173624/216924448-92251333-d84d-45ff-8189-6b522c38d430.png)

---

I implemented it using an anti-pattern to match the file extension we want to replace, e.g. if `format='wav'` we want to replace all file extensions that are not     `'wav'`, `'Wav'`, `'wAv'`, `'waV'`, `'WAv'`, `'WaV'`, `'wAV'`, `'WAV'`.
The required anti-pattern is generated with the new private function `_format_replace_pattern()`. The only downside of the anti-pattern is that it is complicated and not easy to understand.

I added then another function `_maybe_replace_file_extension()` that replaces the file extension inside indices or list of files (needed in `load_media()`) with the requested format.
