### PR TITLE
Fix load attachments for same shared cache/cache

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -41,6 +41,11 @@ def _cached_versions(
     # This fixes https://github.com/audeering/audb/issues/101
     if cache_root is None and os.path.exists(default_cache_root(shared=True)):
         df = pd.concat((df, cached(name=name, shared=True)))
+        # Ensure to remove duplicates,
+        # which can occur if cache and shared cache
+        # point to the same folder.
+        # Compare https://github.com/audeering/audb/issues/314
+        df = df[~df.index.duplicated(keep="first")]
 
     cached_versions = []
     for flavor_root, row in df.iterrows():

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -10,13 +10,7 @@ import audb
 
 @pytest.fixture(scope="function", autouse=False)
 def same_cache():
-    r"""Set shared cache to cache folder.
-
-    Set shared cache folder
-    to the same folder
-    as the user cache.
-
-    """
+    r"""Set shared cache to same folder as user cache."""
     current_shared_cache = audb.config.SHARED_CACHE_ROOT
     audb.config.SHARED_CACHE_ROOT = audb.config.CACHE_ROOT
 
@@ -37,7 +31,7 @@ def test_loading_attachments_from_cache(tmpdir, repository, same_cache):
 
     """
     # Create version 1.0.0 of database,
-    # publish and load to cache
+    # publish and load
     db_name = "db"
     db_version = "1.0.0"
     db_root = audeer.mkdir(audeer.path(tmpdir, db_name))
@@ -54,7 +48,7 @@ def test_loading_attachments_from_cache(tmpdir, repository, same_cache):
     db = audb.load(db_name, version=db_version, verbose=False)
 
     # Create version 2.0.0 of database,
-    # and publish
+    # and publish and load
     db = audb.load_to(db_root, db_name, version=db_version)
     db_version = "2.0.0"
     db.description = f"Version {db_version} of database."
@@ -62,9 +56,9 @@ def test_loading_attachments_from_cache(tmpdir, repository, same_cache):
 
     audb.publish(db_root, db_version, repository)
 
-    # Try to load attachments
     db = audb.load(db_name, version=db_version, verbose=False)
 
+    # Ensure attachment file is loaded
     assert list(db.attachments) == [filename]
     for attachment in list(db.attachments):
         for file in db.attachments[attachment].files:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,71 @@
+import os
+
+import pytest
+
+import audeer
+import audformat
+
+import audb
+
+
+@pytest.fixture(scope="function", autouse=False)
+def same_cache():
+    r"""Set shared cache to cache folder.
+
+    Set shared cache folder
+    to the same folder
+    as the user cache.
+
+    """
+    current_shared_cache = audb.config.SHARED_CACHE_ROOT
+    audb.config.SHARED_CACHE_ROOT = audb.config.CACHE_ROOT
+
+    yield
+
+    audb.config.SHARED_CACHE_ROOT = current_shared_cache
+
+
+def test_loading_attachments_from_cache(tmpdir, repository, same_cache):
+    r"""Ensures loading attachments from cache works.
+
+    As reported in https://github.com/audeering/audb/issues/314,
+    loading an attachment for a database
+    fails to acquire a lock,
+    if the database has a previous version in the cache,
+    and ``audb.config.CACHE_ROOT`` and ``audb.config.SHARED_CACHE_ROOT``
+    point to the same folder.
+
+    """
+    # Create version 1.0.0 of database,
+    # publish and load to cache
+    db_name = "db"
+    db_version = "1.0.0"
+    db_root = audeer.mkdir(audeer.path(tmpdir, db_name))
+    db = audformat.Database(db_name)
+    db.description = f"Version {db_version} of database."
+    filename = "file.txt"
+    with open(audeer.path(db_root, filename), "w") as file:
+        file.write(f"{filename}\n")
+    db.attachments[filename] = audformat.Attachment(filename)
+    db.save(db_root)
+
+    audb.publish(db_root, db_version, repository)
+
+    db = audb.load(db_name, version=db_version, verbose=False)
+
+    # Create version 2.0.0 of database,
+    # and publish
+    db = audb.load_to(db_root, db_name, version=db_version)
+    db_version = "2.0.0"
+    db.description = f"Version {db_version} of database."
+    db.save(db_root)
+
+    audb.publish(db_root, db_version, repository)
+
+    # Try to load attachments
+    db = audb.load(db_name, version=db_version, verbose=False)
+
+    assert list(db.attachments) == [filename]
+    for attachment in list(db.attachments):
+        for file in db.attachments[attachment].files:
+            assert os.path.exists(audeer.path(db.root, file))


### PR DESCRIPTION
Closes https://github.com/audeering/audb/issues/314.

This ensures that `audb.core.load._cached_versions()` does not return duplicated entries, when `audb.config.SHARED_CACHE_ROOT` and `audb.config.CACHE_ROOT` point to the same folder.
As `audb.core.load._get_attachments_from_cache()` is setting a folder lock to all folders given by `audb.core.load._cached_versions()` at the same time, this can then no longer lead to a folder lock error,
and finally it will no longer result in an error/user warning when running `audb.load()`.