### PR TITLE
Compare versions everywhere with audeer.StrictVersion

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -32,7 +32,7 @@ from audb.core.utils import lookup_backend
 
 
 CachedVersions = typing.Sequence[
-    typing.Tuple[audeer.LooseVersion, str, Dependencies],
+    typing.Tuple[audeer.StrictVersion, str, Dependencies],
 ]
 
 
@@ -66,7 +66,7 @@ def _cached_versions(
             cached_versions.insert(
                 0,
                 (
-                    audeer.LooseVersion(row['version']),
+                    audeer.StrictVersion(row['version']),
                     str(flavor_root),
                     deps,
                 ),
@@ -93,7 +93,7 @@ def _cached_files(
             disable=not verbose,
     ):
         found = False
-        file_version = audeer.LooseVersion(deps.version(file))
+        file_version = audeer.StrictVersion(deps.version(file))
         for cache_version, cache_root, cache_deps in cached_versions:
             if cache_version >= file_version:
                 if file in cache_deps:

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -767,8 +767,8 @@ def test_publish_error_messages(
         if (
                 previous_version
                 and (
-                    audeer.LooseVersion(previous_version)
-                    < audeer.LooseVersion(version)
+                    audeer.StrictVersion(previous_version)
+                    < audeer.StrictVersion(version)
                 )
         ):
             deps = audb.dependencies(


### PR DESCRIPTION
Closes #296 

In https://github.com/audeering/audb/pull/294 we introduced to use `audeer.StrictVersion`, maybe we should replace internally `audeer.LooseVersion` as well.