### PR TITLE
Add audb.info.attachments()

### DIFF
--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -28,7 +28,7 @@ def attachments(
             If not set :meth:`audb.default_cache_root` is used
 
     Returns:
-        attachment ID(s) of database
+        attachments of database
 
     Examples:
         >>> list(attachments('emodb', version='1.4.1'))

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -34,7 +34,7 @@ def attachments(
         >>> list(attachments('emodb', version='1.4.1'))
         ['bibtex']
 
-    """  # noqa: E501
+    """
     db = header(
         name,
         version=version,

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -13,6 +13,37 @@ from audb.core.load import (
 )
 
 
+def attachments(
+        name: str,
+        *,
+        version: str = None,
+        cache_root: str = None,
+) -> typing.Dict:
+    """Attachment(s) of database.
+
+    Args:
+        name: name of database
+        version: version of database
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
+
+    Returns:
+        attachment ID(s) of database
+
+    Examples:
+        >>> list(attachments('emodb', version='1.4.1'))
+        ['bibtex']
+
+    """  # noqa: E501
+    db = header(
+        name,
+        version=version,
+        load_tables=False,
+        cache_root=cache_root,
+    )
+    return db.attachments
+
+
 def author(
         name: str,
         *,

--- a/audb/info/__init__.py
+++ b/audb/info/__init__.py
@@ -56,6 +56,7 @@ You can run:
 
 """
 from audb.core.info import (
+    attachments,
     author,
     bit_depths,
     channels,

--- a/docs/api-src/audb.info.rst
+++ b/docs/api-src/audb.info.rst
@@ -7,6 +7,7 @@ audb.info
     :toctree:
     :nosignatures:
 
+    attachments
     author
     bit_depths
     channels

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -38,6 +38,7 @@ DB.media['media'] = audformat.Media()
 DB.schemes['scheme1'] = audformat.Scheme()
 DB.splits['split'] = audformat.Split()
 DB.raters['rater'] = audformat.Rater()
+DB.attachments['attachment'] = audformat.Attachment('file.txt')
 DB['table1'] = audformat.Table(
     audformat.filewise_index(
         ['f11.wav', 'f12.wav', 'f13.wav'],
@@ -94,6 +95,7 @@ def fixture_publish_db():
     # create db + audio files
     sampling_rate = 8000
     audeer.mkdir(DB_ROOT)
+    audeer.touch(audeer.path(DB_ROOT, DB.attachments['attachment'].path))
     for table in list(DB.tables):
         for file in DB[table].files:
             audiofile.write(
@@ -127,6 +129,10 @@ def fixture_clear_cache():
     clear_root(pytest.CACHE_ROOT)
     yield
     clear_root(pytest.CACHE_ROOT)
+
+
+def test_attachemnts():
+    assert str(audb.info.attachments(DB_NAME)) == str(DB.attachments)
 
 
 def test_author():


### PR DESCRIPTION
This adds `audb.info.attachments()` to handle the new attachment feature also with `audb.info`.

![image](https://user-images.githubusercontent.com/173624/231395416-0c5b0e6c-ad7f-4bd5-b7ef-38c84597500b.png)
