### PR TITLE
Update Dependencies method benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -48,38 +48,38 @@ storing string as `object`,
 using `pyarrow` dtypes)
 as of commit 91528e4.
 
-| method                                         |   string |   object |   pyarrow |
-|------------------------------------------------|----------|----------|-----------|
-| Dependencies.\_\_call__()                      |    0.000 |    0.000 |     0.000 |
-| Dependencies.\_\_contains__()                  |    0.000 |    0.000 |     0.000 |
-| Dependencies.\_\_get_item__()                  |    0.000 |    0.000 |     0.000 |
-| Dependencies.\_\_len__()                       |    0.000 |    0.000 |     0.000 |
-| Dependencies.\_\_str__()                       |    0.006 |    0.005 |     0.007 |
-| Dependencies.archives                          |    0.141 |    0.116 |     0.144 |
-| Dependencies.attachments                       |    0.029 |    0.018 |     0.017 |
-| Dependencies.attachment_ids                    |    0.029 |    0.018 |     0.017 |
-| Dependencies.files                             |    0.030 |    0.012 |     0.043 |
-| Dependencies.media                             |    0.127 |    0.072 |     0.086 |
-| Dependencies.removed_media                     |    0.117 |    0.069 |     0.081 |
-| Dependencies.table_ids                         |    0.037 |    0.026 |     0.023 |
-| Dependencies.tables                            |    0.028 |    0.017 |     0.017 |
-| Dependencies.archive(1000 files)               |    0.005 |    0.005 |     0.007 |
-| Dependencies.bit_depth(1000 files)             |    0.004 |    0.004 |     0.006 |
-| Dependencies.channels(1000 files)              |    0.004 |    0.004 |     0.006 |
-| Dependencies.checksum(1000 files)              |    0.004 |    0.004 |     0.006 |
-| Dependencies.duration(1000 files)              |    0.004 |    0.004 |     0.006 |
-| Dependencies.format(1000 files)                |    0.004 |    0.004 |     0.006 |
-| Dependencies.removed(1000 files)               |    0.004 |    0.004 |     0.006 |
-| Dependencies.sampling_rate(1000 files)         |    0.004 |    0.004 |     0.006 |
-| Dependencies.type(1000 files)                  |    0.004 |    0.004 |     0.006 |
-| Dependencies.version(1000 files)               |    0.004 |    0.004 |     0.006 |
-| Dependencies._add_attachment()                 |    0.055 |    0.056 |     0.207 |
-| Dependencies._add_media(1000 files)            |    0.049 |    0.050 |     0.060 |
-| Dependencies._add_meta()                       |    0.120 |    0.128 |     0.138 |
-| Dependencies._drop()                           |    0.075 |    0.075 |     0.117 |
-| Dependencies._remove()                         |    0.068 |    0.068 |     0.064 |
-| Dependencies._update_media()                   |    0.071 |    0.072 |     0.125 |
-| Dependencies._update_media_version(1000 files) |    0.008 |    0.008 |     0.017 |
+| method                                          |   string |   object |   pyarrow |
+|-------------------------------------------------|----------|----------|-----------|
+| Dependencies.__call__()                         |    0.000 |    0.000 |     0.000 |
+| Dependencies.__contains__(10000 files)          |    0.005 |    0.005 |     0.004 |
+| Dependencies.__get_item__(10000 files)          |    0.311 |    0.223 |     0.907 |
+| Dependencies.__len__()                          |    0.000 |    0.000 |     0.000 |
+| Dependencies.__str__()                          |    0.006 |    0.005 |     0.006 |
+| Dependencies.archives                           |    0.145 |    0.112 |     0.144 |
+| Dependencies.attachments                        |    0.029 |    0.018 |     0.017 |
+| Dependencies.attachment_ids                     |    0.028 |    0.018 |     0.016 |
+| Dependencies.files                              |    0.031 |    0.011 |     0.042 |
+| Dependencies.media                              |    0.132 |    0.072 |     0.088 |
+| Dependencies.removed_media                      |    0.118 |    0.063 |     0.081 |
+| Dependencies.table_ids                          |    0.035 |    0.025 |     0.022 |
+| Dependencies.tables                             |    0.028 |    0.017 |     0.016 |
+| Dependencies.archive(10000 files)               |    0.046 |    0.043 |     0.064 |
+| Dependencies.bit_depth(10000 files)             |    0.042 |    0.042 |     0.060 |
+| Dependencies.channels(10000 files)              |    0.041 |    0.042 |     0.060 |
+| Dependencies.checksum(10000 files)              |    0.043 |    0.041 |     0.064 |
+| Dependencies.duration(10000 files)              |    0.042 |    0.042 |     0.059 |
+| Dependencies.format(10000 files)                |    0.044 |    0.042 |     0.064 |
+| Dependencies.removed(10000 files)               |    0.041 |    0.042 |     0.059 |
+| Dependencies.sampling_rate(10000 files)         |    0.043 |    0.043 |     0.061 |
+| Dependencies.type(10000 files)                  |    0.043 |    0.042 |     0.060 |
+| Dependencies.version(10000 files)               |    0.044 |    0.041 |     0.066 |
+| Dependencies._add_attachment()                  |    0.068 |    0.057 |     0.222 |
+| Dependencies._add_media(10000 files)            |    0.057 |    0.057 |     0.068 |
+| Dependencies._add_meta()                        |    0.121 |    0.138 |     0.148 |
+| Dependencies._drop()                            |    0.077 |    0.076 |     0.117 |
+| Dependencies._remove()                          |    0.061 |    0.065 |     0.066 |
+| Dependencies._update_media()                    |    0.087 |    0.087 |     0.149 |
+| Dependencies._update_media_version(10000 files) |    0.011 |    0.011 |     0.026 |
 
 
 ## audb.Dependencies loading/writing to file

--- a/benchmarks/benchmark-dependencies-methods.py
+++ b/benchmarks/benchmark-dependencies-methods.py
@@ -145,7 +145,7 @@ if not os.path.exists(data_cache):
 deps = audb.Dependencies()
 deps.load(data_cache)
 file = "file-10.wav"
-n_files = 1000
+n_files = 10000
 _files = deps._df.index[:n_files].tolist()
 dtypes = ["string", "object", "pyarrow"]
 results = pd.DataFrame(columns=dtypes)
@@ -175,15 +175,15 @@ for dtype in dtypes:
     # Further calls will be faster
     file in deps
 
-    method = "Dependencies.__contains__()"
+    method = f"Dependencies.__contains__({n_files} files)"
     t0 = time.time()
-    file in deps
+    [file in deps for file in _files]
     t = time.time() - t0
     results.at[method, dtype] = t
 
-    method = "Dependencies.__get_item__()"
+    method = f"Dependencies.__get_item__({n_files} files)"
     t0 = time.time()
-    deps[file]
+    [deps[file] for file in _files]
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -344,7 +344,7 @@ for dtype in dtypes:
 
     method = "Dependencies._drop()"
     t0 = time.time()
-    deps._drop(["file-9000.wav"])
+    deps._drop(["file-90000.wav"])
     t = time.time() - t0
     results.at[method, dtype] = t
 


### PR DESCRIPTION
Increases the file size from 1,000 to 10,000 for the row based benchmarks, and also use more than one file for `__get_item__()` and `__contains__()`.

| method                                          |   string |   object |   pyarrow |
|-------------------------------------------------|----------|----------|-----------|
| Dependencies.\_\_call__()                       |    0.000 |    0.000 |     0.000 |
| Dependencies.\_\_contains__(10000 files)        |    0.005 |    0.005 |     0.004 |
| Dependencies.\_\_get_item__(10000 files)        |    0.311 |    0.223 |     0.907 |
| Dependencies.\_\_len__()                        |    0.000 |    0.000 |     0.000 |
| Dependencies.\_\_str__()                        |    0.006 |    0.005 |     0.006 |
| Dependencies.archives                           |    0.145 |    0.112 |     0.144 |
| Dependencies.attachments                        |    0.029 |    0.018 |     0.017 |
| Dependencies.attachment_ids                     |    0.028 |    0.018 |     0.016 |
| Dependencies.files                              |    0.031 |    0.011 |     0.042 |
| Dependencies.media                              |    0.132 |    0.072 |     0.088 |
| Dependencies.removed_media                      |    0.118 |    0.063 |     0.081 |
| Dependencies.table_ids                          |    0.035 |    0.025 |     0.022 |
| Dependencies.tables                             |    0.028 |    0.017 |     0.016 |
| Dependencies.archive(10000 files)               |    0.046 |    0.043 |     0.064 |
| Dependencies.bit_depth(10000 files)             |    0.042 |    0.042 |     0.060 |
| Dependencies.channels(10000 files)              |    0.041 |    0.042 |     0.060 |
| Dependencies.checksum(10000 files)              |    0.043 |    0.041 |     0.064 |
| Dependencies.duration(10000 files)              |    0.042 |    0.042 |     0.059 |
| Dependencies.format(10000 files)                |    0.044 |    0.042 |     0.064 |
| Dependencies.removed(10000 files)               |    0.041 |    0.042 |     0.059 |
| Dependencies.sampling_rate(10000 files)         |    0.043 |    0.043 |     0.061 |
| Dependencies.type(10000 files)                  |    0.043 |    0.042 |     0.060 |
| Dependencies.version(10000 files)               |    0.044 |    0.041 |     0.066 |
| Dependencies._add_attachment()                  |    0.068 |    0.057 |     0.222 |
| Dependencies._add_media(10000 files)            |    0.057 |    0.057 |     0.068 |
| Dependencies._add_meta()                        |    0.121 |    0.138 |     0.148 |
| Dependencies._drop()                            |    0.077 |    0.076 |     0.117 |
| Dependencies._remove()                          |    0.061 |    0.065 |     0.066 |
| Dependencies._update_media()                    |    0.087 |    0.087 |     0.149 |
| Dependencies._update_media_version(10000 files) |    0.011 |    0.011 |     0.026 |
