### PR TITLE
Speed up audb.versions()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -613,7 +613,11 @@ def versions(
                 backend._api_key,
             )
             if path.exists():
-                vs.extend([p.parts[-1] for p in path])
+                for p in path:
+                    version = p.parts[-1]
+                    header = p.joinpath(version).joinpath(f'db-{version}.yaml')
+                    if header.exists():
+                        vs.extend([version])
         else:
             header = backend.join('/', name, 'db.yaml')
             vs.extend(backend.versions(header, suppress_backend_errors=True))

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -615,7 +615,7 @@ def versions(
             if path.exists():
                 for p in path:
                     version = p.parts[-1]
-                    header = p.joinpath(version).joinpath(f'db-{version}.yaml')
+                    header = p.joinpath(f'db-{version}.yaml')
                     if header.exists():
                         vs.extend([version])
         else:


### PR DESCRIPTION
As we still have the problem of `bakcend.ls()` being slow on Artifactory (https://github.com/audeering/audbackend/issues/132) and the solution I use here does only work for legacy backends (as a anonymous user is not allowed to gather all folders on the root of the repo), I propose to speed up `audb` by adding manual code.

The execution time of `audb.versions("emodb")` is (averaged over 10 runs):

| main | this branch |
| --- | --- |
| 3.0 s | 1.2 s |

BTW, when not checking for the header file, but just for the folder, the execution time is 0.7 s. But this seems to risky to me, as the header file is usually our ground truth that the database is complete, compare https://github.com/audeering/audb/blob/e36d548c113b525b9e462302273be41c21b72bc6/audb/core/publish.py#L765-L775

