### PR TITLE
Add attachments argument to audb.load()

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -608,12 +608,13 @@ def filter_deps(
             matching the regular expression
             or provided in the list
         available_deps: sequence of available media files or tables
-        deps_type: ``'media'`` or ``'table'``
+        deps_type: ``'attachment'``, ``'media'`` or ``'table'``
         database_name: name of affected database
         database_version: name of affected database
 
     Returns:
-        list of media or tables inside the dependency object
+        list of attachments, media or tables
+            inside the dependency object
             matching ``requested_deps``
 
     """

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -325,8 +325,6 @@ def _get_attachments_from_backend(
         src_path = audeer.path(db_root_tmp, path)
         dst_path = audeer.path(db_root, path)
         audeer.mkdir(os.path.dirname(dst_path))
-        print(f'{os.path.exists(src_path)=}')
-        print(f'{os.path.exists(dst_path)=}')
         if not os.path.isdir(src_path):
             audeer.move_file(
                 src_path,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -904,23 +904,25 @@ def load(
             matching the regular expression
             or provided in the list.
             If set to ``[]`` no attachments are loaded
-        tables: include only tables
+        tables: load only tables and misc tables
             matching the regular expression
             or provided in the list.
-            It will also limit possible media files
-            to those listed in the selected tables.
-            If ``[]`` is provided
-            only misc tables
-            used as labels in a scheme
-            and no media files are loaded
-        media: include only media files
+            Media files not referenced
+            in the selected tables
+            are automatically excluded, too.
+            If set to ``[]`` 
+            no tables and media files are loaded.
+            Misc tables used in schemes are always loaded
+        media: load only media files
             matching the regular expression
             or provided in the list.
-            The entries for non-matching media files
-            will be removed from tables
-            resulting in potentially empty tables.
-            If ``[]`` is provided
+            Excluded media files are 
+            automatically removed from the tables, too.
+            This may result in empty tables.
+            If set to ``[]``
             no media files are loaded
+            and all tables except
+            misc tables will be empty
         removed_media: keep rows that reference removed media
         full_path: replace relative with absolute file paths
         cache_root: cache folder where databases are stored.

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -305,7 +305,6 @@ def _get_attachments_from_backend(
 
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
-    # utils.mkdir_tree(paths, db_root)
     utils.mkdir_tree(paths, db_root_tmp)
 
     def job(path: str):

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -306,7 +306,7 @@ def _get_attachments_from_backend(
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
     # utils.mkdir_tree(paths, db_root)
-    # utils.mkdir_tree(paths, db_root_tmp)
+    utils.mkdir_tree(paths, db_root_tmp)
 
     def job(path: str):
         archive = deps.archive(path)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -334,32 +334,7 @@ def _get_attachments_from_backend(
             # attachments can be folders
             # which cannot be moved by audeer.move_file()
             # under Windows
-            def move_folder(src_path, dst_path):
-                audeer.mkdir(dst_path)
-                files = audeer.list_file_names(
-                    src_path,
-                    recursive=False,
-                    hidden=True,
-                    basenames=True,
-                )
-                for file in files:
-                    audeer.move_file(
-                        audeer.path(src_path, file),
-                        audeer.path(dst_path, file),
-                    )
-                folders = audeer.list_dir_names(
-                    src_path,
-                    recursive=False,
-                    hidden=True,
-                    basenames=True,
-                )
-                for folder in folders:
-                    move_folder(
-                        audeer.path(src_path, folder),
-                        audeer.path(dst_path, folder),
-                    )
-
-            move_folder(src_path, dst_path)
+            shutil.move(src_path, dst_path)
 
     audeer.run_tasks(
         job,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -926,7 +926,7 @@ def load(
         database object
 
     Raises:
-        ValueError: if table or media is requested
+        ValueError: if attachment, table or media is requested
             that is not part of the database
         ValueError: if a non-supported ``bit_depth``,
             ``format``,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -904,10 +904,23 @@ def load(
             matching the regular expression
             or provided in the list.
             Use ``[]`` to not load any attachment files
-        tables: include only tables matching the regular expression or
-            provided in the list
-        media: include only media matching the regular expression or
-            provided in the list
+        tables: include only tables
+            matching the regular expression
+            or provided in the list.
+            It will also limit possible media files
+            to those listed in the selected tables.
+            If ``[]`` is provided
+            only misc tables
+            used as labels in a scheme
+            and no media files are loaded
+        media: include only media files
+            matching the regular expression
+            or provided in the list.
+            The entries for non-matching media files
+            will be removed from tables
+            resulting in potentially empty tables.
+            If ``[]`` is provided
+            no media files are loaded
         removed_media: keep rows that reference removed media
         full_path: replace relative with absolute file paths
         cache_root: cache folder where databases are stored.

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -325,10 +325,43 @@ def _get_attachments_from_backend(
         src_path = audeer.path(db_root_tmp, path)
         dst_path = audeer.path(db_root, path)
         audeer.mkdir(os.path.dirname(dst_path))
-        audeer.move_file(
-            src_path,
-            dst_path,
-        )
+        print(f'{os.path.exists(src_path)=}')
+        print(f'{os.path.exists(dst_path)=}')
+        if not os.path.isdir(src_path):
+            audeer.move_file(
+                src_path,
+                dst_path,
+            )
+        else:
+            # attachments can be folders
+            # which cannot be moved by audeer.move_file()
+            # under Windows
+            def move_folder(src_path, dst_path):
+                audeer.mkdir(dst_path)
+                files = audeer.list_file_names(
+                    src_path,
+                    recursive=False,
+                    hidden=True,
+                    basenames=True,
+                )
+                for file in files:
+                    audeer.move_file(
+                        audeer.path(src_path, file),
+                        audeer.path(dst_path, file),
+                    )
+                folders = audeer.list_dir_names(
+                    src_path,
+                    recursive=False,
+                    hidden=True,
+                    basenames=True,
+                )
+                for folder in folders:
+                    move_folder(
+                        audeer.path(src_path, folder),
+                        audeer.path(dst_path, folder),
+                    )
+
+            move_folder(src_path, dst_path)
 
     audeer.run_tasks(
         job,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -910,13 +910,13 @@ def load(
             Media files not referenced
             in the selected tables
             are automatically excluded, too.
-            If set to ``[]`` 
+            If set to ``[]``
             no tables and media files are loaded.
             Misc tables used in schemes are always loaded
         media: load only media files
             matching the regular expression
             or provided in the list.
-            Excluded media files are 
+            Excluded media files are
             automatically removed from the tables, too.
             This may result in empty tables.
             If set to ``[]``

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -305,8 +305,8 @@ def _get_attachments_from_backend(
 
     # create folder tree to avoid race condition
     # in os.makedirs when files are unpacked
-    utils.mkdir_tree(paths, db_root)
-    utils.mkdir_tree(paths, db_root_tmp)
+    # utils.mkdir_tree(paths, db_root)
+    # utils.mkdir_tree(paths, db_root_tmp)
 
     def job(path: str):
         archive = deps.archive(path)
@@ -325,16 +325,10 @@ def _get_attachments_from_backend(
         src_path = audeer.path(db_root_tmp, path)
         dst_path = audeer.path(db_root, path)
         audeer.mkdir(os.path.dirname(dst_path))
-        if not os.path.isdir(src_path):
-            audeer.move_file(
-                src_path,
-                dst_path,
-            )
-        else:
-            # attachments can be folders
-            # which cannot be moved by audeer.move_file()
-            # under Windows
-            shutil.move(src_path, dst_path)
+        audeer.move_file(
+            src_path,
+            dst_path,
+        )
 
     audeer.run_tasks(
         job,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -903,7 +903,7 @@ def load(
             for the attachments
             matching the regular expression
             or provided in the list.
-            Use ``[]`` to not load any attachment files
+            If set to ``[]`` no attachments are loaded
         tables: include only tables
             matching the regular expression
             or provided in the list.

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -852,6 +852,7 @@ def load(
         format: str = None,
         mixdown: bool = False,
         sampling_rate: int = None,
+        attachments: typing.Union[str, typing.Sequence[str]] = None,
         tables: typing.Union[str, typing.Sequence[str]] = None,
         media: typing.Union[str, typing.Sequence[str]] = None,
         removed_media: bool = False,
@@ -899,6 +900,11 @@ def load(
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
             ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
+        attachments: load only attachment files
+            for the attachments
+            matching the regular expression
+            or provided in the list.
+            Use ``[]`` to not load any attachment files
         tables: include only tables matching the regular expression or
             provided in the list
         media: include only media matching the regular expression or
@@ -981,8 +987,16 @@ def load(
 
             # load attachments
             if not db_is_complete and not only_metadata:
-                cached_versions = _load_attachments(
+
+                # filter attachments
+                requested_attachments = filter_deps(
+                    attachments,
                     db.attachments,
+                    'attachment',
+                )
+
+                cached_versions = _load_attachments(
+                    requested_attachments,
                     backend,
                     db_root,
                     db,

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -142,6 +142,13 @@ def test_load_only_metadata():
     pd.testing.assert_index_equal(db.files, db_original.files)
     assert not db.meta['audb']['complete']
 
+    flavor_path = audeer.path(
+        audb.default_cache_root(),
+        audb.flavor_path(DB_NAME, DB_VERSION),
+    )
+    print(f'{audeer.list_file_names(flavor_path)=}')
+    print(f'{audeer.list_dir_names(flavor_path)=}')
+
     # Load whole database
     db = audb.load(
         DB_NAME,

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -142,13 +142,6 @@ def test_load_only_metadata():
     pd.testing.assert_index_equal(db.files, db_original.files)
     assert not db.meta['audb']['complete']
 
-    flavor_path = audeer.path(
-        audb.default_cache_root(),
-        audb.flavor_path(DB_NAME, DB_VERSION),
-    )
-    print(f'{audeer.list_file_names(flavor_path)=}')
-    print(f'{audeer.list_dir_names(flavor_path)=}')
-
     # Load whole database
     db = audb.load(
         DB_NAME,


### PR DESCRIPTION
Closes #285 

This adds the `attachments` argument to `audb.load()` to filter for which attachments actual files should be loaded. `attachments=[]` does not load any file. This behavior is identical to `media=[]` and `tables=[]`, so I think we might not need an additional `load_attachments` argument.

![image](https://user-images.githubusercontent.com/173624/233057924-127da04f-898a-495f-a7d9-59164131fdc7.png)

[...]

![image](https://user-images.githubusercontent.com/173624/233271950-a9b4f82e-5b2d-44a9-a1b0-e4d8d92aa6f6.png)

[...]

![image](https://user-images.githubusercontent.com/173624/233058453-6739cf7b-8d6f-46f5-84ac-77b031848dd2.png)
