### PR TITLE
Require audbackend<1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audbackend >=0.3.17
+    audbackend >=0.3.17, <1.0.0
     audeer >=1.18.0
     audformat >=0.16.1
     audiofile >=1.0.0


### PR DESCRIPTION
As we know that we will introduce breaking changes in `audbackend` and will most likely also need to publish that package before we update `audb` it makes sense to add a limit the `audbackend` version in the dependencies of `audb`.