### PR TITLE
DOC: require ipykernel

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 docutils
+ipykernel
 jupyter-sphinx
 sphinx >=3.5.4
 sphinx-audeering-theme >=1.2.1


### PR DESCRIPTION
Ensures `ipykernel` is installed when building the docs.