### PR TITLE
DOC: make independent of published datasets

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -36,8 +36,10 @@ def available(
         >>> audb.available(only_latest=True)
                    backend                                    host   repository version
         name
-        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.1
-        musan  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.0.0
+        air     artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.2
+        emodb   artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.1
+        micirp  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.0.0
+        musan   artifactory  https://audeering.jfrog.io/artifactory  data-public   1.0.0
 
     """  # noqa: E501
     databases = []

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -33,13 +33,12 @@ def available(
         and backend, host, repository, version as columns
 
     Examples:
-        >>> audb.available(only_latest=True)
+        >>> df = audb.available(only_latest=True)
+        >>> df.loc[['air', 'emodb']]
                    backend                                    host   repository version
         name
-        air     artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.2
-        emodb   artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.1
-        micirp  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.0.0
-        musan   artifactory  https://audeering.jfrog.io/artifactory  data-public   1.0.0
+        air    artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.2
+        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.1
 
     """  # noqa: E501
     databases = []

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -37,6 +37,7 @@ def available(
                    backend                                    host   repository version
         name
         emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.1
+        musan  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.0.0
 
     """  # noqa: E501
     databases = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,7 @@ if not audb.exists(database_name, version=database_version):
     audb.load(
         database_name,
         version=database_version,
-        num_workers=5,
+        num_workers=1,
         only_metadata=True,
         verbose=False,
     )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,7 @@ if not audb.exists(database_name, version=database_version):
     audb.load(
         database_name,
         version=database_version,
-        num_workers=1,
+        num_workers=5,
         only_metadata=True,
         verbose=False,
     )

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -21,7 +21,9 @@ Quickstart
 The most common task is to load a database
 with :func:`audb.load`.
 
-Let's first see which databases are available to load.
+Let's first see which databases are available
+on our `public Artifactory server`_.
+
 
 .. jupyter-execute::
 
@@ -29,11 +31,7 @@ Let's first see which databases are available to load.
 
     audb.available()
 
-As you can see we provide the emodb_ database
-as small example database,
-which we `have published`_
-to our `public Artifactory server`_.
-Let's load the database.
+Let's load the emodb_ database.
 
 .. Load with only_metadata=True in the background
 .. jupyter-execute::
@@ -93,6 +91,5 @@ as a :class:`pandas.DataFrame`.
     df[:3]  # show first three entries
 
 
-.. _emodb: http://emodb.bilderbar.info/start.html
-.. _have published: https://github.com/audeering/emodb
+.. _emodb: https://github.com/audeering/emodb
 .. _public Artifactory server: https://audeering.jfrog.io/artifactory

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -31,7 +31,7 @@ on our `public Artifactory server`_.
 
     audb.available()
 
-Let's load the emodb_ database.
+Let's load version 1.4.1 of the emodb_ database.
 
 .. Load with only_metadata=True in the background
 .. jupyter-execute::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -29,7 +29,7 @@ on our `public Artifactory server`_.
 
     import audb
 
-    audb.available()
+    audb.available(only_latest=True)
 
 Let's load version 1.4.1 of the emodb_ database.
 


### PR DESCRIPTION
As we now have started to publish more datasets to the public repo (so far [musan](https://github.com/audeering/musan), [air](https://github.com/audeering/air), [micirp](https://github.com/audeering/micirp)), I updated the example of `audb.available()` to limit the output to two datasets:

![image](https://github.com/audeering/audb/assets/173624/ccfddccc-c6b8-4a34-9cf2-a67b833acb8b)

In addition, I updated the quickstart documentation to make its wording work independent of the number of published datasets, and show only the latest version of the dataset.

![image](https://github.com/audeering/audb/assets/173624/59a56aed-9da2-4527-9b9b-7f133891eef2)
