### PR TITLE
TST: check for correct cache in test_load()

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -225,6 +225,7 @@ def test_load_wrong_argument():
     'format',
     [
         None,
+        'wav',
         'flac',
     ]
 )
@@ -260,7 +261,7 @@ def test_load(format, version):
     )
     db_root = db.meta['audb']['root']
 
-    assert audb.exists(DB_NAME, version=version)
+    assert audb.exists(DB_NAME, version=version, format=format)
 
     files_duration = {
         os.path.join(db_root, os.path.normpath(file)): pd.to_timedelta(


### PR DESCRIPTION
This extends the `test_load()` by also requesting `wav` as format besides `None` and `flac` and it fixes the check that looks if the requested cache folder does exists by incorporating the requested format.