### PR TITLE
Fix pandas and pytest deprecation warnings

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -183,7 +183,7 @@ def _files_duration(
         format: typing.Optional[str],
 ):
     field = define.DEPEND_FIELD_NAMES[define.DependField.DURATION]
-    durs = deps().loc[files][field]
+    durs = deps().loc[files, field]
     durs = durs[durs > 0]
     durs = pd.to_timedelta(durs, unit='s')
     durs.index.name = 'file'

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -148,7 +148,8 @@ def dbs(tmpdir_factory, persistent_repository):
     db_root = tmpdir_factory.mktemp(version)
     paths[version] = str(db_root)
 
-    db['train'].df['label'][0] = None
+    row = db['train'].index[0]
+    db['train'].df.at[row, 'label'] = None
     shutil.copytree(
         audeer.path(previous_db_root, 'extra'),
         audeer.path(db_root, 'extra'),
@@ -313,7 +314,7 @@ def test_load(dbs, format, version, only_metadata):
     # Assert database exists in cache
     assert audb.exists(DB_NAME, version=version, format=format)
     df = audb.cached()
-    assert df.loc[db_root]['version'] == resolved_version
+    assert df.loc[db_root, 'version'] == resolved_version
 
     # Assert files duration are stored as hidden attribute
     if not only_metadata:
@@ -429,7 +430,7 @@ def test_load_from_cache(dbs):
     # Assert database exists in cache
     assert audb.exists(DB_NAME, version=version, format=format)
     df = audb.cached()
-    assert df.loc[db_root]['version'] == version
+    assert df.loc[db_root, 'version'] == version
 
     # Assert media files are identical and exist
     pd.testing.assert_index_equal(db.files, db_original.files)
@@ -456,7 +457,7 @@ def test_load_from_cache(dbs):
     # Assert database exists in cache
     assert audb.exists(DB_NAME, version=version, format=format)
     df = audb.cached()
-    assert df.loc[db_root]['version'] == version
+    assert df.loc[db_root, 'version'] == version
 
     # Assert media files are identical and exist
     pd.testing.assert_index_equal(db.files, db_original.files)

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -309,13 +309,22 @@ def test_lock_load(
         return
 
     warns = not multiprocessing and num_workers != expected
-    with pytest.warns(
-            UserWarning if warns else None,
-            match=audb.core.define.TIMEOUT_MSG,
-    ):
+    params = [([timeout], {})] * num_workers
+    if warns:
+        with pytest.warns(
+                UserWarning,
+                match=audb.core.define.TIMEOUT_MSG,
+        ):
+            result = audeer.run_tasks(
+                load_db,
+                params,
+                num_workers=num_workers,
+                multiprocessing=multiprocessing,
+            )
+    else:
         result = audeer.run_tasks(
             load_db,
-            [([timeout], {})] * num_workers,
+            params,
             num_workers=num_workers,
             multiprocessing=multiprocessing,
         )
@@ -528,13 +537,22 @@ def test_lock_load_media(
         return
 
     warns = not multiprocessing and num_workers != expected
-    with pytest.warns(
-            UserWarning if warns else None,
-            match=audb.core.define.TIMEOUT_MSG,
-    ):
+    params = [([timeout], {})] * num_workers
+    if warns:
+        with pytest.warns(
+                UserWarning,
+                match=audb.core.define.TIMEOUT_MSG,
+        ):
+            result = audeer.run_tasks(
+                load_media,
+                params,
+                num_workers=num_workers,
+                multiprocessing=multiprocessing,
+            )
+    else:
         result = audeer.run_tasks(
             load_media,
-            [([timeout], {})] * num_workers,
+            params,
             num_workers=num_workers,
             multiprocessing=multiprocessing,
         )

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -460,7 +460,7 @@ def test_publish(dbs, persistent_repository, version):
 
     df = audb.available(only_latest=True)
     assert DB_NAME in df.index
-    assert df[df.index == DB_NAME]['version'][0] == latest_version
+    assert df[df.index == DB_NAME]['version'].iat[0] == latest_version
 
     for file in db.files:
         name = archives[file] if file in archives else file


### PR DESCRIPTION
Changes indexing of dataframes and series to be in line with the latest `pandas` deprecation warnings, e.g. avoid chnaged indexing like `df[col][row]` and use `df.loc[row, col]` instead.

It also avoids using `pytest.warns(None, ...)` as this is also marked as deprecated by `pytest`.