### PR TITLE
Speedup dependencies dtypes

### DIFF
--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -48,16 +48,16 @@ DEPEND_FIELD_NAMES = {
 }
 
 DEPEND_FIELD_DTYPES = {
-    DependField.ARCHIVE: "string",
+    DependField.ARCHIVE: "object",
     DependField.BIT_DEPTH: "int32",
     DependField.CHANNELS: "int32",
-    DependField.CHECKSUM: "string",
+    DependField.CHECKSUM: "object",
     DependField.DURATION: "float64",
-    DependField.FORMAT: "string",
+    DependField.FORMAT: "object",
     DependField.REMOVED: "int32",
     DependField.SAMPLING_RATE: "int32",
     DependField.TYPE: "int32",
-    DependField.VERSION: "string",
+    DependField.VERSION: "object",
 }
 
 

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -307,7 +307,6 @@ class Dependencies:
                 na_filter=False,
                 dtype=dtype_mapping,
             )
-            self._df.index = self._df.index.astype("string")
 
     def removed(self, file: str) -> bool:
         r"""Check if file is marked as removed.

--- a/benchmarks/benchmark-dependency-methods.py
+++ b/benchmarks/benchmark-dependency-methods.py
@@ -53,6 +53,7 @@ if not os.path.exists(data_cache):
         df[column] = df[column].astype(dtype)
     df.set_index("file", inplace=True)
     df.index.name = None
+    df.index = df.index.astype("object")
     df.to_pickle(data_cache)
 
 # === Create dependency object ===

--- a/benchmarks/benchmark-dependency-methods.py
+++ b/benchmarks/benchmark-dependency-methods.py
@@ -53,7 +53,6 @@ if not os.path.exists(data_cache):
         df[column] = df[column].astype(dtype)
     df.set_index("file", inplace=True)
     df.index.name = None
-    df.index = df.index.astype("string")
     df.to_pickle(data_cache)
 
 # === Create dependency object ===

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -52,7 +52,6 @@ def deps():
     df = pd.DataFrame.from_records(ROWS)
     df.set_index("file", inplace=True)
     # Ensure correct dtype
-    df.index = df.index.astype("string")
     for name, dtype in zip(
         audb.core.define.DEPEND_FIELD_NAMES.values(),
         audb.core.define.DEPEND_FIELD_DTYPES.values(),
@@ -82,7 +81,6 @@ def test_init(deps):
 
 def test_call(deps):
     expected_df = pd.DataFrame.from_records(ROWS).set_index("file")
-    expected_df.index = expected_df.index.astype("string")
     for name, dtype in zip(
         audb.core.define.DEPEND_FIELD_NAMES.values(),
         audb.core.define.DEPEND_FIELD_DTYPES.values(),


### PR DESCRIPTION
Speedup `audb.Dependencies` by using `object` dtype for strings instead of `string`.

This decision is based on the [benchmark results](https://github.com/audeering/audb/tree/main/benchmarks#audbdependencies-methods) comparing storing string as `object` or `string`, or using `pyarrow` dtypes (for discussion on benchmark see https://github.com/audeering/audb/pull/365). One can see that we get slight improvments when strings as `object` and not as `string`, whereas using `pyarrow` dtypes slows down row based processing.

TODO: add a test what happens when we load existing `db.pkl` from cache that are using `sting` as dtype.