### PR TITLE
DOC: add version to docstring in load_table()

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1237,6 +1237,7 @@ def load_table(
     Args:
         name: name of database
         table: load table from database
+        version: version of database
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
         num_workers: number of parallel jobs or 1 for sequential


### PR DESCRIPTION
The argument `version` was missing in the docstring of `load_table()`:

![image](https://user-images.githubusercontent.com/10383417/229597140-3b1059fe-b6c9-4636-87f5-fb3901a98363.png)
