### PR TITLE
publish() raise ValueError for forbidden versions

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -575,15 +575,19 @@ def publish(
             misc tables, or attachemnts
             that are stored under an ID
             using a char not in ``'[A-Za-z0-9._-]'``
+        ValueError: if ``version`` or ``previous_version``
+            cannot be parsed by :class:`audeer.StrictVersion`
         ValueError: if ``previous_version`` >= ``version``
 
     """
+    # Enforce error if version cannot be converted to audeer.StrictVersion
+    audeer.StrictVersion(version)
     if (
             previous_version is not None
             and previous_version != 'latest'
             and (
-                audeer.LooseVersion(version)
-                <= audeer.LooseVersion(previous_version)
+                audeer.StrictVersion(version)
+                <= audeer.StrictVersion(previous_version)
             )
     ):
         raise ValueError(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -976,14 +976,12 @@ def test_publish_error_version(tmpdir, repository):
     # Only versions supported by audeer.StrictVersion
     # are allowed
 
-    # Prepare database files
+    # Create simple database
     db_path = audeer.mkdir(audeer.path(tmpdir, 'db'))
     audio_file = audeer.path(db_path, 'f1.wav')
     signal = np.zeros((2, 1000))
     sampling_rate = 8000
     audiofile.write(audio_file, signal, sampling_rate)
-
-    # Database with not allowed table ID
     db = audformat.Database('db')
     index = audformat.filewise_index(os.path.basename(audio_file))
     db['table'] = audformat.Table(index)
@@ -998,8 +996,10 @@ def test_publish_error_version(tmpdir, repository):
     # Publish to check previous_version afterwards
     audb.publish(db_path, '1.0.0', repository)
 
+    # Update database
     db['table']['column'].set(['different-label'])
     db.save(db_path)
+
     error_msg = "invalid version number '1.0.0?'"
     with pytest.raises(ValueError, match=re.escape(error_msg)):
         audb.publish(db_path, '2.0.0', repository, previous_version='1.0.0?')

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -971,6 +971,40 @@ def test_publish_error_uppercase_file_extension(tmpdir, repository, file):
         audb.publish(db_path, '1.0.0', repository)
 
 
+def test_publish_error_version(tmpdir, repository):
+
+    # Only versions supported by audeer.StrictVersion
+    # are allowed
+
+    # Prepare database files
+    db_path = audeer.mkdir(audeer.path(tmpdir, 'db'))
+    audio_file = audeer.path(db_path, 'f1.wav')
+    signal = np.zeros((2, 1000))
+    sampling_rate = 8000
+    audiofile.write(audio_file, signal, sampling_rate)
+
+    # Database with not allowed table ID
+    db = audformat.Database('db')
+    index = audformat.filewise_index(os.path.basename(audio_file))
+    db['table'] = audformat.Table(index)
+    db['table']['column'] = audformat.Column()
+    db['table']['column'].set(['label'])
+    db.save(db_path)
+
+    error_msg = "invalid version number '1.0.0?'"
+    with pytest.raises(ValueError, match=re.escape(error_msg)):
+        audb.publish(db_path, '1.0.0?', repository)
+
+    # Publish to check previous_version afterwards
+    audb.publish(db_path, '1.0.0', repository)
+
+    db['table']['column'].set(['different-label'])
+    db.save(db_path)
+    error_msg = "invalid version number '1.0.0?'"
+    with pytest.raises(ValueError, match=re.escape(error_msg)):
+        audb.publish(db_path, '2.0.0', repository, previous_version='1.0.0?')
+
+
 def test_update_database(dbs, persistent_repository):
 
     version = '2.1.0'


### PR DESCRIPTION
Closes #292 

This solves #292 by allowing only version strings supported by `audeer.StrictVersion` which excludes automatically all forbidden chars. It also limits the allowed versions, e.g.

```python
>>> audeer.StrictVersion('1.2.0pre1')
...
ValueError: invalid version number '1.2.0pre1'
```

The only allowed chars are `a` and `b` for alpha and beta releases, e.g.

```python
>>> audeer.StrictVersion('1.2.0a1')
StrictVersion ('1.2a1')
```

but it stills supports dates, e.g.

```python
>>> audeer.StrictVersion('2023.04.26')
StrictVersion ('2023.4.26')
```

![image](https://user-images.githubusercontent.com/173624/234611956-2117364a-47a4-4d90-b895-7d8f38d8e2fc.png)
