### PR TITLE
CI: use Python 3.10 as default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install pre-commit hooks
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.8'
             tasks: tests
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.9'
             tasks: tests
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 #
 #
 default_language_version:
-  python: python3.8
+  python: python3.10
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Switches CI jobs that use only a single Python version from Python 3.8 to Python 3.10.