### PR TITLE
Speed up audb.Dependencies.__str__()

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -98,7 +98,7 @@ class Dependencies:
         return len(self._df)
 
     def __str__(self) -> str:  # noqa: D105
-        return self._df.to_string()
+        return str(self._df)
 
     @property
     def archives(self) -> typing.List[str]:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -229,4 +229,4 @@ def test_len(deps):
 
 
 def test_str(deps):
-    assert str(deps) == deps._df.to_string()
+    assert str(deps) == str(deps._df)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -350,7 +350,6 @@ def test_load(dbs, format, version, only_metadata):
 
     # Assert all files are listed in dependency table
     deps = audb.dependencies(DB_NAME, version=version)
-    assert str(deps().to_string()) == str(deps)
     assert len(deps) == (
         len(db.files) + len(db.tables) + len(db.misc_tables) + len(db.attachments)
     )


### PR DESCRIPTION
This provides a dramatic speed increase for `audb.Dependencies.__str__()` and large dependency tables as we now switch from `df.to_string()` to `str(df)`. The later does not show all rows, but limits the output.

Comparing for a dependency table with 1,000,000 rows:

| main | this branch |
| --- | --- |
| 16.337 s | 0.006 s |

<details><summary>Benchmark code</summary>

```python
import hashlib
import os
import pickle
import random
import string
import time

import pandas as pd

import audb
import audeer


# Dependency table with 1,000,000 entries
random.seed(1)

cache = audeer.mkdir("./cache")

# === Dependency pandas.DataFrame ===
data_cache = audeer.path(cache, "df.pkl")
num_rows = 1000000
dtypes = [str, str, int, int, str, float, str, int, int, int, str]
columns = [ 
    "file",
    "archive",
    "bit_depth",
    "channels",
    "checksum",
    "duration",
    "format",
    "removed",
    "sampling_rate",
    "type",
    "version",
]
if not os.path.exists(data_cache):
    records = [ 
        {
            "file": f"file-{n}.wav",
            "archive": f"archive-{n}",
            "bit_depth": random.choices([0, 16, 24], weights=[0.1, 0.8, 0.1])[0],
            "channels": random.choices([0, 1, 2], weights=[0.1, 0.8, 0.1])[0],
            "checksum": hashlib.md5(
                pickle.dumps(random.choice(string.ascii_letters))
            ).hexdigest(),
            "duration": 10 * random.random(),
            "format": random.choices(["csv", "wav", "txt"], weights=[0.1, 0.8, 0.1])[0], 
            "removed": random.choices([0, 1], weights=[0.1, 0.9])[0],
            "sampling_rate": random.choices(
                [0, 16000, 44100],
                weights=[0.1, 0.8, 0.1],
            )[0],
            "type": random.choices([0, 1, 2], weights=[0.1, 0.8, 0.1])[0],
            "version": random.choices(["1.0.0", "1.1.0"], weights=[0.2, 0.8])[0],
        }
        for n in range(num_rows)
    ]
    df = pd.DataFrame.from_records(records)
    for column, dtype in zip(df.columns, dtypes):
        df[column] = df[column].astype(dtype)
    df.set_index("file", inplace=True)
    df.index.name = ""
    df.to_pickle(data_cache)

deps = audb.Dependencies()
deps.load(data_cache)

# Measure execution time of String
t = time.time()
str(deps)
print(f"Dependency.__str__(): {time.time() -t:.3f} s")
```

</details>