### PR TITLE
DOC: set pyarrow as dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 docutils
 ipykernel
 jupyter-sphinx
+pyarrow
 sphinx >=3.5.4
 sphinx-audeering-theme >=1.2.1
 sphinx-autodoc-typehints


### PR DESCRIPTION
This adds `pyarrow` to the dependencies in `docs/requirements.txt` to avoid a failing doc test due to a raised warning
as `pyarrow` will become a dependency in `pndas` 3.0.0 (see https://github.com/pandas-dev/pandas/issues/54466).

We will also depent in the future on `pyarrow` in `audb` anyway, compare https://github.com/audeering/audb/issues/321