### PR TITLE
only_metadata=True will not load attachment files

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -883,7 +883,7 @@ def load(
     Args:
         name: name of database
         version: version string, latest if ``None``
-        only_metadata: load only metadata
+        only_metadata: load only header and tables of database
         bit_depth: bit depth, one of ``16``, ``24``, ``32``
         channels: channel selection, see :func:`audresample.remix`.
             Note that media files with too few channels

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -977,7 +977,7 @@ def load(
             db_is_complete = _database_is_complete(db)
 
             # load attachments
-            if not db_is_complete:
+            if not db_is_complete and not only_metadata:
                 cached_versions = _load_attachments(
                     db.attachments,
                     backend,

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -308,9 +308,9 @@ def load_to(
     )
     if update:
         if only_metadata:
-            files = deps.attachments + deps.tables
+            files = deps.tables
         else:
-            files = deps.files
+            files = deps.attachments + deps.files
         for file in files:
             full_file = os.path.join(db_root, file)
             if os.path.exists(full_file):
@@ -331,20 +331,23 @@ def load_to(
     )
     db_header.save(db_root_tmp, header_only=True)
 
-    attachments = _find_attachments(
-        db_root,
-        deps,
-    )
-    _get_attachments(
-        attachments,
-        db_root,
-        db_root_tmp,
-        name,
-        deps,
-        backend,
-        num_workers,
-        verbose,
-    )
+    # get altered and new attachments
+
+    if not only_metadata:
+        attachments = _find_attachments(
+            db_root,
+            deps,
+        )
+        _get_attachments(
+            attachments,
+            db_root,
+            db_root_tmp,
+            name,
+            deps,
+            backend,
+            num_workers,
+            verbose,
+        )
 
     # get altered and new tables
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -277,7 +277,7 @@ def load_to(
         root: target directory
         name: name of database
         version: version string, latest if ``None``
-        only_metadata: load only metadata
+        only_metadata: load only header and tables of database
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used.
             Only used to read the dependencies of the requested version

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -352,11 +352,16 @@ def test_load(format, version, only_metadata):
             db[table].df,
         )
 
-    # Assert attachments are identical and files exist
+    # Assert attachments are identical and files do (not) exist
     assert db.attachments == db_original.attachments
     for attachment in db.attachments:
-        for attachment_file in db.attachments[attachment].files:
-            assert os.path.exists(audeer.path(db.root, attachment_file))
+        path = audeer.path(db.root, db.attachments[attachment].path)
+        if only_metadata:
+            assert not os.path.exists(path)
+        else:
+            assert os.path.exists(path)
+            for attachment_file in db.attachments[attachment].files:
+                assert os.path.exists(audeer.path(db.root, attachment_file))
 
     # Assert all files are listed in dependency table
     deps = audb.dependencies(DB_NAME, version=version)
@@ -400,10 +405,15 @@ def test_load(format, version, only_metadata):
     for table in db:
         assert os.path.exists(os.path.join(db_root, f'db.{table}.csv'))
 
-    # Assert attachments files exist
+    # Assert attachments files do (not) exist
     for attachment in db.attachments:
-        for attachment_file in db.attachments[attachment].files:
-            assert os.path.exists(audeer.path(db.root, attachment_file))
+        path = audeer.path(db.root, db.attachments[attachment].path)
+        if only_metadata:
+            assert not os.path.exists(path)
+        else:
+            assert os.path.exists(path)
+            for attachment_file in db.attachments[attachment].files:
+                assert os.path.exists(audeer.path(db.root, attachment_file))
 
 
 @pytest.mark.parametrize(
@@ -675,8 +685,13 @@ def test_load_to(version, only_metadata):
     # Assert attachments are identical and files exist
     assert db.attachments == db_original.attachments
     for attachment in db.attachments:
-        for attachment_file in db.attachments[attachment].files:
-            assert os.path.exists(os.path.join(db_root, attachment_file))
+        path = audeer.path(db.root, db.attachments[attachment].path)
+        if only_metadata:
+            assert not os.path.exists(path)
+        else:
+            assert os.path.exists(path)
+            for attachment_file in db.attachments[attachment].files:
+                assert os.path.exists(audeer.path(db.root, attachment_file))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -312,10 +312,7 @@ def test_load(format, version, only_metadata):
     db_root = db.meta['audb']['root']
 
     # Load original database from folder (expected database)
-    if version is None:
-        resolved_version = audb.latest_version(DB_NAME)
-    else:
-        resolved_version = version
+    resolved_version = version or audb.latest_version(DB_NAME)
     db_original = audformat.Database.load(DB_ROOT_VERSION[resolved_version])
     if format is not None:
         db_original.map_files(
@@ -662,9 +659,8 @@ def test_load_to(version, only_metadata):
     assert db.root == db_root
 
     # Load original database from folder (expected database)
-    if version is None:
-        version = audb.latest_version(DB_NAME)
-    db_original = audformat.Database.load(DB_ROOT_VERSION[version])
+    resolved_version = version or audb.latest_version(DB_NAME)
+    db_original = audformat.Database.load(DB_ROOT_VERSION[resolved_version])
 
     # Assert media files are identical and do (not) exist
     pd.testing.assert_index_equal(db.files, db_original.files)


### PR DESCRIPTION
Closes #284 

This changes the behavior of `only_metadata=True` in `audb.load()` and `audb.load_to()` and downloads no longer any attachment files.

The most notable change happens when you want to update a database.
Let's assume you published the first version with a single attachment pointing to `extra/` as path and containing the files `extra/f1.txt` and `extra/f2.txt`. If you use `audb.load_to(..., only_metadata=True)` and you create a file `extra/f3.txt` 
it will then when executing `audb.publish()` replace the attachment files `extra/f1.txt` and `extra/f2.txt` with `extra/f3.txt`.
The same holds if you create `extra/f2.txt` with a different content then the original file.

![image](https://user-images.githubusercontent.com/173624/232740151-8c2c3b4e-34c4-442d-a3a4-b1ab6f7430c7.png)
