### PR TITLE
DOC: optional overwrite permissions for publish()

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -386,11 +386,11 @@ def publish(
 
     When canceling :func:`audb.publish`
     during publication
-    you can restart it afterwards
-    to continue from the current state.
-    But you might need overwrite permissions
+    you can restart it afterwards.
+    It will continue from the current state,
+    but you might need overwrite permissions
     in addition to write permissions
-    on the backend then.
+    on the backend.
 
     .. _audformat: https://audeering.github.io/audformat/data-introduction.html
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -353,6 +353,9 @@ def publish(
 ) -> Dependencies:
     r"""Publish database.
 
+    Publishes a database conform to audformat_,
+    stored in the ``db_root`` folder.
+
     A database can have dependencies
     to media files and tables of an older version.
     E.g. you might alter an existing table
@@ -380,6 +383,16 @@ def publish(
     even if an older versions exist.
     In this case you don't call :func:`audb.load_to`
     before running :func:`audb.publish`.
+
+    When canceling :func:`audb.publish`
+    during publication
+    you can restart it afterwards
+    to continue from the current state.
+    But you might need overwrite permissions
+    in addition to write permissions
+    on the backend then.
+
+    .. _audformat: https://audeering.github.io/audformat/data-introduction.html
 
     Args:
         db_root: root directory of database


### PR DESCRIPTION
Closes #2 

This documents that `audb.publish()` might need overwrite permissions on the backend when restarting it after it was canceled during publication.

![image](https://user-images.githubusercontent.com/173624/216934536-e510c816-5ead-4f8f-8033-542a52be0301.png)
