### PR TITLE
DOC: more explicit return types in audb.info

### DIFF
--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -18,7 +18,7 @@ def attachments(
         *,
         version: str = None,
         cache_root: str = None,
-) -> typing.Dict:
+) -> typing.Dict[str, audformat.Attachment]:
     """Attachment(s) of database.
 
     Args:
@@ -422,7 +422,7 @@ def media(
         *,
         version: str = None,
         cache_root: str = None,
-) -> typing.Dict:
+) -> typing.Dict[str, audformat.Media]:
     """Audio and video media of database.
 
     Args:
@@ -486,7 +486,7 @@ def misc_tables(
         *,
         version: str = None,
         cache_root: str = None,
-) -> typing.Dict:
+) -> typing.Dict[str, audformat.MiscTable]:
     """Miscellaneous tables of database.
 
     Args:
@@ -548,7 +548,7 @@ def raters(
         *,
         version: str = None,
         cache_root: str = None,
-) -> typing.Dict:
+) -> typing.Dict[str, audformat.Rater]:
     """Raters contributed to database.
 
     Args:
@@ -617,7 +617,7 @@ def schemes(
         version: str = None,
         load_tables: bool = True,
         cache_root: str = None,
-) -> typing.Dict:
+) -> typing.Dict[str, audformat.Scheme]:
     """Schemes of database.
 
     Args:
@@ -682,7 +682,7 @@ def splits(
         *,
         version: str = None,
         cache_root: str = None,
-) -> typing.Dict:
+) -> typing.Dict[str, audformat.Split]:
     """Splits of database.
 
     Args:
@@ -716,7 +716,7 @@ def tables(
         *,
         version: str = None,
         cache_root: str = None,
-) -> typing.Dict:
+) -> typing.Dict[str, audformat.Table]:
     """Tables of database.
 
     Args:


### PR DESCRIPTION
Closes #281 

This updates return types in the `audb.info` module that were stating `typing.Dict` but are returning `typing.Dict[str, audformat.*]` like `typing.Dict[str, audformat.Table]`.
The types are updated for:

* `audb.info.attachments()`
* `audb.info.media()`
* `audb.info.misc_tables()`
* `audb.info.raters()`
* `audb.info.schemes()`
* `audb.info.splits()`
* `audb.info.tables()`

They were not updated for `audb.info.meta()`.

E.g.

![image](https://user-images.githubusercontent.com/173624/231420398-aee53064-85cf-4d2f-9467-861ab6849ef3.png)
