### PR TITLE
Store attachment as single entry

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -110,7 +110,6 @@ class Dependencies:
         archives = self._df.archive.to_list()
         return sorted(list(set(archives)))
 
-
     @property
     def attachment_ids(self) -> typing.List[str]:
         r"""Attachment files.
@@ -124,7 +123,6 @@ class Dependencies:
                 self._df['type'] == define.DependType.ATTACHMENT
             ].archive
         )
-
 
     @property
     def attachment_paths(self) -> typing.List[str]:

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -112,21 +112,6 @@ class Dependencies:
 
 
     @property
-    def attachment_files(self) -> typing.List[str]:
-        r"""Attachment files.
-
-        Returns:
-            list of attachment files
-
-        """
-        return list(
-            self._df[
-                self._df['type'] == define.DependType.ATTACHMENT
-            ].index
-        )
-
-
-    @property
     def attachment_ids(self) -> typing.List[str]:
         r"""Attachment files.
 

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -115,7 +115,7 @@ class Dependencies:
         r"""Attachment paths (can be a file or a folder).
 
         Returns:
-            list of attachment
+            list of attachments
 
         """
         return list(

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -111,25 +111,11 @@ class Dependencies:
         return sorted(list(set(archives)))
 
     @property
-    def attachment_ids(self) -> typing.List[str]:
-        r"""Attachment files.
+    def attachments(self) -> typing.List[str]:
+        r"""Attachment paths (can be a file or a folder).
 
         Returns:
-            list of attachment files
-
-        """
-        return list(
-            self._df[
-                self._df['type'] == define.DependType.ATTACHMENT
-            ].archive
-        )
-
-    @property
-    def attachment_paths(self) -> typing.List[str]:
-        r"""Attachment files.
-
-        Returns:
-            list of attachment files
+            list of attachment
 
         """
         return list(
@@ -139,8 +125,22 @@ class Dependencies:
         )
 
     @property
+    def attachment_ids(self) -> typing.List[str]:
+        r"""Attachment IDs.
+
+        Returns:
+            list of attachment ID
+
+        """
+        return list(
+            self._df[
+                self._df['type'] == define.DependType.ATTACHMENT
+            ].archive
+        )
+
+    @property
     def files(self) -> typing.List[str]:
-        r"""All media, table, attachment files.
+        r"""All media, table, attachments.
 
         Returns:
             list of files

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -110,8 +110,39 @@ class Dependencies:
         archives = self._df.archive.to_list()
         return sorted(list(set(archives)))
 
+
     @property
     def attachment_files(self) -> typing.List[str]:
+        r"""Attachment files.
+
+        Returns:
+            list of attachment files
+
+        """
+        return list(
+            self._df[
+                self._df['type'] == define.DependType.ATTACHMENT
+            ].index
+        )
+
+
+    @property
+    def attachment_ids(self) -> typing.List[str]:
+        r"""Attachment files.
+
+        Returns:
+            list of attachment files
+
+        """
+        return list(
+            self._df[
+                self._df['type'] == define.DependType.ATTACHMENT
+            ].archive
+        )
+
+
+    @property
+    def attachment_paths(self) -> typing.List[str]:
         r"""Attachment files.
 
         Returns:
@@ -376,20 +407,20 @@ class Dependencies:
         """
         return self._df.version[file]
 
-    def _add_attachment_file(
+    def _add_attachment(
             self,
             file: str,
             version: str,
             archive: str,
             checksum: str,
     ):
-        r"""Add or update attachment file.
+        r"""Add or update attachment.
 
         Args:
-            file: relative file path
+            file: relative path of attachment
+            version: version string
             archive: archive name without extension
             checksum: checksum of file
-            version: version string
 
         """
         format = audeer.file_extension(file).lower()
@@ -562,6 +593,8 @@ def error_message_missing_object(
         object_name = f'{object_type} file'
     else:
         object_name = object_type
+
+    # TODO: check if we can combine the two error messages
 
     if isinstance(missing_object_id, str):
         msg = (

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -129,7 +129,7 @@ class Dependencies:
         r"""Attachment IDs.
 
         Returns:
-            list of attachment ID
+            list of attachment IDs
 
         """
         return list(

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -577,8 +577,6 @@ def error_message_missing_object(
     else:
         object_name = object_type
 
-    # TODO: check if we can combine the two error messages
-
     if isinstance(missing_object_id, str):
         msg = (
             f"Could not find a {object_name} "

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1153,7 +1153,7 @@ def load_attachment(
         verbose=verbose,
     )
 
-    if not attachment in deps.archives:
+    if attachment not in deps.archives:
         msg = error_message_missing_object(
             'attachment',
             [attachment],

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -340,6 +340,64 @@ def _get_attachments_from_backend(
     audeer.rmdir(db_root_tmp)
 
 
+def _get_attachments_from_backend_(
+        db: audformat.Database,
+        attachments: typing.Sequence[str],
+        db_root: str,
+        deps: Dependencies,
+        backend: audbackend.Backend,
+        num_workers: typing.Optional[int],
+        verbose: bool,
+):
+    r"""Load attachments from backend."""
+    db_root_tmp = database_tmp_root(db_root)
+
+    # find needed archives
+    archives = []
+    for attachment in attachments:
+        path = db.attachments[attachment].path
+        archives.append((path, deps.archive(path), deps.version(path)))
+
+    def job(path: str, archive: str, version: str):
+        archive = backend.join(
+            db.name,
+            define.DEPEND_TYPE_NAMES[define.DependType.ATTACHMENT],
+            archive,
+        )
+        backend.get_archive(
+            archive,
+            db_root_tmp,
+            version,
+            tmp_root=db_root_tmp,
+        )
+        src_path = audeer.path(db_root_tmp, path)
+        dst_path = audeer.path(db_root, path)
+        audeer.mkdir(os.path.dirname(dst_path))
+        audeer.move_file(
+            src_path,
+            dst_path,
+        )
+        # for file in files:
+        #     if file in attachment_files:
+        #         audeer.move_file(
+        #             os.path.join(db_root_tmp, file),
+        #             os.path.join(db_root, file),
+        #         )
+        #     else:
+        #         os.remove(os.path.join(db_root_tmp, file))
+
+    audeer.run_tasks(
+        job,
+        params=[([path, archive, version], {})
+                for path, archive, version in archives],
+        num_workers=num_workers,
+        progress_bar=verbose,
+        task_description='Load attachments',
+    )
+
+    audeer.rmdir(db_root_tmp)
+
+
 def _get_media_from_backend(
         name: str,
         media: typing.Sequence[str],
@@ -475,6 +533,84 @@ def _get_tables_from_backend(
     )
 
     audeer.rmdir(db_root_tmp)
+
+
+def _load_attachments(
+        attachments: typing.Sequence[str],
+        backend: audbackend.Backend,
+        db_root: str,
+        db: audformat.Database,
+        version: str,
+        cached_versions: typing.Optional[CachedVersions],
+        deps: Dependencies,
+        flavor: Flavor,
+        cache_root: str,
+        num_workers: int,
+        verbose: bool,
+) -> typing.Optional[CachedVersions]:
+    r"""Load attachments to cache.
+
+    Args:
+        attachments: list of attachment IDs
+        backend: backend object
+        db_root: database root
+        db: database object
+        version: database version
+        cached_versions: object representing cached versions
+            of the database
+        deps: database dependency object
+        flavor: database flavor object
+        cache_root: root path of cache
+        num_workers: number of workers to use
+        verbose: if ``True`` show progress bars
+            for each step
+
+    Returns:
+        cached versions object
+            if other versions of the database are found in cache
+
+    """
+    missing_attachments = []
+    for attachment in attachments:
+        path = db.attachments[attachment].path
+        path = audeer.path(db_root, path)
+        if not os.path.exists(path):
+            missing_attachments.append(attachment)
+
+    if missing_attachments:
+        if cached_versions is None:
+            cached_versions = _cached_versions(
+                db.name,
+                version,
+                flavor,
+                cache_root,
+            )
+        # TODO: look for cached attachments
+        # if cached_versions:
+        #     missing_files = _get_files_from_cache(
+        #         missing_files,
+        #         files_type,
+        #         db_root,
+        #         deps,
+        #         cached_versions,
+        #         flavor,
+        #         num_workers,
+        #         verbose,
+        #     )
+        if missing_attachments:
+            if backend is None:
+                backend = lookup_backend(db.name, version)
+            _get_attachments_from_backend_(
+                db,
+                missing_attachments,
+                db_root,
+                deps,
+                backend,
+                num_workers,
+                verbose,
+            )
+
+    return cached_versions
 
 
 def _load_files(
@@ -911,11 +1047,9 @@ def load(
             db_is_complete = _database_is_complete(db)
 
             # load attachments
-            requested_attachment_files = deps.attachment_files
             if not db_is_complete:
-                cached_versions = _load_files(
-                    requested_attachment_files,
-                    'attachment',
+                cached_versions = _load_attachments(
+                    db.attachments,
                     backend,
                     db_root,
                     db,
@@ -1056,7 +1190,7 @@ def load_attachment(
         verbose: show debug messages
 
     Returns:
-        list of attachment file paths
+        list of file paths belonging to attachment
 
     Raises:
         ValueError: if an attachment ID is requested
@@ -1088,16 +1222,8 @@ def load_attachment(
         cache_root=cache_root,
         verbose=verbose,
     )
-    # We use single archive per attachment ID,
-    # so we can infer the files that belong
-    # to an attachment from the archive name
-    attachment_files = list(
-        deps._df[
-            deps._df['archive'] == attachment
-        ].index
-    )
 
-    if not attachment_files:
+    if not attachment in deps.archives:
         msg = error_message_missing_object(
             'attachment',
             [attachment],
@@ -1115,10 +1241,9 @@ def load_attachment(
             version,
         )
 
-        # Load attachments
-        _load_files(
-            attachment_files,
-            'attachment',
+        # Load attachment
+        _load_attachments(
+            [attachment],
             backend,
             db_root,
             db,
@@ -1131,10 +1256,8 @@ def load_attachment(
             verbose,
         )
 
-        attachment_files = [
-            audeer.path(db_root, os.path.normpath(a))
-            for a in attachment_files
-        ]
+    attachment_files = db.attachments[attachment].files
+    attachment_files = [audeer.path(db_root, a) for a in attachment_files]
 
     return attachment_files
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -26,7 +26,7 @@ def _find_attachments(
 
     attachments = []
 
-    for file in deps.attachment_paths:
+    for file in deps.attachments:
         full_file = os.path.join(db_root, file)
         if not os.path.exists(full_file):
             attachments.append(file)
@@ -308,7 +308,7 @@ def load_to(
     )
     if update:
         if only_metadata:
-            files = deps.attachment_paths + deps.tables
+            files = deps.attachments + deps.tables
         else:
             files = deps.files
         for file in files:

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -316,7 +316,10 @@ def load_to(
             if os.path.exists(full_file):
                 checksum = utils.md5(full_file)
                 if checksum != deps.checksum(file):
-                    audeer.rmdir(full_file)
+                    if os.path.isdir(full_file):
+                        audeer.rmdir(full_file)
+                    else:
+                        os.remove(full_file)
 
     # load database header without tables from backend
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -18,30 +18,20 @@ from audb.core.load import (
 )
 
 
-def _find_attachment_files(
+def _find_attachments(
         db_root: str,
         deps: Dependencies,
-        num_workers: typing.Optional[int],
-        verbose: bool,
 ) -> typing.List[str]:
-    r"""Find altered and new attachment files."""
+    r"""Find missing attachments."""
 
-    attachment_files = []
+    attachments = []
 
-    def job(file: str):
+    for file in deps.attachment_paths:
         full_file = os.path.join(db_root, file)
         if not os.path.exists(full_file):
-            attachment_files.append(file)
+            attachments.append(file)
 
-    audeer.run_tasks(
-        job,
-        params=[([file], {}) for file in deps.attachment_files],
-        num_workers=num_workers,
-        progress_bar=verbose,
-        task_description='Find attachments',
-    )
-
-    return attachment_files
+    return attachments
 
 
 def _find_media(
@@ -106,8 +96,8 @@ def _find_tables(
     return tables
 
 
-def _get_attachment_files(
-        attachment_files: typing.List[str],
+def _get_attachments(
+        paths: typing.Sequence[str],
         db_root: str,
         db_root_tmp: str,
         db_name: str,
@@ -116,44 +106,40 @@ def _get_attachment_files(
         num_workers: typing.Optional[int],
         verbose: bool,
 ):
+    r"""Load attachments from backend."""
 
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
-    utils.mkdir_tree(attachment_files, db_root)
-    utils.mkdir_tree(attachment_files, db_root_tmp)
+    utils.mkdir_tree(paths, db_root)
+    utils.mkdir_tree(paths, db_root_tmp)
 
-    # find needed archives
-    archives = set()
-    for file in attachment_files:
-        archives.add((deps.archive(file), deps.version(file)))
-
-    def job(archive: str, version: str):
+    def job(path: str):
+        archive = deps.archive(path)
+        version = deps.version(path)
         archive = backend.join(
             db_name,
             define.DEPEND_TYPE_NAMES[define.DependType.ATTACHMENT],
             archive,
         )
-        files = backend.get_archive(
+        backend.get_archive(
             archive,
             db_root_tmp,
             version,
             tmp_root=db_root_tmp,
         )
-        for file in files:
-            if file in attachment_files:
-                audeer.move_file(
-                    os.path.join(db_root_tmp, file),
-                    os.path.join(db_root, file),
-                )
-            else:
-                os.remove(os.path.join(db_root_tmp, file))
+        src_path = audeer.path(db_root_tmp, path)
+        dst_path = audeer.path(db_root, path)
+        audeer.move_file(
+            src_path,
+            dst_path,
+        )
 
     audeer.run_tasks(
         job,
-        params=[([archive, version], {}) for archive, version in archives],
+        params=[([path], {}) for path in paths],
         num_workers=num_workers,
         progress_bar=verbose,
-        task_description='Get attachments',
+        task_description='Load attachments',
     )
 
 
@@ -222,7 +208,7 @@ def _get_tables(
         # If a pickled version of the table exists,
         # we have to remove it to make sure that
         # later on the new CSV tables are loaded.
-        # This can happen if we upgrading an existing
+        # This can happen if we upgrade an existing
         # database to a different version.
         path_pkl = os.path.join(
             db_root, table
@@ -330,7 +316,22 @@ def load_to(
             if os.path.exists(full_file):
                 checksum = utils.md5(full_file)
                 if checksum != deps.checksum(file):
-                    os.remove(full_file)
+                    if os.path.isdir(full_file):
+                        for f in audeer.list_file_names(
+                            full_file,
+                            recursive=True,
+                            hidden=True,
+                        ):
+                            os.remove(f)
+                        for d in audeer.list_dir_names(
+                            full_file,
+                            recursive=True,
+                            hidden=True,
+                        ):
+                            os.rmdir(d)
+                        os.rmdir(full_file)
+                    else:
+                        os.remove(full_file)
 
     # load database header without tables from backend
 
@@ -342,12 +343,20 @@ def load_to(
     )
     db_header.save(db_root_tmp, header_only=True)
 
-    # get altered and new attachment files
-
-    attachment_files = _find_attachment_files(db_root, deps, num_workers,
-                                              verbose)
-    _get_attachment_files(attachment_files, db_root, db_root_tmp, name, deps,
-                          backend, num_workers, verbose)
+    attachments = _find_attachments(
+        db_root,
+        deps,
+    )
+    _get_attachments(
+        attachments,
+        db_root,
+        db_root_tmp,
+        name,
+        deps,
+        backend,
+        num_workers,
+        verbose,
+    )
 
     # get altered and new tables
 
@@ -372,6 +381,7 @@ def load_to(
         # make sure to remove header if user interrupts
         os.remove(os.path.join(db_root, define.HEADER_FILE))
         raise
+
     # afterwards remove header to avoid the database
     # can be loaded before download is complete
     os.remove(os.path.join(db_root, define.HEADER_FILE))

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -322,13 +322,13 @@ def load_to(
     )
     if update:
         if only_metadata:
-            files = deps.attachment_files + deps.tables
+            files = deps.attachment_paths + deps.tables
         else:
             files = deps.files
         for file in files:
             full_file = os.path.join(db_root, file)
             if os.path.exists(full_file):
-                checksum = audbackend.md5(full_file)
+                checksum = utils.md5(full_file)
                 if checksum != deps.checksum(file):
                     os.remove(full_file)
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -316,22 +316,7 @@ def load_to(
             if os.path.exists(full_file):
                 checksum = utils.md5(full_file)
                 if checksum != deps.checksum(file):
-                    if os.path.isdir(full_file):
-                        for f in audeer.list_file_names(
-                            full_file,
-                            recursive=True,
-                            hidden=True,
-                        ):
-                            os.remove(f)
-                        for d in audeer.list_dir_names(
-                            full_file,
-                            recursive=True,
-                            hidden=True,
-                        ):
-                            os.rmdir(d)
-                        os.rmdir(full_file)
-                    else:
-                        os.remove(full_file)
+                    audeer.rmdir(full_file)
 
     # load database header without tables from backend
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -79,19 +79,16 @@ def _find_attachments(
     r"""Find altered, new or removed attachments and update 'deps'."""
 
     for attachment_id in deps.attachment_ids:
-        if not attachment_id in db.attachments:
+        if attachment_id not in db.attachments:
             path = deps._df.index[deps._df.archive == attachment_id][0]
             deps._drop(path)
 
     db_files = list(db.files) + [f'db.{t}.csv' for t in db.tables]
 
     # check attachments are valid
-    db_attachment_files = []
     for attachment_id in db.attachments:
 
         path = db.attachments[attachment_id].path
-
-        # TODO: makes 'type-has-changed-error' obsolete?
         for file in db_files:
             if file.startswith(path):
                 raise RuntimeError(
@@ -128,7 +125,6 @@ def _find_attachments(
                 "points to an empty folder."
             )
 
-
     # add dependencies to new or updated attachments
     attachment_ids = []
     for attachment_id in audeer.progress_bar(
@@ -139,7 +135,7 @@ def _find_attachments(
         # use one archive per attachment ID
         path = db.attachments[attachment_id].path
         checksum = utils.md5(audeer.path(db_root, path))
-        if not path in deps or checksum != deps.checksum(path):
+        if path not in deps or checksum != deps.checksum(path):
             deps._add_attachment(
                 file=path,
                 version=version,

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -16,30 +16,6 @@ from audb.core.dependencies import Dependencies
 from audb.core.repository import Repository
 
 
-def _assert_file_type_does_not_change(
-        deps: Dependencies,
-        file: str,
-        type: int,
-):
-    if file in deps and deps.type(file) != type:
-        error_msg = (
-            f"The type of an existing dependency must not change, "
-            f"but you are trying to change the type of the dependency "
-            f"'{file}'. "
-        )
-        if define.DependType.META in [deps.type(file), type]:
-            error_msg += (
-                'You might have a naming clash between a table '
-                'and an attached file.'
-            )
-        else:
-            error_msg += (
-                'You might have a naming clash between a media file '
-                'and an attached file.'
-            )
-        raise RuntimeError(error_msg)
-
-
 def _check_for_duplicates(
         db: audformat.Database,
         num_workers: int,
@@ -172,25 +148,6 @@ def _find_attachments(
             )
             attachment_ids.append(attachment_id)
 
-        #
-        # for file in db.attachments[attachment_id].files:
-        #     _assert_file_type_does_not_change(
-        #         deps,
-        #         file,
-        #         define.DependType.ATTACHMENT,
-        #     )
-        #     checksum = audbackend.md5(audeer.path(db_root, file))
-        #     if file not in deps or checksum != deps.checksum(file):
-        #         attachments.add(attachment_id)
-        #     # update version number for all files in archive
-        #     if attachment_id in attachments:
-        #         deps._add_attachment_file(
-        #             file=file,
-        #             version=version,
-        #             archive=attachment_id,
-        #             checksum=checksum,
-        #         )
-
     return list(attachment_ids)
 
 
@@ -237,11 +194,6 @@ def _find_media(
             )
             add_media.append(values)
         elif not deps.removed(file):
-            _assert_file_type_does_not_change(
-                deps,
-                file,
-                define.DependType.MEDIA,
-            )
             checksum = audbackend.md5(path)
             if checksum != deps.checksum(file):
                 archive = deps.archive(file)
@@ -298,7 +250,6 @@ def _find_tables(
             disable=not verbose,
     ):
         file = f'db.{table}.csv'
-        _assert_file_type_does_not_change(deps, file, define.DependType.META)
         checksum = audbackend.md5(os.path.join(db_root, file))
         if file not in deps or checksum != deps.checksum(file):
             deps._add_meta(file, version, table, checksum)

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -83,9 +83,8 @@ def _find_attachments(
             path = deps._df.index[deps._df.archive == attachment_id][0]
             deps._drop(path)
 
-    db_files = list(db.files) + [f'db.{t}.csv' for t in db.tables]
-
     # check attachments are valid
+    db_files = list(db.files) + [f'db.{t}.csv' for t in db.tables]
     for attachment_id in db.attachments:
 
         path = db.attachments[attachment_id].path

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -69,7 +69,7 @@ def md5(
     for file in files:
         # encode file name that renaming of files
         # produces different checksum
-        hasher.update(file.encode())
+        hasher.update(file.replace(os.path.sep, '/').encode())
         with open(audeer.path(path, file), 'rb') as fp:
             for chunk in md5_read_chunk(fp, chunk_size):
                 hasher.update(chunk)

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -1,4 +1,3 @@
-import errno
 import hashlib
 import os
 import typing
@@ -56,22 +55,22 @@ def md5(
     r"""Create MD5 checksum of file or folder."""
     path = audeer.path(path)
 
-    if not os.path.exists(path):
-        raise FileNotFoundError(
-            errno.ENOENT,
-            os.strerror(errno.ENOENT),
-            path,
-        )
+    if not os.path.isdir(path):
+        return audbackend.md5(path)
 
     files = audeer.list_file_names(
         audeer.path(path),
         recursive=True,
         hidden=True,
+        basenames=True,
     )
 
     hasher = hashlib.md5()
     for file in files:
-        with open(file, 'rb') as fp:
+        # encode file name that renaming of files
+        # produces different checksum
+        hasher.update(file.encode())
+        with open(audeer.path(path, file), 'rb') as fp:
             for chunk in md5_read_chunk(fp, chunk_size):
                 hasher.update(chunk)
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -393,8 +393,6 @@ def test_load(format, version):
 )
 def test_load_attachment(version, attachment_id):
 
-    deps = audb.dependencies(DB_NAME, version=version)
-
     db = audb.load(
         DB_NAME,
         version=version,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -339,14 +339,14 @@ def test_load(format, version):
 
     deps = audb.dependencies(DB_NAME, version=version)
     assert str(deps().to_string()) == str(deps)
-    attachment_files = audeer.flatten_list(
-        [attachment.files for _, attachment in db.attachments.items()]
-    )
     assert len(deps) == (
         len(db.files)
         + len(db.tables)
         + len(db.misc_tables)
-        + len(attachment_files)
+        + len(db.attachments)
+    )
+    attachment_files = audeer.flatten_list(
+        [attachment.files for _, attachment in db.attachments.items()]
     )
     for attachment_file in attachment_files:
         assert os.path.exists(audeer.path(db.root, attachment_file))
@@ -395,10 +395,10 @@ def test_load_attachment(version, attachment_id):
 
     deps = audb.dependencies(DB_NAME, version=version)
 
-    expected_attachment_files = list(
-        deps._df[
-            deps._df['archive'] == attachment_id
-        ].index
+    db = audb.load(
+        DB_NAME,
+        version=version,
+        verbose=False,
     )
 
     paths = audb.load_attachment(
@@ -410,6 +410,7 @@ def test_load_attachment(version, attachment_id):
 
     if version is None:
         version = audb.latest_version(DB_NAME)
+
     expected_paths = [
         os.path.join(
             pytest.CACHE_ROOT,
@@ -417,7 +418,7 @@ def test_load_attachment(version, attachment_id):
             version,
             os.path.normpath(file),
         )
-        for file in expected_attachment_files
+        for file in db.attachments[attachment_id].files
     ]
     assert paths == expected_paths
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -420,7 +420,7 @@ def test_publish(version):
         assert archive in deps.archives
 
     # Check checksums of attachment files
-    for path in deps.attachment_paths:
+    for path in deps.attachments:
         expected_checksum = audb.core.utils.md5(audeer.path(db.root, path))
         assert deps.checksum(path) == expected_checksum
 
@@ -585,23 +585,23 @@ def test_publish_attachment(tmpdir):
             '1.0.0',
             '2.0.0',
             [],
-            ['extra/folder/file2.txt'],
+            [os.path.join('extra', 'folder', 'file2.txt')],
         ),
         (
             '2.0.0',
             '1.0.0',
             [LONG_PATH],
-            ['extra/folder/file3.txt'],
+            [os.path.join('extra', 'folder', 'file3.txt')],
         ),
         (
             '2.0.0',
             '3.0.0',
             ['audio/001.wav'],
             [
-                'extra/file.txt',
-                'extra/folder/file1.txt',
-                'extra/folder/file3.txt',
-                'extra/folder/sub-folder/file3.txt',
+                os.path.join('extra', 'file.txt'),
+                os.path.join('extra', 'folder', 'file1.txt'),
+                os.path.join('extra', 'folder', 'file3.txt'),
+                os.path.join('extra', 'folder', 'sub-folder', 'file3.txt'),
             ],
         ),
         (
@@ -615,10 +615,10 @@ def test_publish_attachment(tmpdir):
             '3.0.0',
             ['audio/001.wav'],
             [
-                'extra/file.txt',
-                'extra/folder/file1.txt',
-                'extra/folder/file2.txt',
-                'extra/folder/sub-folder/file3.txt',
+                os.path.join('extra', 'file.txt'),
+                os.path.join('extra', 'folder', 'file1.txt'),
+                os.path.join('extra', 'folder', 'file2.txt'),
+                os.path.join('extra', 'folder', 'sub-folder', 'file3.txt'),
             ],
         ),
         (
@@ -644,7 +644,7 @@ def test_publish_changed_db(
     assert media1 - media2 == set(media_difference)
 
     attachment1 = []
-    for path in depend1.attachment_paths:
+    for path in depend1.attachments:
         root = DB_ROOT_VERSION[version1]
         files = audeer.list_file_names(
             audeer.path(root, path),
@@ -655,7 +655,7 @@ def test_publish_changed_db(
         attachment1.extend(files)
 
     attachment2 = []
-    for path in depend2.attachment_paths:
+    for path in depend2.attachments:
         root = DB_ROOT_VERSION[version2]
         files = audeer.list_file_names(
             audeer.path(root, path),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,11 +12,11 @@ import audb
     [
         (
             ['f', os.path.join('sub', 'f')],
-            'b7a818f20a169f8e903408706fdbb2cb',
+            'b540f38948f445622adc657a757f4b0d',
         ),
         (
             ['f', os.path.join('sub', 'g')],
-            '234b7950b37a3ff61d4d422233c65347',
+            '305107efbb15f9334d22ae4fbeec4de6',
         ),
         (
             ['ä', 'ö', 'ü', 'ß'],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+import os
+
+import pytest
+
+import audeer
+
+import audb
+
+
+@pytest.mark.parametrize(
+    'files, expected',
+    [
+        (
+            ['f', os.path.join('sub', 'f')],
+            'b7a818f20a169f8e903408706fdbb2cb',
+        ),
+        (
+            ['f', os.path.join('sub', 'g')],
+            '234b7950b37a3ff61d4d422233c65347',
+        ),
+        (
+            ['ä', 'ö', 'ü', 'ß'],
+            '622165ad36122984c6b2c7ba466aa262',
+        ),
+    ]
+)
+def test_md5(tmpdir, files, expected):
+
+    root = tmpdir
+
+    for file in files:
+        path = audeer.path(root, file)
+        audeer.mkdir(os.path.dirname(path))
+        audeer.touch(path)
+
+    assert audb.core.utils.md5(root) == expected


### PR DESCRIPTION
Closes #275 

As discussed in #275 it is sufficient to store the path of the attachment in the dependency file. This applies the necessary changes.

This basically changes the entry for an attached folder `path/to/folder` with ID `attachment` and the files `path/to/folder/f1.txt` and `path/to/folder/sub/f2.txt` from:

```
                          archive    ...
path/to/folder/f1.txt     attachment ...
path/to/folder/sub/f2.txt attachment ...
```

to:

```
               archive    ...
path/to/folder attachment ...
```

In addition, `audb.Dependencies.attachment_files` is removed and instead `audb.Dependencies.attachment_ids` and `audb.Dependencies.attachments` are added.

I will leave some comments in the code to make it easier to follow the changes.