### PR TITLE
Fix audb.versions() for private repos

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -621,9 +621,10 @@ def versions(
             except artifactory.ArtifactoryException:  # pragma: nocover
                 # This tackles the case of missing repo
                 # or missing read permissions.
-                # We cannot test this at the moment,
-                # because when using a repo without read access
-                # on the public Artifactory server
+                # We cannot test this at the moment
+                # on the public Artifactory server.
+                # Because after trying
+                # to connect to a repo without read access
                 # the connection is also blocked for valid repos.
                 pass
         else:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -601,6 +601,8 @@ def versions(
     for repository in config.REPOSITORIES:
         backend = utils.access_backend(repository)
         if isinstance(backend, audbackend.Artifactory):
+            import artifactory
+
             # Avoid using ls() on Artifactory
             # see https://github.com/devopshq/artifactory/issues/423
             folder = backend.join("/", name, "db")
@@ -609,12 +611,21 @@ def versions(
                 backend._username,
                 backend._api_key,
             )
-            if path.exists():
-                for p in path:
-                    version = p.parts[-1]
-                    header = p.joinpath(f"db-{version}.yaml")
-                    if header.exists():
-                        vs.extend([version])
+            try:
+                if path.exists():
+                    for p in path:
+                        version = p.parts[-1]
+                        header = p.joinpath(f"db-{version}.yaml")
+                        if header.exists():
+                            vs.extend([version])
+            except artifactory.ArtifactoryException:  # pragma: nocover
+                # This tackles the case of missing repo
+                # or missing read permissions.
+                # We cannot test this at the moment,
+                # because when using a repo without read access
+                # on the public Artifactory server
+                # the connection is also blocked for valid repos.
+                pass
         else:
             header = backend.join("/", name, "db.yaml")
             vs.extend(backend.versions(header, suppress_backend_errors=True))


### PR DESCRIPTION
Closes #351 

Ensures that `audb.versions()` does not fail for a user on Artifactory repositories without read permission.

As we cannot write a test for this on the public Artifactory server, I tested it on our internal server.