### PR TITLE
DOC: fix link to Artifactory anonymous access docs

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -23,4 +23,4 @@ Alternatively, they can export them as environment variables.
     export ARTIFACTORY_API_KEY="MY_API_KEY"
 
 
-.. _anonymous access: https://jfrog.com/knowledge-base/how-to-grant-an-anonymous-user-access-to-specific-repositories/
+.. _anonymous access: https://jfrog.com/help/r/how-to-grant-an-anonymous-user-access-to-specific-repositories/


### PR DESCRIPTION
Artifactory changed the link of the documentation on anonymous access.