### PR TITLE
publish(): only version has to be StrictVersion

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -575,13 +575,17 @@ def publish(
             misc tables, or attachemnts
             that are stored under an ID
             using a char not in ``'[A-Za-z0-9._-]'``
-        ValueError: if ``version`` or ``previous_version``
-            cannot be parsed by :class:`audeer.StrictVersion`
+        ValueError: if ``version`` cannot be parsed
+            by :class:`audeer.StrictVersion`
         ValueError: if ``previous_version`` >= ``version``
 
     """
-    # Enforce error if version cannot be converted to audeer.StrictVersion
-    audeer.StrictVersion(version)
+    # Get a StrictVersion object
+    # and enforce given version is supported by it
+    strict_version = audeer.StrictVersion('1.0')
+    if not strict_version.version_re.match(version):
+        raise ValueError(f"Invalid version number '{version}'.")
+
     if (
             previous_version is not None
             and previous_version != 'latest'

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -590,8 +590,8 @@ def publish(
             previous_version is not None
             and previous_version != 'latest'
             and (
-                audeer.StrictVersion(version)
-                <= audeer.StrictVersion(previous_version)
+                audeer.LooseVersion(version)
+                <= audeer.LooseVersion(previous_version)
             )
     ):
         raise ValueError(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1003,9 +1003,9 @@ def test_publish_error_version(tmpdir, repository):
     # Request `previous_version` with forbidden character.
     # As it is not possible to publish such a database,
     # it will not be able to find it
-    error_msg = "Cannot find version 1.0.0? for database 'db'."
+    error_msg = "Cannot find version 1.0.0/ for database 'db'."
     with pytest.raises(RuntimeError, match=re.escape(error_msg)):
-        audb.publish(db_path, '2.0.0', repository, previous_version='1.0.0?')
+        audb.publish(db_path, '2.0.0', repository, previous_version='1.0.0/')
 
 
 def test_update_database(dbs, persistent_repository):

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1000,8 +1000,11 @@ def test_publish_error_version(tmpdir, repository):
     db['table']['column'].set(['different-label'])
     db.save(db_path)
 
-    error_msg = "Invalid version number '1.0.0?'"
-    with pytest.raises(ValueError, match=re.escape(error_msg)):
+    # Request `previous_version` with forbidden character.
+    # As it is not possible to publish such a database,
+    # it will not be able to find it
+    error_msg = "Cannot find version 1.0.0? for database 'db'."
+    with pytest.raises(RuntimeError, match=re.escape(error_msg)):
         audb.publish(db_path, '2.0.0', repository, previous_version='1.0.0?')
 
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -989,7 +989,7 @@ def test_publish_error_version(tmpdir, repository):
     db['table']['column'].set(['label'])
     db.save(db_path)
 
-    error_msg = "invalid version number '1.0.0?'"
+    error_msg = "Invalid version number '1.0.0?'"
     with pytest.raises(ValueError, match=re.escape(error_msg)):
         audb.publish(db_path, '1.0.0?', repository)
 
@@ -1000,7 +1000,7 @@ def test_publish_error_version(tmpdir, repository):
     db['table']['column'].set(['different-label'])
     db.save(db_path)
 
-    error_msg = "invalid version number '1.0.0?'"
+    error_msg = "Invalid version number '1.0.0?'"
     with pytest.raises(ValueError, match=re.escape(error_msg)):
         audb.publish(db_path, '2.0.0', repository, previous_version='1.0.0?')
 


### PR DESCRIPTION
Closes #296 

To not break backward compatibility with previous published databases, `audb.publish()` does now only check `version` is compatible with `audeer.StrictVersion`, not `previous_version`.

![image](https://user-images.githubusercontent.com/173624/234784410-6f88ebeb-83b3-4148-9d9a-a3cbdd463440.png)
