### PR TITLE
Switch to new backend interface

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -374,9 +374,10 @@ def _get_attachments_from_backend(
         archive = deps.archive(path)
         version = deps.version(path)
         archive = backend.join(
+            '/',
             db.name,
             define.DEPEND_TYPE_NAMES[define.DependType.ATTACHMENT],
-            archive,
+            archive + '.zip',
         )
         backend.get_archive(
             archive,
@@ -441,9 +442,10 @@ def _get_media_from_backend(
 
     def job(archive: str, version: str):
         archive = backend.join(
+            '/',
             name,
             define.DEPEND_TYPE_NAMES[define.DependType.MEDIA],
-            archive,
+            archive + '.zip',
         )
         # extract and move all files that are stored in the archive,
         # even if only a single file from the archive was requested
@@ -503,9 +505,10 @@ def _get_tables_from_backend(
 
     def job(table: str):
         archive = backend.join(
+            '/',
             db.name,
             define.DEPEND_TYPE_NAMES[define.DependType.META],
-            deps.archive(table),
+            deps.archive(table) + '.zip',
         )
         backend.get_archive(
             archive,
@@ -1350,7 +1353,7 @@ def load_header_to(
     local_header = os.path.join(db_root, define.HEADER_FILE)
     if overwrite or not os.path.exists(local_header):
         backend = lookup_backend(name, version)
-        remote_header = backend.join(name, define.HEADER_FILE)
+        remote_header = backend.join('/', name, define.HEADER_FILE)
         if add_audb_meta:
             db_root_tmp = database_tmp_root(db_root)
             local_header = os.path.join(db_root_tmp, define.HEADER_FILE)

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -122,9 +122,10 @@ def _get_attachments(
         archive = deps.archive(path)
         version = deps.version(path)
         archive = backend.join(
+            '/',
             db_name,
             define.DEPEND_TYPE_NAMES[define.DependType.ATTACHMENT],
-            archive,
+            archive + '.zip',
         )
         backend.get_archive(
             archive,
@@ -173,9 +174,10 @@ def _get_media(
 
     def job(archive: str, version: str):
         archive = backend.join(
+            '/',
             db_name,
             define.DEPEND_TYPE_NAMES[define.DependType.MEDIA],
-            archive,
+            archive + '.zip',
         )
         files = backend.get_archive(
             archive,
@@ -221,9 +223,10 @@ def _get_tables(
         if os.path.exists(path_pkl):
             os.remove(path_pkl)
         archive = backend.join(
+            '/',
             db_name,
             define.DEPEND_TYPE_NAMES[define.DependType.META],
-            deps.archive(table),
+            deps.archive(table) + '.zip',
         )
         backend.get_archive(
             archive,

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -11,6 +11,7 @@ import audformat
 import audiofile
 
 from audb.core import define
+from audb.core import utils
 from audb.core.api import dependencies
 from audb.core.dependencies import Dependencies
 from audb.core.repository import Repository
@@ -345,12 +346,13 @@ def _put_attachments(
 ):
     def job(attachment_id: str):
         archive_file = backend.join(
+            '/',
             db.name,
             define.DEPEND_TYPE_NAMES[define.DependType.ATTACHMENT],
-            attachment_id,
+            attachment_id + '.zip',
         )
         files = db.attachments[attachment_id].files
-        backend.put_archive(db_root, files, archive_file, version)
+        backend.put_archive(db_root, archive_file, version, files=files)
 
     audeer.run_tasks(
         job,
@@ -389,9 +391,10 @@ def _put_media(
                     update_media.append(file)
 
                 archive_file = backend.join(
+                    '/',
                     db_name,
                     define.DEPEND_TYPE_NAMES[define.DependType.MEDIA],
-                    archive,
+                    archive + '.zip',
                 )
 
                 if previous_version is not None:
@@ -423,9 +426,9 @@ def _put_media(
 
                 backend.put_archive(
                     db_root,
-                    files,
                     archive_file,
                     version,
+                    files=files,
                 )
 
         update_media = []
@@ -451,11 +454,12 @@ def _put_tables(
     def job(table: str):
         file = f'db.{table}.csv'
         archive_file = backend.join(
+            '/',
             db_name,
             define.DEPEND_TYPE_NAMES[define.DependType.META],
-            table,
+            table + '.zip',
         )
-        backend.put_archive(db_root, file, archive_file, version)
+        backend.put_archive(db_root, archive_file, version, files=file)
 
     audeer.run_tasks(
         job,
@@ -602,14 +606,10 @@ def publish(
         verbose=verbose,
     )
 
-    backend = audbackend.create(
-        repository.backend,
-        repository.host,
-        repository.name,
-    )
+    backend = utils.access_backend(repository)
 
-    remote_header = backend.join(db.name, define.HEADER_FILE)
-    versions = backend.versions(remote_header)
+    remote_header = backend.join('/', db.name, define.HEADER_FILE)
+    versions = backend.versions(remote_header, suppress_backend_errors=True)
     if version in versions:
         raise RuntimeError(
             'A version '
@@ -755,12 +755,16 @@ def publish(
 
     # publish dependencies and header
     deps.save(deps_path)
-    archive_file = backend.join(db.name, define.DB)
-    backend.put_archive(db_root, define.DEPENDENCIES_FILE, archive_file,
-                        version)
+    archive_file = backend.join('/', db.name, define.DB + '.zip')
+    backend.put_archive(
+        db_root,
+        archive_file,
+        version,
+        files=define.DEPENDENCIES_FILE,
+    )
     try:
         local_header = os.path.join(db_root, define.HEADER_FILE)
-        remote_header = db.name + '/' + define.HEADER_FILE
+        remote_header = backend.join('/', db.name, define.HEADER_FILE)
         backend.put_file(local_header, remote_header, version)
     except Exception:  # pragma: no cover
         # after the header is published

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1,26 +1,7 @@
 Authentication
 ==============
 
-If you want to use an Artifactory backend,
-users need to authenticate.
-You could use `anonymous access`_,
-but we would only recommend it for downloading public data.
-
-To authenticate
-users have to store their credentials in :file:`~/.artifactory_python.cfg`.
-
-.. code-block:: cfg
-
-    [your-organization.jfrog.io/artifactory]
-    username = MY_USERNAME
-    password = MY_API_KEY
-
-Alternatively, they can export them as environment variables.
-
-.. code-block:: bash
-
-    export ARTIFACTORY_USERNAME="MY_USERNAME"
-    export ARTIFACTORY_API_KEY="MY_API_KEY"
-
-
-.. _anonymous access: https://jfrog.com/help/r/how-to-grant-an-anonymous-user-access-to-specific-repositories/
+Using Artifactory as backend
+requires authentication.
+For more information,
+see :class:`audbackend.Artifactory`.

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -22,6 +22,10 @@
         if os.path.exists(folder):
             shutil.rmtree(folder)
 
+    # create repository
+    os.mkdir('./data')
+    os.mkdir('./data/data-local')
+
 
 .. _publish:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
-    'audbackend >=0.3.17, <1.0.0',
+    'audbackend >=1.0.0',
     'audeer >=1.20.0',
     'audformat >=0.16.1',
     'audiofile >=1.0.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
-    'audbackend >=1.0.0',
+    'audbackend[artifactory] >=1.0.0',
     'audeer >=1.20.0',
     'audformat >=0.16.1',
     'audiofile >=1.0.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import glob
 import os
 
-import audeer
 import pytest
+
+import audeer
 
 import audb
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import glob
 import os
 
+import audeer
 import pytest
 
 import audb
@@ -122,11 +123,13 @@ def repository(tmpdir_factory):
 
     """
     host = tmpdir_factory.mktemp('host')
+    name = 'data-unittests-local'
     repository = audb.Repository(
-        name='data-unittests-local',
+        name=name,
         host=host,
         backend='file-system',
     )
+    audeer.mkdir(audeer.path(host, name))
     current_repositories = audb.config.REPOSITORIES
     audb.config.REPOSITORIES = [repository]
 
@@ -156,11 +159,13 @@ def persistent_repository(tmpdir_factory):
 
     """
     host = tmpdir_factory.mktemp('host')
+    name = 'data-unittests-local'
     repository = audb.Repository(
-        name='data-unittests-local',
+        name=name,
         host=host,
         backend='file-system',
     )
+    audeer.mkdir(audeer.path(host, name))
     current_repositories = audb.config.REPOSITORIES
     audb.config.REPOSITORIES = [repository]
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -67,25 +67,25 @@ def test_cached_name(cache):
     df = audb.cached(name=DB_NAMES[0])
     assert len(df) == 0
     # Load first database
-    audb.load(DB_NAMES[0])
+    audb.load(DB_NAMES[0], verbose=False)
     df = audb.cached()
     assert len(df) == 1
-    assert set(df['name']) == set([DB_NAMES[0]])
+    assert set(df['name']) == {DB_NAMES[0]}
     df = audb.cached(name=DB_NAMES[0])
     assert len(df) == 1
-    assert set(df['name']) == set([DB_NAMES[0]])
+    assert set(df['name']) == {DB_NAMES[0]}
     df = audb.cached(name=DB_NAMES[1])
     assert len(df) == 0
     # Load second database
-    audb.load(DB_NAMES[1])
+    audb.load(DB_NAMES[1], verbose=False)
     df = audb.cached()
     assert len(df) == 2
     assert set(df['name']) == set(DB_NAMES)
     df = audb.cached(name=DB_NAMES[0])
     assert len(df) == 1
-    assert set(df['name']) == set([DB_NAMES[0]])
+    assert set(df['name']) == {DB_NAMES[0]}
     df = audb.cached(name=DB_NAMES[1])
     assert len(df) == 1
-    assert set(df['name']) == set([DB_NAMES[1]])
+    assert set(df['name']) == {DB_NAMES[1]}
     df = audb.cached(name='non-existent')
     assert len(df) == 0

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -817,20 +817,27 @@ def test_load_to_update(tmpdir, dbs, only_metadata):
 
 
 @pytest.mark.parametrize(
-    'name, version',
+    'name, version, error, error_msg',
     [
-        (DB_NAME, None),
-        (DB_NAME, '1.0.0'),
+        (DB_NAME, '1.0.0', None, None),
         pytest.param(  # database does not exist
-            'does-not-exist', None,
-            marks=pytest.mark.xfail(raises=RuntimeError),
+            'does-not-exist',
+            '1.0.0',
+            RuntimeError,
+            "Cannot find database 'does-not-exist'.",
         ),
         pytest.param(  # version does not exist
-            DB_NAME, 'does-not-exist',
-            marks=pytest.mark.xfail(raises=RuntimeError),
+            DB_NAME,
+            '999.9.9',
+            RuntimeError,
+            f"Cannot find version '999.9.9' for database '{DB_NAME}'.",
         )
     ]
 )
-def test_repository(persistent_repository, name, version):
-    repository = audb.repository(name, version)
-    assert repository == persistent_repository
+def test_repository(persistent_repository, name, version, error, error_msg):
+    if error is not None:
+        with pytest.raises(error, match=error_msg):
+            repository = audb.repository(name, version)
+    else:
+        repository = audb.repository(name, version)
+        assert repository == persistent_repository

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -331,7 +331,7 @@ def test_lock_load(
 )
 def test_lock_load_crash(set_repositories):
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(audbackend.BackendError):
         load_db(-1)
 
 
@@ -384,7 +384,7 @@ def test_lock_load_from_cached_versions(
     thread.start()
 
     # -> loading missing table from cache fails
-    with pytest.raises(RuntimeError):
+    with pytest.raises(audbackend.BackendError):
         audb.load(
             DB_NAME,
             version='2.0.0',
@@ -412,7 +412,7 @@ def test_lock_load_from_cached_versions(
     thread.start()
 
     # -> loading missing media from cache fails
-    with pytest.raises(RuntimeError):
+    with pytest.raises(audbackend.BackendError):
         audb.load(
             DB_NAME,
             version='2.0.0',

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 
+import audbackend
 import numpy as np
 import pandas as pd
 import pytest
@@ -463,7 +464,7 @@ def test_publish(dbs, persistent_repository, version):
 
     for file in db.files:
         name = archives[file] if file in archives else file
-        file_path = backend.join(db.name, 'media', name)
+        file_path = backend.join('/', db.name, 'media', name)
         backend.exists(file_path, version)
         path = os.path.join(dbs[version], file)
         assert deps.checksum(file) == audeer.md5(path)
@@ -948,6 +949,17 @@ def test_publish_error_changed_deps_file_type(tmpdir, repository):
     with pytest.raises(RuntimeError, match=error_msg):
         audb.publish(db_path, '2.0.0', repository)
     audeer.rmdir(db_path)
+
+
+def test_publish_error_repository_does_not_exist(tmpdir, repository):
+
+    db = audformat.Database('test')
+    db.save(tmpdir)
+
+    repository.name = 'does-not-exist'
+    with pytest.raises(audbackend.BackendError) as ex:
+        audb.publish(tmpdir, '1.0.0', repository)
+    assert 'No such file or directory' in str(ex.value.exception)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -3,11 +3,11 @@ import os
 import re
 import shutil
 
-import audbackend
 import numpy as np
 import pandas as pd
 import pytest
 
+import audbackend
 import audeer
 import audformat.testing
 import audiofile


### PR DESCRIPTION
Apply necessary changes to `audb` in order to use the new backend interface that will be introduced with `audackend>=1.0.0`, see https://github.com/audeering/audbackend/issues/76.
This does not change how files are stored on Artifatory hosts as we use the legacy backend option there.

~~Building the docs and running the docstring examples are temporary disabled until we have a published version of emodb with the new structure~~

In the Authentication section we now link to `audbackend.Artifactory`:

![image](https://github.com/audeering/audb/assets/10383417/06a8d4f9-c67c-470b-b41f-f87b4200c294)
