### PR TITLE
Speedup audb.Dependencies to list conversions

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -91,7 +91,7 @@ class Dependencies:
             list with meta information
 
         """
-        return list(self._df.loc[file])
+        return self._df.loc[file].tolist()
 
     def __len__(self) -> int:
         r"""Number of all media, table, attachment files."""
@@ -118,7 +118,7 @@ class Dependencies:
             list of attachments
 
         """
-        return list(self._df[self._df["type"] == define.DependType.ATTACHMENT].index)
+        return self._df[self._df["type"] == define.DependType.ATTACHMENT].index.tolist()
 
     @property
     def attachment_ids(self) -> typing.List[str]:
@@ -128,7 +128,9 @@ class Dependencies:
             list of attachment IDs
 
         """
-        return list(self._df[self._df["type"] == define.DependType.ATTACHMENT].archive)
+        return self._df[
+            self._df["type"] == define.DependType.ATTACHMENT
+        ].archive.tolist()
 
     @property
     def files(self) -> typing.List[str]:
@@ -138,7 +140,7 @@ class Dependencies:
             list of files
 
         """
-        return list(self._df.index)
+        return self._df.index.tolist()
 
     @property
     def media(self) -> typing.List[str]:
@@ -148,7 +150,7 @@ class Dependencies:
             list of media
 
         """
-        return list(self._df[self._df["type"] == define.DependType.MEDIA].index)
+        return self._df[self._df["type"] == define.DependType.MEDIA].index.tolist()
 
     @property
     def removed_media(self) -> typing.List[str]:
@@ -158,12 +160,9 @@ class Dependencies:
             list of media
 
         """
-        return list(
-            self._df[
-                (self._df["type"] == define.DependType.MEDIA)
-                & (self._df["removed"] == 1)
-            ].index
-        )
+        return self._df[
+            (self._df["type"] == define.DependType.MEDIA) & (self._df["removed"] == 1)
+        ].index.tolist()
 
     @property
     def table_ids(self) -> typing.List[str]:
@@ -187,7 +186,7 @@ class Dependencies:
             list of tables
 
         """
-        return list(self._df[self._df["type"] == define.DependType.META].index)
+        return self._df[self._df["type"] == define.DependType.META].index.tolist()
 
     def archive(self, file: str) -> str:
         r"""Name of archive the file belongs to.


### PR DESCRIPTION
Speeds up conversion to Python list by using `x.tolist()` instead of `list(x)` in the following methods/properties:

* `audb.Dependencies.__getitem__()`
* `audb.Dependencies.attachments`
* `audb.Dependencies.attachment_ids`
* `audb.Dependencies.files`
* `audb.Dependencies.media`
* `audb.Dependencies.removed_media`
* `audb.Dependencies.tables`

| Method                                         | main | this branch |
| ---------------------------------------------- | -------------- | --- |
| `Dependency.__call__()`                        |        0.000 s | 0.000 s |
| `Dependency.__contains__()`                    |        0.000 s | 0.000 s |
| `Dependency.__get_item__()`                    |        0.000 s | 0.000 s |
| `Dependency.__len__()`                         |        0.000 s | 0.000 s |
| `Dependency.__str__()`                         |        0.006 s | 0.006 s |
| `Dependency.archives`                          |        0.147 s | 0.149 s |
| `Dependency.attachments`                       |        0.045 s | **0.031 s** |
| `Dependency.attachment_ids`                    |        0.045 s | **0.030 s** |
| `Dependency.files`                             |        0.185 s | **0.025 s** |
| `Dependency.media`                             |        0.264 s | **0.136 s** |
| `Dependency.removed_media`                     |        0.250 s | **0.126 s** |
| `Dependency.table_ids`                         |        0.053 s | **0.040 s** |
| `Dependency.tables`                            |        0.046 s | **0.031 s** |
| `Dependency.archive(1000 files)`               |        0.005 s | 0.006 s |
| `Dependency.bit_depth(1000 files)`             |        0.004 s | 0.004 s |
| `Dependency.channels(1000 files)`              |        0.004 s | 0.004 s |
| `Dependency.checksum(1000 files)`              |        0.004 s | 0.004 s |
| `Dependency.duration(1000 files)`              |        0.004 s | 0.004 s |
| `Dependency.format(1000 files)`                |        0.004 s | 0.004 s |
| `Dependency.removed(1000 files)`               |        0.004 s | 0.004 s |
| `Dependency.sampling_rate(1000 files)`         |        0.004 s | 0.004 s |
| `Dependency.type(1000 files)`                  |        0.005 s | 0.004 s |
| `Dependency.version(1000 files)`               |        0.004 s | 0.004 s |
| `Dependency._add_attachment()`                 |        0.061 s | 0.074 s |
| `Dependency._add_media(1000 files)`            |        0.050 s | 0.065 s |
| `Dependency._add_meta()`                       |        0.124 s | 0.118 s |
| `Dependency._drop()`                           |        0.078 s | 0.076 s |
| `Dependency._remove()`                         |        0.068 s | 0.062 s |
| `Dependency._update_media()`                   |        0.073 s | 0.074 s |
| `Dependency._update_media_version(1000 files)` |        0.008 s | 0.008 s |
