### PR TITLE
CI: update emodb cache version

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/audb
-        key: emodb-1.4.0
+        key: emodb-1.4.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/audb
-        key: emodb-1.4.0
+        key: emodb-1.4.1
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
As mentioned in https://github.com/audeering/audb/pull/273#issuecomment-1497320778 we forgot to update the cache of the CI job for the newest `emodb` version.