### PR TITLE
DOC: fix codecov badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Have a look at the installation_ and quickstart_ instructions.
 .. |tests| image:: https://github.com/audeering/audb/workflows/Test/badge.svg
     :target: https://github.com/audeering/audb/actions?query=workflow%3ATest
     :alt: Test status
-.. |coverage| image:: https://codecov.io/gh/audeering/audb/branch/master/graph/badge.svg?token=drrULW8vEG
+.. |coverage| image:: https://codecov.io/gh/audeering/audb/branch/main/graph/badge.svg?token=drrULW8vEG
     :target: https://codecov.io/gh/audeering/audb/
     :alt: code coverage
 .. |docs| image:: https://img.shields.io/pypi/v/audb?label=docs


### PR DESCRIPTION
This fixes the URL for the codecov badge in the README to point to the `main` branch instead of `master`.

Unfortunately, that URL does also not work at the moment:

https://codecov.io/gh/audeering/audb/branch/main/graph/badge.svg?token=drrULW8vEG

[![codecov](https://codecov.io/gh/audeering/audb/branch/main/graph/badge.svg?token=drrULW8vEG)](https://codecov.io/gh/audeering/audb)

But it is the URL, that is given by codecov:

![image](https://user-images.githubusercontent.com/173624/222063415-29e04b7f-3331-4c55-a7c3-c803d9e6eada.png)
