### PR TITLE
Fix repo discovery for private/non-existing repos

### DIFF
--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -72,10 +72,14 @@ def _lookup(
     """
     for repository in config.REPOSITORIES:
 
-        backend = access_backend(repository)
+        try:
+            backend = access_backend(repository)
+        except audbackend.BackendError:
+            continue
+
         header = backend.join('/', name, 'db.yaml')
 
-        if backend.exists(header, version):
+        if backend.exists(header, version, suppress_backend_errors=True):
             return repository, backend
 
     raise RuntimeError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,58 @@ def persistent_repository(tmpdir_factory):
     audb.config.REPOSITORIES = current_repositories
 
 
+@pytest.fixture(scope='module', autouse=False)
+def private_and_public_repository():
+    r"""Private and public repository on Artifactory.
+
+    Configure the following repositories:
+    * data-private: repo on public Artifactory without access
+    * data-public: repo on public Artifactory with anonymous access
+
+    Note, that the order of the repos is important.
+    audb will visit the repos in the given order
+    until it finds the requested database.
+
+    """
+    host = 'https://audeering.jfrog.io/artifactory'
+    backend = 'artifactory'
+    current_repositories = audb.config.REPOSITORIES
+    audb.config.REPOSITORIES = [
+        audb.Repository('data-private', host, backend),
+        audb.Repository('data-public', host, backend),
+    ]
+
+    yield repository
+
+    audb.config.REPOSITORIES = current_repositories
+
+
+@pytest.fixture(scope='module', autouse=False)
+def non_existing_repository():
+    r"""Non-existing repository on Artifactory.
+
+    Configure the following repositories:
+    * non-existing: non-exsiting repo on public Artifactory
+    * data-public: repo on public Artifactory with anonymous access
+
+    Note, that the order of the repos is important.
+    audb will visit the repos in the given order
+    until it finds the requested database.
+
+    """
+    host = 'https://audeering.jfrog.io/artifactory'
+    backend = 'artifactory'
+    current_repositories = audb.config.REPOSITORIES
+    audb.config.REPOSITORIES = [
+        audb.Repository('non-existing', host, backend),
+        audb.Repository('data-public', host, backend),
+    ]
+
+    yield repository
+
+    audb.config.REPOSITORIES = current_repositories
+
+
 @pytest.fixture(scope='package', autouse=True)
 def hide_default_repositories():
     r"""Hide default audb repositories during testing."""

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,37 @@
+import audb
+
+
+def test_visiting_repos(private_and_public_repository):
+    r"""Tests visiting several repos when looking for a database.
+
+    When requesting a database,
+    audb needs to look for it
+    in every repository on the corresponding backend.
+    This should not fail,
+    even when the user has no access rights.
+
+    """
+    audb.load(
+        'emodb',
+        version='1.4.1',
+        only_metadata=True,
+        verbose=False,
+    )
+
+
+def test_visiting_non_existing_repos(non_existing_repository):
+    r"""Tests visiting non-existing backends when looking for a database.
+
+    When requesting a database,
+    audb needs to look for it
+    in every repository on the corresponding backend.
+    This should not fail,
+    even when the user has no access rights.
+
+    """
+    audb.load(
+        'emodb',
+        version='1.4.1',
+        only_metadata=True,
+        verbose=False,
+    )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,8 +1,8 @@
 import audb
 
 
-def test_visiting_repos(private_and_public_repository):
-    r"""Tests visiting several repos when looking for a database.
+def test_visiting_private_repos(private_and_public_repository):
+    r"""Tests visiting private repos when looking for a database.
 
     When requesting a database,
     audb needs to look for it
@@ -26,7 +26,7 @@ def test_visiting_non_existing_repos(non_existing_repository):
     audb needs to look for it
     in every repository on the corresponding backend.
     This should not fail,
-    even when the user has no access rights.
+    even when a repository does not exist.
 
     """
     audb.load(


### PR DESCRIPTION
Closes #333 

Make sure that `audb` does not raise a backend error when looking for databases on different backends, including ones where no permissions are given or that do not exist. For the later you might argue that it is ok to raise an error, but on Artifactory we cannot differentiate between having no access rights and non-existing repos. As we usually share the same config file for all users, it seems more important to me to not fail in the case of missing access rights.

The pull request first adds a test that fails for the current main branch, and changes the code afterwards to no longer raise an error.