### PR TITLE
DOC: use emodb v1.4.0 in examples

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/audb
-        key: emodb-1.2.0
+        key: emodb-1.4.0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/audb
-        key: emodb-1.2.0
+        key: emodb-1.4.0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -41,7 +41,7 @@ def available(
         >>> audb.available(only_latest=True)
                    backend                                    host   repository version
         name
-        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.3.0
+        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.0
 
     """  # noqa: E501
     databases = []
@@ -125,7 +125,7 @@ def cached(
     Examples:
         >>> db = audb.load(
         ...     'emodb',
-        ...     version='1.3.0',
+        ...     version='1.4.0',
         ...     only_metadata=True,
         ...     full_path=False,
         ...     verbose=False,
@@ -134,7 +134,7 @@ def cached(
         >>> print(df.iloc[0].to_string())
         name                emodb
         flavor_id        d3b62a9b
-        version             1.3.0
+        version             1.4.0
         complete            False
         bit_depth            None
         channels             None
@@ -244,7 +244,7 @@ def dependencies(
         dependency object
 
     Examples:
-        >>> deps = dependencies('emodb', version='1.3.0')
+        >>> deps = dependencies('emodb', version='1.4.0')
         >>> deps.version('db.emotion.csv')
         '1.1.0'
 
@@ -323,13 +323,13 @@ def exists(
     Examples:
         >>> db = audb.load(
         ...     'emodb',
-        ...     version='1.3.0',
+        ...     version='1.4.0',
         ...     only_metadata=True,
         ...     verbose=False,
         ... )
-        >>> audb.exists('emodb', version='1.3.0')
+        >>> audb.exists('emodb', version='1.4.0')
         True
-        >>> audb.exists('emodb', version='1.3.0', format='wav')
+        >>> audb.exists('emodb', version='1.4.0', format='wav')
         False
 
     """
@@ -405,8 +405,8 @@ def flavor_path(
             is requested
 
     Examples:
-        >>> flavor_path('emodb', version='1.3.0').split(os.path.sep)
-        ['emodb', '1.3.0', 'd3b62a9b']
+        >>> flavor_path('emodb', version='1.4.0').split(os.path.sep)
+        ['emodb', '1.4.0', 'd3b62a9b']
 
     """
     flavor = Flavor(
@@ -436,7 +436,7 @@ def latest_version(
 
     Examples:
         >>> latest_version('emodb')
-        '1.3.0'
+        '1.4.0'
 
     """
     vs = versions(name)
@@ -563,7 +563,7 @@ def repository(
         RuntimeError: if database is not found
 
     Examples:
-        >>> audb.repository('emodb', '1.3.0')
+        >>> audb.repository('emodb', '1.4.0')
         Repository('data-public', 'https://audeering.jfrog.io/artifactory', 'artifactory')
 
     """  # noqa: E501
@@ -583,7 +583,7 @@ def versions(
 
     Examples:
         >>> versions('emodb')
-        ['1.1.0', '1.1.1', '1.2.0', '1.3.0']
+        ['1.1.0', '1.1.1', '1.2.0', '1.3.0', '1.4.0']
 
     """
     vs = []

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -30,8 +30,8 @@ class Dependencies:
         Empty DataFrame
         Columns: [archive, bit_depth, channels, checksum, duration, format, removed, sampling_rate, type, version]
         Index: []
-        >>> # Request dependencies for emodb 1.3.0
-        >>> deps = audb.dependencies('emodb', version='1.3.0')
+        >>> # Request dependencies for emodb 1.4.0
+        >>> deps = audb.dependencies('emodb', version='1.4.0')
         >>> # List all files or archives
         >>> deps.files[:3]
         ['db.emotion.csv', 'db.files.csv', 'wav/03a01Fa.wav']

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -31,7 +31,7 @@ def author(
         author(s) of database
 
     Examples:
-        >>> author('emodb', version='1.3.0')
+        >>> author('emodb', version='1.4.0')
         'Felix Burkhardt, Astrid Paeschke, Miriam Rolfes, Walter Sendlmeier, Benjamin Weiss'
 
     """  # noqa: E501
@@ -72,7 +72,7 @@ def bit_depths(
             that is not part of the database
 
     Examples:
-        >>> bit_depths('emodb', version='1.3.0')
+        >>> bit_depths('emodb', version='1.4.0')
         {16}
 
     """
@@ -108,7 +108,7 @@ def channels(
             that is not part of the database
 
     Examples:
-        >>> channels('emodb', version='1.3.0')
+        >>> channels('emodb', version='1.4.0')
         {1}
 
     """
@@ -134,7 +134,7 @@ def description(
         description of database
 
     Examples:
-        >>> desc = description('emodb', version='1.3.0')
+        >>> desc = description('emodb', version='1.4.0')
         >>> desc.split('.')[0]  # show first sentence
         'Berlin Database of Emotional Speech'
 
@@ -176,9 +176,9 @@ def duration(
             that is not part of the database
 
     Examples:
-        >>> duration('emodb', version='1.3.0')
+        >>> duration('emodb', version='1.4.0')
         Timedelta('0 days 00:24:47.092187500')
-        >>> duration('emodb', version='1.3.0', media=['wav/03a01Fa.wav'])
+        >>> duration('emodb', version='1.4.0', media=['wav/03a01Fa.wav'])
         Timedelta('0 days 00:00:01.898250')
 
     """
@@ -207,7 +207,7 @@ def files(
         media files
 
     Examples:
-        >>> files('emodb', version='1.3.0')[:2]
+        >>> files('emodb', version='1.4.0')[:2]
         ['wav/03a01Fa.wav', 'wav/03a01Nc.wav']
 
     """
@@ -243,7 +243,7 @@ def formats(
             that is not part of the database
 
     Examples:
-        >>> formats('emodb', version='1.3.0')
+        >>> formats('emodb', version='1.4.0')
         {'wav'}
 
     """
@@ -273,7 +273,7 @@ def header(
         database object without table data
 
     Examples:
-        >>> db = header('emodb', version='1.3.0')
+        >>> db = header('emodb', version='1.4.0')
         >>> db.name
         'emodb'
 
@@ -311,7 +311,7 @@ def languages(
         languages of database
 
     Examples:
-        >>> languages('emodb', version='1.3.0')
+        >>> languages('emodb', version='1.4.0')
         ['deu']
 
     """
@@ -342,7 +342,7 @@ def license(
         license of database
 
     Examples:
-        >>> license('emodb', version='1.3.0')
+        >>> license('emodb', version='1.4.0')
         'CC0-1.0'
 
     """
@@ -373,7 +373,7 @@ def license_url(
         license URL of database
 
     Examples:
-        >>> license_url('emodb', version='1.3.0')
+        >>> license_url('emodb', version='1.4.0')
         'https://creativecommons.org/publicdomain/zero/1.0/'
 
     """
@@ -404,7 +404,7 @@ def media(
         media of database
 
     Examples:
-        >>> media('emodb', version='1.3.0')
+        >>> media('emodb', version='1.4.0')
         microphone:
             {type: other, format: wav, channels: 1, sampling_rate: 16000}
 
@@ -436,7 +436,7 @@ def meta(
         meta information of database
 
     Examples:
-        >>> meta('emodb', version='1.3.0')
+        >>> meta('emodb', version='1.4.0')
         pdf:
           http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.130.8506&rep=rep1&type=pdf
 
@@ -468,7 +468,7 @@ def misc_tables(
         miscellaneous tables of database
 
     Examples:
-        >>> list(misc_tables('emodb', version='1.3.0'))
+        >>> list(misc_tables('emodb', version='1.4.0'))
         ['speaker']
 
     """  # noqa: E501
@@ -499,7 +499,7 @@ def organization(
         organization responsible for database
 
     Examples:
-        >>> organization('emodb', version='1.3.0')
+        >>> organization('emodb', version='1.4.0')
         'audEERING'
 
     """
@@ -530,7 +530,7 @@ def raters(
         raters of database
 
     Examples:
-        >>> raters('emodb', version='1.3.0')
+        >>> raters('emodb', version='1.4.0')
         gold:
             {type: human}
 
@@ -572,7 +572,7 @@ def sampling_rates(
             that is not part of the database
 
     Examples:
-        >>> sampling_rates('emodb', version='1.3.0')
+        >>> sampling_rates('emodb', version='1.4.0')
         {16000}
 
     """
@@ -602,7 +602,7 @@ def schemes(
         schemes of database
 
     Examples:
-        >>> list(schemes('emodb', version='1.3.0'))
+        >>> list(schemes('emodb', version='1.4.0'))
         ['age', 'confidence', 'duration', 'emotion', 'gender', 'language', 'speaker', 'transcription']
 
     """  # noqa: E501
@@ -633,7 +633,7 @@ def source(
         source of database
 
     Examples:
-        >>> source('emodb', version='1.3.0')
+        >>> source('emodb', version='1.4.0')
         'http://emodb.bilderbar.info/download/download.zip'
 
     """
@@ -664,7 +664,7 @@ def splits(
         splits of database
 
     Examples:
-        >>> splits('emodb', version='1.3.0')
+        >>> splits('emodb', version='1.4.0')
         test:
           {description: Unofficial speaker-independent test split, type: test}
         train:
@@ -698,7 +698,7 @@ def tables(
         tables of database
 
     Examples:
-        >>> list(tables('emodb', version='1.3.0'))
+        >>> list(tables('emodb', version='1.4.0'))
         ['emotion', 'emotion.categories.test.gold_standard', 'emotion.categories.train.gold_standard', 'files']
 
     """  # noqa: E501
@@ -729,7 +729,7 @@ def usage(
         usage of database
 
     Examples:
-        >>> usage('emodb', version='1.3.0')
+        >>> usage('emodb', version='1.4.0')
         'unrestricted'
 
     """

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -820,7 +820,7 @@ def load(
     Examples:
         >>> db = audb.load(
         ...     'emodb',
-        ...     version='1.3.0',
+        ...     version='1.4.0',
         ...     tables=['emotion', 'files'],
         ...     only_metadata=True,
         ...     full_path=False,
@@ -1124,12 +1124,12 @@ def load_media(
         >>> paths = load_media(
         ...     'emodb',
         ...     ['wav/03a01Fa.wav'],
-        ...     version='1.3.0',
+        ...     version='1.4.0',
         ...     format='flac',
         ...     verbose=False,
         ... )
         >>> paths[0].split(os.path.sep)[-5:]
-        ['emodb', '1.3.0', '40bb2241', 'wav', '03a01Fa.flac']
+        ['emodb', '1.4.0', '40bb2241', 'wav', '03a01Fa.flac']
 
     """
     media = audeer.to_list(media)
@@ -1255,7 +1255,7 @@ def load_table(
         >>> df = load_table(
         ...     'emodb',
         ...     'emotion',
-        ...     version='1.3.0',
+        ...     version='1.4.0',
         ...     verbose=False,
         ... )
         >>> df[:3]

--- a/audb/info/__init__.py
+++ b/audb/info/__init__.py
@@ -23,7 +23,7 @@ r"""Get information from database headers.
 
     audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         only_metadata=True,
         verbose=False,
     )
@@ -39,7 +39,7 @@ So instead of running:
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         only_metadata=True,
         verbose=False,
     )
@@ -51,7 +51,7 @@ You can run:
 
     audb.info.tables(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
     )
 
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ audb.config.REPOSITORIES = [
     )
 ]
 database_name = 'emodb'
-database_version = '1.3.0'
+database_version = '1.4.0'
 if not audb.exists(database_name, version=database_version):
     print(f'Pre-caching {database_name} v{database_version}')
     audb.load(

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -45,7 +45,7 @@ You request a :class:`audb.Dependencies` object with
 
 .. jupyter-execute::
 
-    deps = audb.dependencies('emodb', version='1.3.0')
+    deps = audb.dependencies('emodb', version='1.4.0')
 
 You can see all entries by calling the returned object.
 
@@ -72,7 +72,7 @@ in the database dependency table.
 
 .. jupyter-execute::
 
-    deps = audb.dependencies('emodb', version='1.3.0')
+    deps = audb.dependencies('emodb', version='1.4.0')
     df = deps()
     df.duration[:10]
 
@@ -81,7 +81,7 @@ you can get their overall duration with:
 
 .. jupyter-execute::
 
-    audb.info.duration('emodb', version='1.3.0')
+    audb.info.duration('emodb', version='1.4.0')
 
 The duration of parts of a database
 can be calculated
@@ -95,7 +95,7 @@ of the emodb database.
 
     import numpy as np
 
-    df = audb.load_table('emodb', 'emotion', version='1.3.0', verbose=False)
+    df = audb.load_table('emodb', 'emotion', version='1.4.0', verbose=False)
     files = df.index[:10]
     duration_in_sec = np.sum([deps.duration(f) for f in files])
     pd.to_timedelta(duration_in_sec, unit='s')

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -56,7 +56,7 @@ even if a new version of the database is published.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         only_metadata=True,
         verbose=False,
     )
@@ -65,7 +65,7 @@ even if a new version of the database is published.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         verbose=False,
     )
 
@@ -154,7 +154,7 @@ inside the :ref:`cache <caching>`.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         format='flac',
         sampling_rate=44100,
         only_metadata=True,
@@ -165,7 +165,7 @@ inside the :ref:`cache <caching>`.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         format='flac',
         sampling_rate=44100,
         verbose=False,
@@ -204,7 +204,7 @@ but all the tables and the header.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         only_metadata=True,
         verbose=False,
     )
@@ -222,7 +222,7 @@ It can list all table definitions.
 
     audb.info.tables(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
     )
 
 Or get the total duration of all media files.
@@ -231,7 +231,7 @@ Or get the total duration of all media files.
 
     audb.info.duration(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
     )
 
 See :mod:`audb.info` for a list of all available options.
@@ -261,7 +261,7 @@ about the speakers (here ``db['files']``):
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         tables=['files'],
         only_metadata=True,
         full_path=False,
@@ -301,7 +301,7 @@ only the data of this speaker.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         media=media,
         full_path=False,
         only_metadata=True,
@@ -312,7 +312,7 @@ only the data of this speaker.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         media=media,
         full_path=False,
         verbose=False,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -41,14 +41,14 @@ Let's load the database.
 
     db = audb.load(
         'emodb',
-        version='1.3.0',
+        version='1.4.0',
         only_metadata=True,
         verbose=False,
     )
 
 .. code-block:: python
 
-    db = audb.load('emodb', version='1.3.0', verbose=False)
+    db = audb.load('emodb', version='1.4.0', verbose=False)
 
 This downloads the database header,
 all the media files,


### PR DESCRIPTION
This switches all examples and tests to use the new version 1.4.0 of `emodb`.