### PR TITLE
TST: use temp dirs provided by pytest

### DIFF
--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -26,5 +26,8 @@ def add_audb_with_public_data(doctest_namespace):
         ),
     ]
     doctest_namespace['audb'] = audb
+
     yield
-    audb.config.REPOSITORIES = pytest.REPOSITORIES
+
+    # Remove public repo
+    audb.config.REPOSITORIES.pop()

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -15,8 +15,19 @@ def cache(tmp_path_factory):
 
     """
     cache = tmp_path_factory.mktemp('cache').as_posix()
+    # We use the environment variable here
+    # to ensure audb.config.CACHE_ROOT
+    # does still return the default config value
+    # in the doctest
+    env_cache = os.environ.get('AUDB_CACHE_ROOT', None)
     os.environ['AUDB_CACHE_ROOT'] = cache
-    return cache
+
+    yield
+
+    if env_cache is None:
+        del os.environ['AUDB_CACHE_ROOT']
+    else:  # pragma: nocover
+        os.environ['AUDB_CACHE_ROOT'] = env_cache
 
 
 @pytest.fixture(autouse=True)

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -6,7 +6,7 @@ import audb
 
 
 @pytest.fixture(scope='package', autouse=True)
-def cache(tmp_path_factory):
+def cache(tmpdir_factory):
     r"""Provide a reuseable cache for docstring tests.
 
     As we rely on emodb from the public repo,
@@ -14,7 +14,7 @@ def cache(tmp_path_factory):
     across all docstring tests.
 
     """
-    cache = tmp_path_factory.mktemp('cache').as_posix()
+    cache = str(tmpdir_factory.mktemp('cache'))
     # We use the environment variable here
     # to ensure audb.config.CACHE_ROOT
     # does still return the default config value

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -20,7 +20,9 @@ def cache(tmpdir_factory):
     # does still return the default config value
     # in the doctest
     env_cache = os.environ.get('AUDB_CACHE_ROOT', None)
+    env_shared_cache = os.environ.get('AUDB_SHARED_CACHE_ROOT', None)
     os.environ['AUDB_CACHE_ROOT'] = str(cache)
+    os.environ['AUDB_SHARED_CACHE_ROOT'] = str(cache)
 
     yield
 
@@ -28,6 +30,11 @@ def cache(tmpdir_factory):
         del os.environ['AUDB_CACHE_ROOT']
     else:  # pragma: nocover
         os.environ['AUDB_CACHE_ROOT'] = env_cache
+
+    if env_shared_cache is None:
+        del os.environ['AUDB_SHARED_CACHE_ROOT']
+    else:  # pragma: nocover
+        os.environ['AUDB_SHARED_CACHE_ROOT'] = env_shared_cache
 
 
 @pytest.fixture(autouse=True)

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -7,6 +7,13 @@ import audb
 
 @pytest.fixture(scope='package', autouse=True)
 def cache(tmp_path_factory):
+    r"""Provide a reuseable cache for docstring tests.
+
+    As we rely on emodb from the public repo,
+    it makes sense to cache it
+    across all docstring tests.
+
+    """
     cache = tmp_path_factory.mktemp('cache').as_posix()
     os.environ['AUDB_CACHE_ROOT'] = cache
     return cache
@@ -27,10 +34,6 @@ def add_audb_with_public_data(doctest_namespace):
     as the code file where the docstring is defined.
 
     """
-    # cache = tmp_path / 'cache'
-    # cache.mkdir()
-    # cache = str(cache)
-    # os.environ['AUDB_CACHE_ROOT'] = cache
     audb.config.REPOSITORIES = [
         audb.Repository(
             name='data-public',

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -1,6 +1,15 @@
+import os
+
 import pytest
 
 import audb
+
+
+@pytest.fixture(scope='package', autouse=True)
+def cache(tmp_path_factory):
+    cache = tmp_path_factory.mktemp('cache').as_posix()
+    os.environ['AUDB_CACHE_ROOT'] = cache
+    return cache
 
 
 @pytest.fixture(autouse=True)
@@ -18,6 +27,10 @@ def add_audb_with_public_data(doctest_namespace):
     as the code file where the docstring is defined.
 
     """
+    # cache = tmp_path / 'cache'
+    # cache.mkdir()
+    # cache = str(cache)
+    # os.environ['AUDB_CACHE_ROOT'] = cache
     audb.config.REPOSITORIES = [
         audb.Repository(
             name='data-public',

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -31,7 +31,7 @@ def cache(tmpdir_factory):
 
 
 @pytest.fixture(autouse=True)
-def add_audb_with_public_data(doctest_namespace):
+def public_repository(doctest_namespace):
     r"""Provide access to the public Artifactory repository.
 
     Some tests in the docstrings need access to the emodb database.

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -14,13 +14,13 @@ def cache(tmpdir_factory):
     across all docstring tests.
 
     """
-    cache = str(tmpdir_factory.mktemp('cache'))
+    cache = tmpdir_factory.mktemp('cache')
     # We use the environment variable here
     # to ensure audb.config.CACHE_ROOT
     # does still return the default config value
     # in the doctest
     env_cache = os.environ.get('AUDB_CACHE_ROOT', None)
-    os.environ['AUDB_CACHE_ROOT'] = cache
+    os.environ['AUDB_CACHE_ROOT'] = str(cache)
 
     yield
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -99,20 +99,20 @@ def _cached_files(
                 if file in cache_deps:
                     if deps.checksum(file) == cache_deps.checksum(file):
                         path = os.path.join(cache_root, file)
-                        if flavor and flavor.format is not None:
-                            path = audeer.replace_file_extension(
-                                path,
-                                flavor.format,
-                            )
+                        # if flavor and flavor.format is not None:
+                        #     path = audeer.replace_file_extension(
+                        #         path,
+                        #         flavor.format,
+                        #     )
                         if os.path.exists(path):
                             found = True
                             break
         if found:
-            if flavor and flavor.format is not None:
-                file = audeer.replace_file_extension(
-                    file,
-                    flavor.format,
-                )
+            # if flavor and flavor.format is not None:
+            #     file = audeer.replace_file_extension(
+            #         file,
+            #         flavor.format,
+            #     )
             cached_files.append((cache_root, file))
         else:
             missing_files.append(file)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -99,20 +99,20 @@ def _cached_files(
                 if file in cache_deps:
                     if deps.checksum(file) == cache_deps.checksum(file):
                         path = os.path.join(cache_root, file)
-                        # if flavor and flavor.format is not None:
-                        #     path = audeer.replace_file_extension(
-                        #         path,
-                        #         flavor.format,
-                        #     )
+                        if flavor and flavor.format is not None:
+                            path = audeer.replace_file_extension(
+                                path,
+                                flavor.format,
+                            )
                         if os.path.exists(path):
                             found = True
                             break
         if found:
-            # if flavor and flavor.format is not None:
-            #     file = audeer.replace_file_extension(
-            #         file,
-            #         flavor.format,
-            #     )
+            if flavor and flavor.format is not None:
+                file = audeer.replace_file_extension(
+                    file,
+                    flavor.format,
+                )
             cached_files.append((cache_root, file))
         else:
             missing_files.append(file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,19 +45,15 @@ def cleanup_environment_variables():
 # A fresh tmp folder is used for each test.
 #
 @pytest.fixture(scope='function', autouse=True)
-def cache(tmp_path):
-    cache = tmp_path / 'cache'
-    cache.mkdir()
-    cache = str(cache)
+def cache(tmpdir):
+    cache = audeer.mkdir(audeer.path(tmpdir, 'cache'))
     audb.config.CACHE_ROOT = cache
     return cache
 
 
 @pytest.fixture(scope='function', autouse=True)
-def shared_cache(tmp_path):
-    cache = tmp_path / 'shared_cache'
-    cache.mkdir()
-    cache = str(cache)
+def shared_cache(tmpdir):
+    cache = audeer.mkdir(audeer.path(tmpdir, 'shared_cache'))
     audb.config.SHARED_CACHE_ROOT = cache
     return cache
 
@@ -72,8 +68,8 @@ def shared_cache(tmp_path):
 # across all tests in a module.
 #
 @pytest.fixture(scope='module', autouse=False)
-def persistent_repository(tmp_path_factory):
-    host = tmp_path_factory.mktemp('host').as_posix()
+def persistent_repository(tmpdir_factory):
+    host = str(tmpdir_factory.mktemp('host'))
     repository = audb.Repository(
         name='data-unittests-local',
         host=host,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,14 +92,15 @@ def hide_default_caches():
 
     """
     audb.config.CACHE_ROOT = None
-    audb.config.SHARED_CACHE_ROOT = None
+    # Don't clean audb.config.SHARED_CACHE_ROOT
+    # as it is set by shared_cache anyway
 
     env_cache = os.environ.get('AUDB_CACHE_ROOT', None)
     env_shared_cache = os.environ.get('AUDB_SHARED_CACHE_ROOT', None)
     if env_cache is not None:
         del os.environ['AUDB_CACHE_ROOT']
     if env_shared_cache is not None:
-        del os.environ['AUDB_SAHRED_CACHE_ROOT']
+        del os.environ['AUDB_SHARED_CACHE_ROOT']
 
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,6 @@ def cleanup_coverage_files():
 # for providing the cache to `audb`
 # as the config value is overwritten
 # by the audb config file
-
-
 @pytest.fixture(scope='function', autouse=True)
 def cache(tmp_path):
     cache = tmp_path / 'cache'
@@ -61,8 +59,6 @@ def shared_cache(tmp_path):
 # for each test,
 # the other fixture allows to reuse the same repository
 # across all tests in a module.
-
-
 @pytest.fixture(scope='module', autouse=False)
 def persistent_repository(tmp_path_factory):
     host = tmp_path_factory.mktemp('host').as_posix()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,5 +90,9 @@ def repository(tmpdir):
         host=audeer.path(tmpdir, 'host'),
         backend='file-system',
     )
-    audb.config.REPOSITORIES += [repository]
-    return repository
+    current_repositories = audb.config.REPOSITORIES
+    audb.config.REPOSITORIES = [repository]
+
+    yield repository
+
+    audb.config.REPOSITORIES = current_repositories

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,11 @@ def shared_cache(tmpdir):
 # the other fixture allows to reuse the same repository
 # across all tests in a module.
 #
+@pytest.fixture(scope='package', autouse=True)
+def hide_default_repository():
+    audb.config.REPOSITORIES = []
+
+
 @pytest.fixture(scope='module', autouse=False)
 def persistent_repository(tmpdir_factory):
     host = str(tmpdir_factory.mktemp('host'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,7 @@ def hide_default_caches():
     ``AUDB_CACHE_ROOT``
     and ``AUDB_SHARED_CACHE_ROOT``.
 
-    To ensure those will not interfer with the tests
+    To ensure those will not interfere with the tests
     we hide them when executing the tests.
 
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import audb
 import audeer
 
 
-pytest.ID = audeer.uid()
 pytest.NUM_WORKERS = 5
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import shutil
 
 import pytest
 
@@ -8,53 +7,41 @@ import audb
 import audeer
 
 
-pytest.ROOT = audeer.path(
-    os.path.dirname(os.path.realpath(__file__)),
-    'tmp',
-)
-
-pytest.BACKEND = 'file-system'
-pytest.FILE_SYSTEM_HOST = os.path.join(pytest.ROOT, 'repo')
 pytest.ID = audeer.uid()
 pytest.NUM_WORKERS = 5
-pytest.REPOSITORY_NAME = 'data-unittests-local'
 
 
 @pytest.fixture(scope='session', autouse=True)
-def cleanup_session():
+def cleanup_coverage_files():
     path = os.path.join(
-        pytest.ROOT,
-        '..',
+        os.path.dirname(os.path.realpath(__file__)),
         '.coverage.*',
     )
     for file in glob.glob(path):
         os.remove(file)
-    yield
-    if os.path.exists(pytest.ROOT):
-        shutil.rmtree(pytest.ROOT)
 
 
-@pytest.fixture(scope='module', autouse=False)
-def persistent_repository(tmp_path_factory):
-    host = tmp_path_factory.mktemp('host').as_posix()
-    repository = audb.Repository(
-        name=pytest.REPOSITORY_NAME,
-        host=host,
-        backend=pytest.BACKEND,
-    )
-    audb.config.REPOSITORIES = [repository]
-    return repository
+# === CACHE ===
+#
+# Provide two fixtures that create tmp folders
+# holding the cache and shared cache folder.
+# A fresh tmp folder is used for each test.
+#
+# We use `os.environ['AUDB_CACHE_ROOT']`
+# instead of `audb.config.CACHE`
+# for providing the cache to `audb`
+# as the config value is overwritten
+# by the audb config file
 
 
-@pytest.fixture(scope='function', autouse=False)
-def repository(tmpdir):
-    repository = audb.Repository(
-        name=pytest.REPOSITORY_NAME,
-        host=audeer.path(tmpdir, 'host'),
-        backend=pytest.BACKEND,
-    )
-    audb.config.REPOSITORIES += [repository]
-    return repository
+@pytest.fixture(scope='function', autouse=True)
+def cache(tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    cache = str(cache)
+    os.environ['AUDB_CACHE_ROOT'] = cache
+    audb.config.CACHE = cache
+    return cache
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -66,10 +53,34 @@ def shared_cache(tmp_path):
     return cache
 
 
-@pytest.fixture(scope='function', autouse=True)
-def cache(tmp_path):
-    cache = tmp_path / 'cache'
-    cache.mkdir()
-    cache = str(cache)
-    os.environ['AUDB_CACHE_ROOT'] = cache
-    return cache
+# === REPOSITORIES ===
+#
+# Provide two fixtures that create tmp folders
+# holding a repository on a file-system backend.
+# One fixture provides a fresh repository
+# for each test,
+# the other fixture allows to reuse the same repository
+# across all tests in a module.
+
+
+@pytest.fixture(scope='module', autouse=False)
+def persistent_repository(tmp_path_factory):
+    host = tmp_path_factory.mktemp('host').as_posix()
+    repository = audb.Repository(
+        name='data-unittests-local',
+        host=host,
+        backend='file-system',
+    )
+    audb.config.REPOSITORIES = [repository]
+    return repository
+
+
+@pytest.fixture(scope='function', autouse=False)
+def repository(tmpdir):
+    repository = audb.Repository(
+        name='data-unittests-local',
+        host=audeer.path(tmpdir, 'host'),
+        backend='file-system',
+    )
+    audb.config.REPOSITORIES += [repository]
+    return repository

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import audeer
 pytest.NUM_WORKERS = 5
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='package', autouse=True)
 def cleanup_coverage_files():
     path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -20,7 +20,7 @@ def cleanup_coverage_files():
         os.remove(file)
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='package', autouse=True)
 def cleanup_environment_variables():
     env_cache = os.environ.get('AUDB_CACHE_ROOT', None)
     env_shared_cache = os.environ.get('AUDB_SHARED_CACHE_ROOT', None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,31 @@ def cleanup_session():
     yield
     if os.path.exists(pytest.ROOT):
         shutil.rmtree(pytest.ROOT)
+
+
+@pytest.fixture(scope='module', autouse=False)
+def persistent_repository(tmp_path_factory):
+    host = tmp_path_factory.mktemp('host').as_posix()
+    repository = audb.Repository(
+        name=pytest.REPOSITORY_NAME,
+        host=host,
+        backend=pytest.BACKEND,
+    )
+    audb.config.REPOSITORIES = [repository]
+    return repository
+
+
+@pytest.fixture(scope='function', autouse=False)
+def repository(tmpdir):
+    repository = audb.Repository(
+        name=pytest.REPOSITORY_NAME,
+        host=audeer.path(tmpdir, 'host'),
+        backend=pytest.BACKEND,
+    )
+    audb.config.REPOSITORIES += [repository]
+    return repository
+
+
+@pytest.fixture(scope='function', autouse=False)
+def shared_cache(tmpdir):
+    return audeer.mkdir(tmpdir, 'cache')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,12 +14,10 @@ pytest.ROOT = audeer.path(
 )
 
 pytest.BACKEND = 'file-system'
-pytest.CACHE_ROOT = os.path.join(pytest.ROOT, 'cache')
 pytest.FILE_SYSTEM_HOST = os.path.join(pytest.ROOT, 'repo')
 pytest.ID = audeer.uid()
 pytest.NUM_WORKERS = 5
 pytest.REPOSITORY_NAME = 'data-unittests-local'
-pytest.SHARED_CACHE_ROOT = os.path.join(pytest.ROOT, 'shared')
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -59,6 +57,19 @@ def repository(tmpdir):
     return repository
 
 
-@pytest.fixture(scope='function', autouse=False)
-def shared_cache(tmpdir):
-    return audeer.mkdir(tmpdir, 'cache')
+@pytest.fixture(scope='function', autouse=True)
+def shared_cache(tmp_path):
+    cache = tmp_path / 'shared_cache'
+    cache.mkdir()
+    cache = str(cache)
+    os.environ['AUDB_SHARED_CACHE_ROOT'] = cache
+    return cache
+
+
+@pytest.fixture(scope='function', autouse=True)
+def cache(tmp_path):
+    cache = tmp_path / 'cache'
+    cache.mkdir()
+    cache = str(cache)
+    os.environ['AUDB_CACHE_ROOT'] = cache
+    return cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,14 +19,6 @@ pytest.FILE_SYSTEM_HOST = os.path.join(pytest.ROOT, 'repo')
 pytest.ID = audeer.uid()
 pytest.NUM_WORKERS = 5
 pytest.REPOSITORY_NAME = 'data-unittests-local'
-pytest.REPOSITORIES = [
-    audb.Repository(
-        name=pytest.REPOSITORY_NAME,
-        host=pytest.FILE_SYSTEM_HOST,
-        backend=pytest.BACKEND,
-    ),
-]
-pytest.PUBLISH_REPOSITORY = pytest.REPOSITORIES[0]
 pytest.SHARED_CACHE_ROOT = os.path.join(pytest.ROOT, 'shared')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def hide_default_repository():
 
 @pytest.fixture(scope='module', autouse=False)
 def persistent_repository(tmpdir_factory):
-    host = str(tmpdir_factory.mktemp('host'))
+    host = tmpdir_factory.mktemp('host')
     repository = audb.Repository(
         name='data-unittests-local',
         host=host,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,15 +79,20 @@ def persistent_repository(tmpdir_factory):
         host=host,
         backend='file-system',
     )
+    current_repositories = audb.config.REPOSITORIES
     audb.config.REPOSITORIES = [repository]
-    return repository
+
+    yield repository
+
+    audb.config.REPOSITORIES = current_repositories
 
 
 @pytest.fixture(scope='function', autouse=False)
-def repository(tmpdir):
+def repository(tmpdir_factory):
+    host = tmpdir_factory.mktemp('host')
     repository = audb.Repository(
         name='data-unittests-local',
-        host=audeer.path(tmpdir, 'host'),
+        host=host,
         backend='file-system',
     )
     current_repositories = audb.config.REPOSITORIES

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def shared_cache(tmpdir):
 # across all tests in a module.
 #
 @pytest.fixture(scope='package', autouse=True)
-def hide_default_repository():
+def hide_default_repositories():
     audb.config.REPOSITORIES = []
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,31 +1,21 @@
 import os
 
-import pytest
-
 import audb
 import audeer
 
 
-def test_available():
+def test_available(repository):
 
     # Non existing repo
     name = 'non-existing-repo'
-    audb.config.REPOSITORIES = [
-        audb.Repository(
-            name=name,
-            host=pytest.FILE_SYSTEM_HOST,
-            backend=pytest.BACKEND,
-        )
-    ]
     df = audb.available()
     assert len(df) == 0
 
-    # Borken database in repo
+    # Broken database in repo
     name = 'non-existing-database'
-    audb.config.REPOSITORIES = pytest.REPOSITORIES
     path = os.path.join(
-        audb.config.REPOSITORIES[0].host,
-        audb.config.REPOSITORIES[0].name,
+        repository.host,
+        repository.name,
         name,
     )
     path = audeer.mkdir(path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,9 +6,6 @@ import audeer
 
 def test_available(repository):
 
-    print(f'{repository=}')
-    print(f'{audb.config.REPOSITORIES=}')
-
     # Broken database in repo
     name = 'non-existing-database'
     path = os.path.join(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,10 +6,8 @@ import audeer
 
 def test_available(repository):
 
-    # Non existing repo
-    name = 'non-existing-repo'
-    df = audb.available()
-    assert len(df) == 0
+    print(f'{repository=}')
+    print(f'{audb.config.REPOSITORIES=}')
 
     # Broken database in repo
     name = 'non-existing-database'
@@ -19,6 +17,18 @@ def test_available(repository):
         name,
     )
     path = audeer.mkdir(path)
-    audb.available()
+    df = audb.available()
     os.rmdir(path)
+    assert len(df) == 0
+
+    # Non existing repo
+    name = 'non-existing-repo'
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name=name,
+            host=repository.host,
+            backend=repository.backend,
+        )
+    ]
+    df = audb.available()
     assert len(df) == 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -19,8 +19,6 @@ DB_NAMES = [
 )
 def publish_dbs(tmpdir_factory, persistent_repository):
 
-    db_root = str(tmpdir_factory.mktemp('db'))
-
     # create dbs
 
     for name in DB_NAMES:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,14 +17,14 @@ DB_NAMES = [
     scope='module',
     autouse=True,
 )
-def publish_dbs(tmp_path_factory, persistent_repository):
+def publish_dbs(tmpdir_factory, persistent_repository):
 
-    db_root = tmp_path_factory.mktemp('db').as_posix()
+    db_root = str(tmpdir_factory.mktemp('db'))
 
     # create dbs
 
     for name in DB_NAMES:
-        db_root = tmp_path_factory.mktemp(name).as_posix()
+        db_root = str(tmpdir_factory.mktemp(name))
         db = audformat.testing.create_db(minimal=True)
         db.name = name
         db['files'] = audformat.Table(audformat.filewise_index(['f1.wav']))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,12 +17,12 @@ DB_NAMES = [
     scope='module',
     autouse=True,
 )
-def publish_dbs(tmpdir_factory, persistent_repository):
+def dbs(tmpdir_factory, persistent_repository):
 
     # create dbs
 
     for name in DB_NAMES:
-        db_root = str(tmpdir_factory.mktemp(name))
+        db_root = tmpdir_factory.mktemp(name)
         db = audformat.testing.create_db(minimal=True)
         db.name = name
         db['files'] = audformat.Table(audformat.filewise_index(['f1.wav']))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,44 +2,91 @@ import os
 import pytest
 
 import audeer
+import audformat.testing
 
 import audb
 
 
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
+DB_NAMES = [
+    f'test_cache-{pytest.ID}-0',
+    f'test_cache-{pytest.ID}-1',
+]
 
 
-@pytest.mark.parametrize(
-    'shared, expected',
-    [
-        (False, audeer.path(pytest.CACHE_ROOT)),
-        (True, audeer.path(pytest.SHARED_CACHE_ROOT)),
-    ]
+@pytest.fixture(
+    scope='module',
+    autouse=True,
 )
-def test_cache_root(shared, expected):
-    assert audb.default_cache_root(shared=shared) == expected
+def publish_dbs(tmp_path_factory, persistent_repository):
+
+    db_root = tmp_path_factory.mktemp('db').as_posix()
+
+    # create dbs
+
+    for name in DB_NAMES:
+        db_root = tmp_path_factory.mktemp(name).as_posix()
+        db = audformat.testing.create_db(minimal=True)
+        db.name = name
+        db['files'] = audformat.Table(audformat.filewise_index(['f1.wav']))
+
+        db.save(db_root)
+        audformat.testing.create_audio_files(db)
+        audb.publish(
+            db_root,
+            '1.0.0',
+            persistent_repository,
+            verbose=False,
+        )
 
 
-def test_empty_shared_cache():
+@pytest.mark.parametrize('shared', [False, True])
+def test_cache_root(cache, shared_cache, shared):
+    if shared:
+        assert audb.default_cache_root(shared=shared) == shared_cache
+    else:
+        assert audb.default_cache_root(shared=shared) == cache
+
+
+def test_empty_shared_cache(shared_cache):
     # Handle non-existing cache folder
     # See https://github.com/audeering/audb/issues/125
-    assert not os.path.exists(audeer.path(pytest.SHARED_CACHE_ROOT))
+    audeer.rmdir(shared_cache)
+    assert not os.path.exists(shared_cache)
     df = audb.cached(shared=True)
     assert len(df) == 0
     # Handle empty shared cache folder
     # See https://github.com/audeering/audb/issues/126
-    audeer.mkdir(pytest.SHARED_CACHE_ROOT)
+    audeer.mkdir(shared_cache)
     df = audb.cached(shared=True)
     assert 'name' in df.columns
 
 
-def test_cached_name():
-    # Here we only have emodb available.
-    # A test using more published databases
-    # is executed in test_publish.py
-    df = audb.cached(name='emodb')
-    assert len(df) > 0
-    assert set(df['name']) == set(['emodb'])
+def test_cached_name(cache):
+    # Empty cache
+    df = audb.cached()
+    assert len(df) == 0
+    df = audb.cached(name=DB_NAMES[0])
+    assert len(df) == 0
+    # Load first database
+    audb.load(DB_NAMES[0])
+    df = audb.cached()
+    assert len(df) == 1
+    assert set(df['name']) == set([DB_NAMES[0]])
+    df = audb.cached(name=DB_NAMES[0])
+    assert len(df) == 1
+    assert set(df['name']) == set([DB_NAMES[0]])
+    df = audb.cached(name=DB_NAMES[1])
+    assert len(df) == 0
+    # Load second database
+    audb.load(DB_NAMES[1])
+    df = audb.cached()
+    assert len(df) == 2
+    assert set(df['name']) == set(DB_NAMES)
+    df = audb.cached(name=DB_NAMES[0])
+    assert len(df) == 1
+    assert set(df['name']) == set([DB_NAMES[0]])
+    df = audb.cached(name=DB_NAMES[1])
+    assert len(df) == 1
+    assert set(df['name']) == set([DB_NAMES[1]])
     df = audb.cached(name='non-existent')
     assert len(df) == 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,8 +8,8 @@ import audb
 
 
 DB_NAMES = [
-    f'test_cache-{pytest.ID}-0',
-    f'test_cache-{pytest.ID}-1',
+    'test_cache-0',
+    'test_cache-1',
 ]
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,7 +27,7 @@ def test_config_file(tmpdir):
     )
     global_config.update(config)
     assert global_config['cache_root'] == '~/user'
-    assert global_config['shared_cache_root'] == audb.config.SHARED_CACHE_ROOT
+    assert global_config['shared_cache_root'] == '/data/audb'
 
     # Fail for wrong repositories entries
     with open(config_file, 'w') as cf:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,16 +1,14 @@
-import os
-
 import pytest
 
 import audb
 import audeer
 
 
-def test_config_file():
+def test_config_file(tmpdir):
 
-    audeer.mkdir(pytest.ROOT)
+    root = audeer.mkdir(tmpdir)
 
-    config_file = os.path.join(pytest.ROOT, '.audb.yaml')
+    config_file = audeer.path(root, '.audb.yaml')
 
     # Try loading non-existing file
     config = audb.core.config.load_configuration_file(config_file)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,10 +9,6 @@ import audiofile
 import audb
 
 
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
-
-
 DB_NAME = f'test_convert-{pytest.ID}'
 
 
@@ -95,16 +91,6 @@ def db_root(tmp_path_factory, persistent_repository):
     )
 
     return db_root
-
-
-@pytest.fixture(
-    scope='function',
-    autouse=True,
-)
-def fixture_clear_cache():
-    audeer.rmdir(pytest.CACHE_ROOT)
-    yield
-    audeer.rmdir(pytest.CACHE_ROOT)
 
 
 @pytest.mark.parametrize(
@@ -271,7 +257,7 @@ def test_sampling_rate(db_root, sampling_rate):
             assert audiofile.sampling_rate(converted_file) == sampling_rate
 
 
-def test_mixed_cache():
+def test_mixed_cache(cache, shared_cache):
     # Avoid failing searching for other versions
     # if databases a stored accross private and shared cache
     # and the private one is empty, see
@@ -286,12 +272,11 @@ def test_mixed_cache():
         verbose=False,
         only_metadata=True,
         tables='files',
-        cache_root=pytest.SHARED_CACHE_ROOT,
+        cache_root=shared_cache,
     )
     # Now try to load same version to private cache
     # to force audb.cached() to return empty dataframe
-    audeer.rmdir(pytest.CACHE_ROOT)
-    audeer.mkdir(pytest.CACHE_ROOT)
+    audeer.rmdir(cache)
     audb.load(
         DB_NAME,
         sampling_rate=8000,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -16,7 +16,7 @@ DB_NAME = f'test_convert-{pytest.ID}'
     scope='module',
     autouse=True,
 )
-def db_root(tmp_path_factory, persistent_repository):
+def db_root(tmpdir_factory, persistent_repository):
     r"""Publish single database.
 
     Returns:
@@ -25,7 +25,7 @@ def db_root(tmp_path_factory, persistent_repository):
     """
 
     version = '1.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
 
     # define audio files and metadata
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -25,7 +25,7 @@ def db_root(tmpdir_factory, persistent_repository):
     """
 
     version = '1.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
+    db_root = tmpdir_factory.mktemp(version)
 
     # define audio files and metadata
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,7 +9,7 @@ import audiofile
 import audb
 
 
-DB_NAME = f'test_convert-{pytest.ID}'
+DB_NAME = 'test_convert'
 
 
 @pytest.fixture(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-
 import numpy as np
 import pytest
 
@@ -15,97 +13,88 @@ os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
 os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
 
 
-@pytest.fixture(
-    scope='session',
-    autouse=True,
-)
-def fixture_set_repositories():
-    audb.config.REPOSITORIES = pytest.REPOSITORIES
-
-
 DB_NAME = f'test_convert-{pytest.ID}'
-DB_ROOT = os.path.join(pytest.ROOT, 'db')
-
-DB_FILES = {
-    'audio/file1.wav': {
-        'bit_depth': 16,
-        'channels': 1,
-        'format': 'wav',
-        'sampling_rate': 8000,
-    },
-    'audio/file2.wav': {
-        'bit_depth': 24,
-        'channels': 2,
-        'format': 'wav',
-        'sampling_rate': 16000,
-    },
-    'audio/file3.flac': {
-        'bit_depth': 8,
-        'channels': 3,
-        'format': 'flac',
-        'sampling_rate': 44100,
-    },
-}
-
-
-def clear_root(root: str):
-    root = audeer.path(root)
-    if os.path.exists(root):
-        shutil.rmtree(root)
 
 
 @pytest.fixture(
     scope='module',
     autouse=True,
 )
-def fixture_publish_db():
+def db_root(tmp_path_factory, persistent_repository):
+    r"""Publish single database.
 
-    clear_root(DB_ROOT)
-    clear_root(pytest.FILE_SYSTEM_HOST)
+    Returns:
+        path to original database root
+
+    """
+
+    version = '1.0.0'
+    db_root = tmp_path_factory.mktemp(version).as_posix()
+
+    # define audio files and metadata
+
+    db_files = {
+        'audio/file1.wav': {
+            'bit_depth': 16,
+            'channels': 1,
+            'format': 'wav',
+            'sampling_rate': 8000,
+        },
+        'audio/file2.wav': {
+            'bit_depth': 24,
+            'channels': 2,
+            'format': 'wav',
+            'sampling_rate': 16000,
+        },
+        'audio/file3.flac': {
+            'bit_depth': 8,
+            'channels': 3,
+            'format': 'flac',
+            'sampling_rate': 44100,
+        },
+    }
 
     # create db
 
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
-    db['files'] = audformat.Table(audformat.filewise_index(list(DB_FILES)))
+
+    db['files'] = audformat.Table(audformat.filewise_index(list(db_files)))
     db['files']['original'] = audformat.Column()
-    db['files']['original'].set(list(DB_FILES))
-    for file in DB_FILES:
+    db['files']['original'].set(list(db_files))
+    for file in db_files:
         signal = np.zeros(
             (
-                DB_FILES[file]['channels'],
-                DB_FILES[file]['sampling_rate'],
+                db_files[file]['channels'],
+                db_files[file]['sampling_rate'],
             ),
             dtype=np.float32,
         )
-        path = os.path.join(DB_ROOT, file)
+        path = os.path.join(db_root, file)
         audeer.mkdir(os.path.dirname(path))
         audiofile.write(
-            path, signal, DB_FILES[file]['sampling_rate'],
-            bit_depth=DB_FILES[file]['bit_depth']
+            path, signal, db_files[file]['sampling_rate'],
+            bit_depth=db_files[file]['bit_depth']
         )
     db['segments'] = audformat.Table(
         audformat.segmented_index(
-            [list(DB_FILES)[0]] * 3,
+            [list(db_files)[0]] * 3,
             starts=['0s', '1s', '2s'],
             ends=['1s', '2s', '3s'],
         )
     )
-    db.save(DB_ROOT)
+    db.save(db_root)
 
     # publish db
 
     audb.publish(
-        DB_ROOT,
-        '1.0.0',
-        pytest.PUBLISH_REPOSITORY,
+        db_root,
+        version,
+        persistent_repository,
         verbose=False,
     )
 
-    yield
-
-    clear_root(DB_ROOT)
-    clear_root(pytest.FILE_SYSTEM_HOST)
+    return db_root
 
 
 @pytest.fixture(
@@ -113,9 +102,9 @@ def fixture_publish_db():
     autouse=True,
 )
 def fixture_clear_cache():
-    clear_root(pytest.CACHE_ROOT)
+    audeer.rmdir(pytest.CACHE_ROOT)
     yield
-    clear_root(pytest.CACHE_ROOT)
+    audeer.rmdir(pytest.CACHE_ROOT)
 
 
 @pytest.mark.parametrize(
@@ -124,7 +113,7 @@ def fixture_clear_cache():
         None, 16,
     ],
 )
-def test_bit_depth(bit_depth):
+def test_bit_depth(db_root, bit_depth):
 
     db = audb.load(
         DB_NAME,
@@ -141,7 +130,7 @@ def test_bit_depth(bit_depth):
     for converted_file, original_file in zip(db.files, original_files):
 
         converted_file = os.path.join(db.meta['audb']['root'], converted_file)
-        original_file = os.path.join(DB_ROOT, original_file)
+        original_file = os.path.join(db_root, original_file)
 
         if bit_depth is None:
             assert audiofile.bit_depth(converted_file) == \
@@ -156,7 +145,7 @@ def test_bit_depth(bit_depth):
         None, 1, [0, -1], range(5),
     ],
 )
-def test_channels(channels):
+def test_channels(db_root, channels):
 
     db = audb.load(
         DB_NAME,
@@ -172,7 +161,7 @@ def test_channels(channels):
     for converted_file, original_file in zip(db.files, original_files):
 
         converted_file = os.path.join(db.meta['audb']['root'], converted_file)
-        original_file = os.path.join(DB_ROOT, original_file)
+        original_file = os.path.join(db_root, original_file)
 
         if channels is None:
             assert audiofile.channels(converted_file) == \
@@ -193,7 +182,7 @@ def test_channels(channels):
         audb.core.define.Format.FLAC,
     ],
 )
-def test_format(format):
+def test_format(db_root, format):
 
     db = audb.load(
         DB_NAME,
@@ -210,7 +199,7 @@ def test_format(format):
     for converted_file, original_file in zip(db.files, original_files):
 
         converted_file = os.path.join(db.meta['audb']['root'], converted_file)
-        original_file = os.path.join(DB_ROOT, original_file)
+        original_file = os.path.join(db_root, original_file)
 
         if format is None:
             assert converted_file[-4:] == original_file[-4:]
@@ -224,7 +213,7 @@ def test_format(format):
         False, True
     ],
 )
-def test_mixdown(mixdown):
+def test_mixdown(db_root, mixdown):
 
     db = audb.load(
         DB_NAME,
@@ -241,7 +230,7 @@ def test_mixdown(mixdown):
     for converted_file, original_file in zip(db.files, original_files):
 
         converted_file = os.path.join(db.meta['audb']['root'], converted_file)
-        original_file = os.path.join(DB_ROOT, original_file)
+        original_file = os.path.join(db_root, original_file)
 
         if mixdown:
             assert audiofile.channels(converted_file) == 1
@@ -256,7 +245,7 @@ def test_mixdown(mixdown):
         None, 16000
     ],
 )
-def test_sampling_rate(sampling_rate):
+def test_sampling_rate(db_root, sampling_rate):
 
     db = audb.load(
         DB_NAME,
@@ -273,7 +262,7 @@ def test_sampling_rate(sampling_rate):
     for converted_file, original_file in zip(db.files, original_files):
 
         converted_file = os.path.join(db.meta['audb']['root'], converted_file)
-        original_file = os.path.join(DB_ROOT, original_file)
+        original_file = os.path.join(db_root, original_file)
 
         if sampling_rate is None:
             assert audiofile.sampling_rate(converted_file) == \
@@ -301,7 +290,7 @@ def test_mixed_cache():
     )
     # Now try to load same version to private cache
     # to force audb.cached() to return empty dataframe
-    clear_root(pytest.CACHE_ROOT)
+    audeer.rmdir(pytest.CACHE_ROOT)
     audeer.mkdir(pytest.CACHE_ROOT)
     audb.load(
         DB_NAME,

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,15 +1,9 @@
-import os
 import pandas as pd
 import pytest
 
 import audformat.testing
-import audeer
 
 import audb
-
-
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
 
 
 DB_NAME = f'test_filter-{pytest.ID}'
@@ -102,16 +96,6 @@ def db(tmp_path_factory, persistent_repository):
         archives=archives,
         verbose=False,
     )
-
-
-@pytest.fixture(
-    scope='function',
-    autouse=True,
-)
-def fixture_clear_cache():
-    audeer.rmdir(pytest.CACHE_ROOT)
-    yield
-    audeer.rmdir(pytest.CACHE_ROOT)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -17,7 +17,7 @@ def db(tmpdir_factory, persistent_repository):
     r"""Publish a single database."""
 
     version = '1.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
+    db_root = tmpdir_factory.mktemp(version)
 
     # create db
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -13,11 +13,11 @@ DB_NAME = f'test_filter-{pytest.ID}'
     scope='module',
     autouse=True,
 )
-def db(tmp_path_factory, persistent_repository):
+def db(tmpdir_factory, persistent_repository):
     r"""Publish a single database."""
 
     version = '1.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
 
     # create db
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,7 +6,7 @@ import audformat.testing
 import audb
 
 
-DB_NAME = f'test_filter-{pytest.ID}'
+DB_NAME = 'test_filter'
 
 
 @pytest.fixture(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-
 import pandas as pd
 import pytest
 
@@ -14,32 +12,18 @@ os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
 os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
 
 
-@pytest.fixture(
-    scope='session',
-    autouse=True,
-)
-def fixture_set_repositories():
-    audb.config.REPOSITORIES = pytest.REPOSITORIES
-
-
 DB_NAME = f'test_filter-{pytest.ID}'
-DB_ROOT = os.path.join(pytest.ROOT, 'db')
-
-
-def clear_root(root: str):
-    root = audeer.path(root)
-    if os.path.exists(root):
-        shutil.rmtree(root)
 
 
 @pytest.fixture(
     scope='module',
     autouse=True,
 )
-def fixture_publish_db():
+def db(tmp_path_factory, persistent_repository):
+    r"""Publish a single database."""
 
-    clear_root(DB_ROOT)
-    clear_root(pytest.FILE_SYSTEM_HOST)
+    version = '1.0.0'
+    db_root = tmp_path_factory.mktemp(version).as_posix()
 
     # create db
 
@@ -99,7 +83,7 @@ def fixture_publish_db():
         starts=starts,
         ends=ends,
     )
-    db.save(DB_ROOT)
+    db.save(db_root)
     audformat.testing.create_audio_files(db)
 
     # publish db
@@ -112,17 +96,12 @@ def fixture_publish_db():
             }
         )
     audb.publish(
-        DB_ROOT,
-        '1.0.0',
-        pytest.PUBLISH_REPOSITORY,
+        db_root,
+        version,
+        persistent_repository,
         archives=archives,
         verbose=False,
     )
-
-    yield
-
-    clear_root(DB_ROOT)
-    clear_root(pytest.FILE_SYSTEM_HOST)
 
 
 @pytest.fixture(
@@ -130,9 +109,9 @@ def fixture_publish_db():
     autouse=True,
 )
 def fixture_clear_cache():
-    clear_root(pytest.CACHE_ROOT)
+    audeer.rmdir(pytest.CACHE_ROOT)
     yield
-    clear_root(pytest.CACHE_ROOT)
+    audeer.rmdir(pytest.CACHE_ROOT)
 
 
 @pytest.mark.parametrize(
@@ -272,7 +251,5 @@ def test_tables(tables, format, expected_tables, expected_files):
         num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
-    print(list(db))
-    print(expected_tables)
     assert list(db) == expected_tables
     assert list(db.files) == expected_files

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -11,7 +11,7 @@ import audiofile
 import audb
 
 
-DB_NAME = f'test_info-{pytest.ID}'
+DB_NAME = 'test_info'
 DB_VERSION = '1.0.0'
 
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -11,10 +11,6 @@ import audiofile
 import audb
 
 
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
-
-
 DB_NAME = f'test_info-{pytest.ID}'
 DB_VERSION = '1.0.0'
 
@@ -106,16 +102,6 @@ def db(tmp_path_factory, persistent_repository):
     )
 
     return db
-
-
-@pytest.fixture(
-    scope='function',
-    autouse=True,
-)
-def fixture_clear_cache():
-    audeer.rmdir(pytest.CACHE_ROOT)
-    yield
-    audeer.rmdir(pytest.CACHE_ROOT)
 
 
 def test_attachemnts(db):

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -79,7 +79,7 @@ def db(tmpdir_factory, persistent_repository):
 
     # create db + audio files
 
-    db_root = str(tmpdir_factory.mktemp(DB_VERSION))
+    db_root = tmpdir_factory.mktemp(DB_VERSION)
     sampling_rate = 8000
     audeer.touch(audeer.path(db_root, db.attachments['attachment'].path))
     for table in list(db.tables):

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -19,7 +19,7 @@ DB_VERSION = '1.0.0'
     scope='module',
     autouse=True,
 )
-def db(tmp_path_factory, persistent_repository):
+def db(tmpdir_factory, persistent_repository):
     r"""Publish a single database.
 
     Returns:
@@ -79,7 +79,7 @@ def db(tmp_path_factory, persistent_repository):
 
     # create db + audio files
 
-    db_root = tmp_path_factory.mktemp(DB_VERSION).as_posix()
+    db_root = str(tmpdir_factory.mktemp(DB_VERSION))
     sampling_rate = 8000
     audeer.touch(audeer.path(db_root, db.attachments['attachment'].path))
     for table in list(db.tables):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -38,7 +38,7 @@ def fixture_ensure_tmp_folder_deleted():
     scope='module',
     autouse=True,
 )
-def dbs(tmp_path_factory, persistent_repository):
+def dbs(tmpdir_factory, persistent_repository):
     r"""Publish different versions of the same database.
 
     Returns:
@@ -94,7 +94,7 @@ def dbs(tmp_path_factory, persistent_repository):
     # publish 1.0.0
 
     version = '1.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
 
     audeer.mkdir(audeer.path(db_root, 'extra/folder/sub-folder'))
@@ -117,7 +117,7 @@ def dbs(tmp_path_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '1.1.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
 
     audformat.testing.add_table(
@@ -147,7 +147,7 @@ def dbs(tmp_path_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '1.1.1'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
 
     db['train'].df['label'][0] = None
@@ -173,7 +173,7 @@ def dbs(tmp_path_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '2.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
 
     shutil.copytree(
@@ -209,7 +209,7 @@ def dbs(tmp_path_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '3.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
 
     shutil.copytree(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -12,9 +12,6 @@ import audeer
 import audb
 
 
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
-
 DB_NAME = f'test_load-{pytest.ID}'
 
 
@@ -33,7 +30,7 @@ def fixture_ensure_tmp_folder_deleted():
     """
     yield
 
-    dirs = audeer.list_dir_names(pytest.CACHE_ROOT, recursive=True)
+    dirs = audeer.list_dir_names(os.environ['AUDB_CACHE_ROOT'], recursive=True)
     assert len([d for d in dirs if d.endswith('~')]) == 0
 
 
@@ -239,8 +236,8 @@ def dbs(tmp_path_factory, persistent_repository):
     return paths
 
 
-def test_database_cache_folder():
-    cache_root = os.path.join(pytest.CACHE_ROOT, 'cache')
+def test_database_cache_folder(cache):
+    cache_root = os.path.join(cache, 'cache')
     version = '1.0.0'
     db_root = audb.core.load.database_cache_root(
         DB_NAME,
@@ -426,7 +423,7 @@ def test_load(dbs, format, version, only_metadata):
         ),
     ]
 )
-def test_load_attachment(version, attachment_id):
+def test_load_attachment(cache, version, attachment_id):
 
     db = audb.load(
         DB_NAME,
@@ -446,7 +443,7 @@ def test_load_attachment(version, attachment_id):
 
     expected_paths = [
         os.path.join(
-            pytest.CACHE_ROOT,
+            cache,
             DB_NAME,
             version,
             os.path.normpath(file),
@@ -459,7 +456,7 @@ def test_load_attachment(version, attachment_id):
     cache_root = audb.core.load.database_cache_root(
         DB_NAME,
         version,
-        pytest.CACHE_ROOT,
+        cache,
         audb.Flavor(),
     )
     shutil.rmtree(cache_root)
@@ -531,7 +528,7 @@ def test_load_attachment_errors(version, attachment_id, error, error_msg):
         ),
     ]
 )
-def test_load_media(version, media, format):
+def test_load_media(cache, version, media, format):
 
     paths = audb.load_media(
         DB_NAME,
@@ -541,7 +538,7 @@ def test_load_media(version, media, format):
         verbose=False,
     )
     expected_paths = [
-        os.path.join(pytest.CACHE_ROOT, p)
+        os.path.join(cache, p)
         for p in paths
     ]
     if format is not None:
@@ -557,7 +554,7 @@ def test_load_media(version, media, format):
     cache_root = audb.core.load.database_cache_root(
         DB_NAME,
         version,
-        pytest.CACHE_ROOT,
+        cache,
         audb.Flavor(format=format),
     )
     shutil.rmtree(cache_root)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -42,7 +42,7 @@ def dbs(tmpdir_factory, persistent_repository):
     r"""Publish different versions of the same database.
 
     Returns:
-        dictionary containg root folder for each version
+        dictionary containing root folder for each version
 
     """
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -94,8 +94,8 @@ def dbs(tmpdir_factory, persistent_repository):
     # publish 1.0.0
 
     version = '1.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
 
     audeer.mkdir(audeer.path(db_root, 'extra/folder/sub-folder'))
     audeer.touch(audeer.path(db_root, 'extra/file.txt'))
@@ -117,8 +117,8 @@ def dbs(tmpdir_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '1.1.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
 
     audformat.testing.add_table(
         db, 'train', audformat.define.IndexType.SEGMENTED,
@@ -147,8 +147,8 @@ def dbs(tmpdir_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '1.1.1'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
 
     db['train'].df['label'][0] = None
     shutil.copytree(
@@ -173,8 +173,8 @@ def dbs(tmpdir_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '2.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
 
     shutil.copytree(
         audeer.path(previous_db_root, 'extra'),
@@ -209,8 +209,8 @@ def dbs(tmpdir_factory, persistent_repository):
 
     previous_db_root = db_root
     version = '3.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
 
     shutil.copytree(
         audeer.path(previous_db_root, 'extra'),

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -613,14 +613,6 @@ def test_load_table(version, table):
     assert files == expected_files
 
 
-# In the `test_load_to` test
-# it is important
-# that first all only_metadata=True cases are tested
-# as otherwise some files will exist
-# and the test will fail.
-# To ensure the right order
-# `@pytest.mark.parametrize('only_metadata', ...)`
-# needs to be defined as last entry.
 @pytest.mark.parametrize(
     'version',
     [

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -406,6 +406,66 @@ def test_load(dbs, format, version, only_metadata):
                 assert os.path.exists(audeer.path(db.root, attachment_file))
 
 
+def test_load_from_cache(dbs):
+
+    # Load a database with flavor to cache
+    # and reload afterwards from cache
+    format = 'flac'
+    version = '1.0.0'
+    db = audb.load(
+        DB_NAME,
+        version='1.0.0',
+        format='flac',
+        full_path=False,
+        num_workers=pytest.NUM_WORKERS,
+        verbose=False,
+    )
+    db_root = db.meta['audb']['root']
+
+    # Load original database from folder (expected database)
+    db_original = audformat.Database.load(dbs[version])
+    db_original.map_files(
+        lambda x: audeer.replace_file_extension(x, format)
+    )
+
+    # Assert database exists in cache
+    assert audb.exists(DB_NAME, version=version, format=format)
+    df = audb.cached()
+    assert df.loc[db_root]['version'] == version
+
+    # Assert media files are identical and exist
+    pd.testing.assert_index_equal(db.files, db_original.files)
+    for file in db.files:
+        assert os.path.exists(os.path.join(db_root, file))
+
+    version = '2.0.0'
+    db = audb.load(
+        DB_NAME,
+        version='2.0.0',
+        format='flac',
+        full_path=False,
+        num_workers=pytest.NUM_WORKERS,
+        verbose=False,
+    )
+    db_root = db.meta['audb']['root']
+
+    # Load original database from folder (expected database)
+    db_original = audformat.Database.load(dbs[version])
+    db_original.map_files(
+        lambda x: audeer.replace_file_extension(x, format)
+    )
+
+    # Assert database exists in cache
+    assert audb.exists(DB_NAME, version=version, format=format)
+    df = audb.cached()
+    assert df.loc[db_root]['version'] == version
+
+    # Assert media files are identical and exist
+    pd.testing.assert_index_equal(db.files, db_original.files)
+    for file in db.files:
+        assert os.path.exists(os.path.join(db_root, file))
+
+
 @pytest.mark.parametrize(
     'version, attachment_id',
     [

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -12,7 +12,7 @@ import audeer
 import audb
 
 
-DB_NAME = f'test_load-{pytest.ID}'
+DB_NAME = 'test_load'
 
 
 @pytest.fixture(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -19,7 +19,7 @@ DB_NAME = 'test_load'
     scope='function',
     autouse=True,
 )
-def fixture_ensure_tmp_folder_deleted():
+def assert_database_tmp_folder_is_deleted():
     """Fixture to test that the ~ tmp folder gets deleted.
 
     audb.load() first loads files to a folder

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -30,7 +30,7 @@ def fixture_ensure_tmp_folder_deleted():
     """
     yield
 
-    dirs = audeer.list_dir_names(os.environ['AUDB_CACHE_ROOT'], recursive=True)
+    dirs = audeer.list_dir_names(audb.default_cache_root(), recursive=True)
     assert len([d for d in dirs if d.endswith('~')]) == 0
 
 

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -17,7 +17,7 @@ DB_VERSION = '1.0.0'
     scope='module',
     autouse=True,
 )
-def dbs(tmp_path_factory, persistent_repository):
+def dbs(tmpdir_factory, persistent_repository):
 
     # Collect single database paths
     # and return them in the end
@@ -25,7 +25,7 @@ def dbs(tmp_path_factory, persistent_repository):
 
     # publish 1.0.0
 
-    db_root = tmp_path_factory.mktemp(DB_VERSION).as_posix()
+    db_root = str(tmpdir_factory.mktemp(DB_VERSION))
     paths[DB_VERSION] = db_root
 
     db = audformat.testing.create_db(minimal=True)

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -25,7 +25,7 @@ def dbs(tmpdir_factory, persistent_repository):
 
     # publish 1.0.0
 
-    db_root = str(tmpdir_factory.mktemp(DB_VERSION))
+    db_root = tmpdir_factory.mktemp(DB_VERSION)
     paths[DB_VERSION] = db_root
 
     db = audformat.testing.create_db(minimal=True)

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -9,7 +9,7 @@ import audeer
 import audb
 
 
-DB_NAME = f'test_load_on_demand-{pytest.ID}'
+DB_NAME = 'test_load_on_demand'
 DB_VERSION = '1.0.0'
 
 

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 import pandas as pd
 import pytest
@@ -14,35 +13,24 @@ os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
 os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
 
 
-@pytest.fixture(
-    scope='session',
-    autouse=True,
-)
-def fixture_set_repositories():
-    audb.config.REPOSITORIES = pytest.REPOSITORIES
-
-
 DB_NAME = f'test_load_on_demand-{pytest.ID}'
-DB_ROOT = os.path.join(pytest.ROOT, 'db')
 DB_VERSION = '1.0.0'
-
-
-def clear_root(root: str):
-    root = audeer.path(root)
-    if os.path.exists(root):
-        shutil.rmtree(root)
 
 
 @pytest.fixture(
     scope='module',
     autouse=True,
 )
-def fixture_publish_db():
+def dbs(tmp_path_factory, persistent_repository):
 
-    clear_root(DB_ROOT)
-    clear_root(pytest.FILE_SYSTEM_HOST)
+    # Collect single database paths
+    # and return them in the end
+    paths = {}
 
-    # create db
+    # publish 1.0.0
+
+    db_root = tmp_path_factory.mktemp(DB_VERSION).as_posix()
+    paths[DB_VERSION] = db_root
 
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
@@ -77,31 +65,26 @@ def fixture_publish_db():
     )
     db.attachments['file'] = audformat.Attachment('file.txt')
     db.attachments['folder'] = audformat.Attachment('folder/')
-    audeer.mkdir(audeer.path(DB_ROOT, 'folder'))
-    audeer.touch(audeer.path(DB_ROOT, 'file.txt'))
-    audeer.touch(audeer.path(DB_ROOT, 'folder/file1.txt'))
-    audeer.touch(audeer.path(DB_ROOT, 'folder/file2.txt'))
-    db.save(DB_ROOT)
+    audeer.mkdir(audeer.path(db_root, 'folder'))
+    audeer.touch(audeer.path(db_root, 'file.txt'))
+    audeer.touch(audeer.path(db_root, 'folder/file1.txt'))
+    audeer.touch(audeer.path(db_root, 'folder/file2.txt'))
+    db.save(db_root)
     audformat.testing.create_audio_files(db)
 
-    # publish 1.0.0
-
     audb.publish(
-        DB_ROOT,
+        db_root,
         DB_VERSION,
-        pytest.PUBLISH_REPOSITORY,
+        persistent_repository,
         verbose=False,
     )
 
-    yield
-
-    clear_root(DB_ROOT)
-    clear_root(pytest.FILE_SYSTEM_HOST)
+    return paths
 
 
-def test_load_only_metadata():
+def test_load_only_metadata(dbs):
 
-    db_original = audformat.Database.load(DB_ROOT)
+    db_original = audformat.Database.load(dbs[DB_VERSION])
 
     db = audb.load(
         DB_NAME,

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -9,10 +9,6 @@ import audeer
 import audb
 
 
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
-
-
 DB_NAME = f'test_load_on_demand-{pytest.ID}'
 DB_VERSION = '1.0.0'
 

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -113,9 +113,9 @@ DB_VERSIONS = ['1.0.0', '2.0.0']
     scope='module',
     autouse=True,
 )
-def fixture_publish_db(tmp_path_factory, persistent_repository):
+def fixture_publish_db(tmpdir_factory, persistent_repository):
 
-    db_root = tmp_path_factory.mktemp('db').as_posix()
+    db_root = str(tmpdir_factory.mktemp('db'))
 
     # create db
 

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -78,14 +78,14 @@ def fixture_ensure_lock_file_deleted():
     assert not any(
         [
             os.path.exists(path)
-            for path in lock_paths(os.environ['AUDB_CACHE_ROOT'])
+            for path in lock_paths(audb.default_cache_root())
         ]
     )
     yield
     assert not any(
         [
             os.path.exists(path)
-            for path in lock_paths(os.environ['AUDB_CACHE_ROOT'])
+            for path in lock_paths(audb.default_cache_root())
         ]
     )
 

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -326,7 +326,10 @@ def test_lock_load_crash(fixture_set_repositories):
     ['file-system'],
     indirect=True,
 )
-def test_lock_load_from_cached_versions(fixture_set_repositories):
+def test_lock_load_from_cached_versions(
+        persistent_repository,
+        fixture_set_repositories,
+):
 
     # ensure immediate timeout if cache folder is locked
     cached_version_timeout = audb.core.define.CACHED_VERSIONS_TIMEOUT
@@ -351,8 +354,8 @@ def test_lock_load_from_cached_versions(fixture_set_repositories):
     # must be copied from version 1.0.0
     audb.config.REPOSITORIES = [
         audb.Repository(
-            name=pytest.REPOSITORY_NAME,
-            host=pytest.FILE_SYSTEM_HOST,
+            name=persistent_repository.name,
+            host=persistent_repository.host,
             backend='crash-file-system',
         ),
     ]

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -113,15 +113,15 @@ def set_repositories(persistent_repository, request):
     scope='module',
     autouse=True,
 )
-def db(tmpdir_factory, persistent_repository):
-    r"""Publish a database.
+def dbs(tmpdir_factory, persistent_repository):
+    r"""Publish databases.
 
     This publishes a database with the name ``DB_NAME``
     and the versions 1.0.0 and 2.0.0
     to a module wide repository.
 
     """
-    db_root = str(tmpdir_factory.mktemp('db'))
+    db_root = tmpdir_factory.mktemp('db')
 
     # create db
 

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -105,7 +105,7 @@ def fixture_set_repositories(persistent_repository, request):
     ]
 
 
-DB_NAME = f'test_lock-{pytest.ID}'
+DB_NAME = 'test_lock'
 DB_VERSIONS = ['1.0.0', '2.0.0']
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -14,8 +14,6 @@ import audiofile
 
 import audb
 
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
 
 DB_NAME = f'test_publish-{pytest.ID}'
 LONG_PATH = '/'.join(['audio'] * 50) + '/new.wav'
@@ -1203,12 +1201,3 @@ def test_update_database_without_media(tmpdir, persistent_repository):
             audeer.path(build_root, attachment_file),
             audeer.path(db_load.root, attachment_file),
         )
-
-
-def test_cached():
-    # Check first that we have different database names available
-    df = audb.cached()
-    names = list(set(df.name))
-    assert len(names) > 1
-    df = audb.cached(name=names[0])
-    assert set(df.name) == set([names[0]])

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -345,7 +345,7 @@ def dbs(tmp_path_factory):
     'name',
     ['?', '!', ','],
 )
-def test_invalid_archives(dbs, name):
+def test_invalid_archives(dbs, persistent_repository, name):
 
     archives = {
         'audio/001.wav': name
@@ -354,7 +354,7 @@ def test_invalid_archives(dbs, name):
         audb.publish(
             dbs['1.0.0'],
             '1.0.1',
-            pytest.PUBLISH_REPOSITORY,
+            persistent_repository,
             archives=archives,
             num_workers=pytest.NUM_WORKERS,
             verbose=False,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -15,7 +15,7 @@ import audiofile
 import audb
 
 
-DB_NAME = f'test_publish-{pytest.ID}'
+DB_NAME = 'test_publish'
 LONG_PATH = '/'.join(['audio'] * 50) + '/new.wav'
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -23,7 +23,7 @@ LONG_PATH = '/'.join(['audio'] * 50) + '/new.wav'
     scope='session',
     autouse=True,
 )
-def dbs(tmp_path_factory):
+def dbs(tmpdir_factory):
     r"""Store different versions of the same database.
 
     Returns:
@@ -39,7 +39,7 @@ def dbs(tmp_path_factory):
     #
     # Folder without content
     version = '0.1.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
 
     # Version 1.0.0
@@ -63,7 +63,7 @@ def dbs(tmp_path_factory):
     #   - speaker
     #   - misc
     version = '1.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
@@ -155,7 +155,7 @@ def dbs(tmp_path_factory):
     #   - speaker
     #   - misc
     version = '2.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
     shutil.copytree(
         audeer.path(paths['1.0.0'], 'extra'),
@@ -171,7 +171,7 @@ def dbs(tmp_path_factory):
     #
     # Folder without content
     version = '2.1.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
 
     # Version 3.0.0
@@ -195,7 +195,7 @@ def dbs(tmp_path_factory):
     #   - speaker
     #   - misc
     version = '3.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
     remove_file = 'audio/001.wav'
     db.drop_files(remove_file)
@@ -224,7 +224,7 @@ def dbs(tmp_path_factory):
     #   - speaker
     #   - misc
     version = '4.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
     db.save(db_root)
 
@@ -251,7 +251,7 @@ def dbs(tmp_path_factory):
     #   - speaker
     #   - misc
     version = '5.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
     db['files'] = db['files'].extend_index(
         audformat.filewise_index([f'file{n}.wav' for n in range(20)])
@@ -287,7 +287,7 @@ def dbs(tmp_path_factory):
     #   - speaker
     #   - misc
     version = '6.0.0'
-    db_root = tmp_path_factory.mktemp(version).as_posix()
+    db_root = str(tmpdir_factory.mktemp(version))
     paths[version] = db_root
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -39,7 +39,7 @@ def dbs(tmpdir_factory):
     #
     # Folder without content
     version = '0.1.0'
-    db_root = str(tmpdir_factory.mktemp(version))
+    db_root = tmpdir_factory.mktemp(version)
     paths[version] = db_root
 
     # Version 1.0.0
@@ -63,8 +63,8 @@ def dbs(tmpdir_factory):
     #   - speaker
     #   - misc
     version = '1.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
     db.schemes['scheme'] = audformat.Scheme(
@@ -155,8 +155,8 @@ def dbs(tmpdir_factory):
     #   - speaker
     #   - misc
     version = '2.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
     shutil.copytree(
         audeer.path(paths['1.0.0'], 'extra'),
         audeer.path(db_root, 'extra'),
@@ -171,8 +171,8 @@ def dbs(tmpdir_factory):
     #
     # Folder without content
     version = '2.1.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
 
     # Version 3.0.0
     #
@@ -195,8 +195,8 @@ def dbs(tmpdir_factory):
     #   - speaker
     #   - misc
     version = '3.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
     remove_file = 'audio/001.wav'
     db.drop_files(remove_file)
     del db.attachments['file']
@@ -224,8 +224,8 @@ def dbs(tmpdir_factory):
     #   - speaker
     #   - misc
     version = '4.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
     db.save(db_root)
 
     # Version 5.0.0
@@ -251,8 +251,8 @@ def dbs(tmpdir_factory):
     #   - speaker
     #   - misc
     version = '5.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
     db['files'] = db['files'].extend_index(
         audformat.filewise_index([f'file{n}.wav' for n in range(20)])
     )
@@ -287,8 +287,8 @@ def dbs(tmpdir_factory):
     #   - speaker
     #   - misc
     version = '6.0.0'
-    db_root = str(tmpdir_factory.mktemp(version))
-    paths[version] = db_root
+    db_root = tmpdir_factory.mktemp(version)
+    paths[version] = str(db_root)
     db = audformat.testing.create_db(minimal=True)
     db.name = DB_NAME
     db.schemes['scheme'] = audformat.Scheme(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -27,7 +27,7 @@ def dbs(tmpdir_factory):
     r"""Store different versions of the same database.
 
     Returns:
-        dictionary containg root folder for each version
+        dictionary containing root folder for each version
 
     """
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -680,15 +680,15 @@ def test_publish_changed_db(
 @pytest.mark.parametrize(
     'version, previous_version, error_type, error_msg',
     [
-        # (
-        #     '1.0.0',
-        #     None,
-        #     RuntimeError,
-        #     (
-        #         "A version '1.0.0' already exists for database "
-        #         f"'{DB_NAME}'."
-        #     ),
-        # ),
+        (
+            '1.0.0',
+            None,
+            RuntimeError,
+            (
+                "A version '1.0.0' already exists for database "
+                f"'{DB_NAME}'."
+            ),
+        ),
         (
             '4.0.0',
             None,

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -8,7 +8,7 @@ import audeer
 import audb
 
 
-DB_NAME = f'test_remove-{pytest.ID}'
+DB_NAME = 'test_remove'
 DB_FILES = {
     '1.0.0': [
         'audio/bundle1.wav',

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -25,9 +25,9 @@ DB_FILES = {
     scope='module',
     autouse=True,
 )
-def publish_db(tmp_path_factory, persistent_repository):
+def publish_db(tmpdir_factory, persistent_repository):
 
-    db_root = tmp_path_factory.mktemp('db').as_posix()
+    db_root = str(tmpdir_factory.mktemp('db'))
 
     # create db
 

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -25,9 +25,15 @@ DB_FILES = {
     scope='module',
     autouse=True,
 )
-def publish_db(tmpdir_factory, persistent_repository):
+def dbs(tmpdir_factory, persistent_repository):
+    r"""Publish databases.
 
-    db_root = str(tmpdir_factory.mktemp('db'))
+    This publishes a database with the name ``DB_NAME``
+    and the versions 1.0.0 and 2.0.0
+    to a module wide repository.
+
+    """
+    db_root = tmpdir_factory.mktemp('db')
 
     # create db
 

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -8,10 +8,6 @@ import audeer
 import audb
 
 
-os.environ['AUDB_CACHE_ROOT'] = pytest.CACHE_ROOT
-os.environ['AUDB_SHARED_CACHE_ROOT'] = pytest.SHARED_CACHE_ROOT
-
-
 DB_NAME = f'test_remove-{pytest.ID}'
 DB_FILES = {
     '1.0.0': [
@@ -79,7 +75,7 @@ def publish_db(tmp_path_factory, persistent_repository):
         'flac',
     ]
 )
-def test_remove(format):
+def test_remove(cache, format):
 
     for remove in (
             DB_FILES['1.0.0'][0],  # bundle1
@@ -89,7 +85,7 @@ def test_remove(format):
     ):
 
         # remove db cache to ensure we always get a fresh copy
-        audeer.rmdir(pytest.CACHE_ROOT)
+        audeer.rmdir(cache)
 
         audb.remove_media(DB_NAME, remove)
 


### PR DESCRIPTION
Make sure databases, repositories, and caches are stored in temp folders handled by `pytest`, instead of manually creating and deleting them.

In addition, it provides fixtures to access those repositories/databases/caches. This allows us now also more easily to specify if we want to start with a fresh, empty repo/cache or continue with an existing one.