### PR TITLE
CI: enable doc test on dev branch

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,9 +2,9 @@ name: Documentation
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   build:


### PR DESCRIPTION
Be sure the test for building the docs is also executed when creating a pull request that has the `dev` branch as target.