### PR TITLE
Speed up Dependencies._add_meta()

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -390,20 +390,22 @@ class Dependencies:
             checksum: checksum of file
 
         """
-        format = audeer.file_extension(file).lower()
-
-        self._df.loc[file] = [
-            archive,  # archive
-            0,  # bit_depth
-            0,  # channels
-            checksum,  # checksum
-            0.0,  # duration
-            format,  # format
-            0,  # removed
-            0,  # sampling_rate
-            define.DependType.ATTACHMENT,  # type
-            version,  # version
+        values = [
+            (
+                file,  # file
+                archive,  # archive
+                0,  # bit_depth
+                0,  # channels
+                checksum,  # checksum
+                0.0,  # duration
+                audeer.file_extension(file).lower(),  # format
+                0,  # removed
+                0,  # sampling_rate
+                define.DependType.ATTACHMENT,  # type
+                version,  # version
+            ),
         ]
+        self._add_rows(values)
 
     def _add_media(
         self,
@@ -430,12 +432,7 @@ class Dependencies:
                 where each tuple holds the values of a new media entry
 
         """
-        df = pd.DataFrame.from_records(
-            values,
-            columns=["file"] + list(define.DEPEND_FIELD_NAMES.values()),
-        ).set_index("file")
-
-        self._df = pd.concat([self._df, df])
+        self._add_rows(values)
 
     def _add_meta(
         self,
@@ -453,20 +450,53 @@ class Dependencies:
             version: version string
 
         """
-        format = audeer.file_extension(file).lower()
-
-        self._df.loc[file] = [
-            archive,  # archive
-            0,  # bit_depth
-            0,  # channels
-            checksum,  # checksum
-            0.0,  # duration
-            format,  # format
-            0,  # removed
-            0,  # sampling_rate
-            define.DependType.META,  # type
-            version,  # version
+        values = [
+            (
+                file,  # file
+                archive,  # archive
+                0,  # bit_depth
+                0,  # channels
+                checksum,  # checksum
+                0.0,  # duration
+                audeer.file_extension(file).lower(),  # format
+                0,  # removed
+                0,  # sampling_rate
+                define.DependType.META,  # type
+                version,  # version
+            ),
         ]
+        self._add_rows(values)
+
+    def _add_rows(
+        self,
+        values: typing.Sequence[
+            typing.Tuple[
+                str,  # file
+                str,  # archive
+                int,  # bit_depth
+                int,  # channels
+                str,  # checksum
+                float,  # duration
+                str,  # format
+                int,  # removed
+                float,  # sampling_rate
+                int,  # type
+                str,  # version
+            ]
+        ],
+    ):
+        r"""Add rows to dependency table.
+
+        Args:
+            values: list of tuples,
+                where each tuple holds the values of a new row
+
+        """
+        df = pd.DataFrame.from_records(
+            values,
+            columns=["file"] + list(define.DEPEND_FIELD_NAMES.values()),
+        ).set_index("file")
+        self._df = pd.concat([self._df, df])
 
     def _column_loc(
         self,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,34 +51,34 @@ using `pyarrow` dtypes).
 |-------------------------------------------------|----------|----------|-----------|
 | Dependencies.\_\_call__()                       |    0.000 |    0.000 |     0.000 |
 | Dependencies.\_\_contains__(10000 files)        |    0.005 |    0.004 |     0.004 |
-| Dependencies.\_\_get_item__(10000 files)        |    0.322 |    0.224 |     0.900 |
+| Dependencies.\_\_get_item__(10000 files)        |    0.317 |    0.224 |     0.909 |
 | Dependencies.\_\_len__()                        |    0.000 |    0.000 |     0.000 |
 | Dependencies.\_\_str__()                        |    0.006 |    0.005 |     0.006 |
-| Dependencies.archives                           |    0.144 |    0.116 |     0.152 |
-| Dependencies.attachments                        |    0.030 |    0.018 |     0.018 |
-| Dependencies.attachment_ids                     |    0.029 |    0.018 |     0.018 |
-| Dependencies.files                              |    0.030 |    0.011 |     0.046 |
-| Dependencies.media                              |    0.129 |    0.073 |     0.095 |
-| Dependencies.removed_media                      |    0.117 |    0.070 |     0.087 |
-| Dependencies.table_ids                          |    0.037 |    0.026 |     0.023 |
+| Dependencies.archives                           |    0.143 |    0.115 |     0.148 |
+| Dependencies.attachments                        |    0.029 |    0.018 |     0.017 |
+| Dependencies.attachment_ids                     |    0.029 |    0.018 |     0.017 |
+| Dependencies.files                              |    0.031 |    0.011 |     0.045 |
+| Dependencies.media                              |    0.135 |    0.072 |     0.091 |
+| Dependencies.removed_media                      |    0.123 |    0.068 |     0.086 |
+| Dependencies.table_ids                          |    0.036 |    0.026 |     0.026 |
 | Dependencies.tables                             |    0.029 |    0.017 |     0.017 |
-| Dependencies.archive(10000 files)               |    0.045 |    0.042 |     0.065 |
+| Dependencies.archive(10000 files)               |    0.046 |    0.045 |     0.066 |
 | Dependencies.bit_depth(10000 files)             |    0.024 |    0.024 |     0.045 |
-| Dependencies.channels(10000 files)              |    0.023 |    0.023 |     0.045 |
+| Dependencies.channels(10000 files)              |    0.024 |    0.024 |     0.043 |
 | Dependencies.checksum(10000 files)              |    0.026 |    0.023 |     0.047 |
-| Dependencies.duration(10000 files)              |    0.023 |    0.023 |     0.043 |
-| Dependencies.format(10000 files)                |    0.026 |    0.023 |     0.047 |
-| Dependencies.removed(10000 files)               |    0.023 |    0.023 |     0.043 |
-| Dependencies.sampling_rate(10000 files)         |    0.023 |    0.023 |     0.043 |
-| Dependencies.type(10000 files)                  |    0.023 |    0.023 |     0.043 |
-| Dependencies.version(10000 files)               |    0.026 |    0.023 |     0.047 |
-| Dependencies._add_attachment()                  |    0.055 |    0.062 |     0.220 |
-| Dependencies._add_media(10000 files)            |    0.057 |    0.057 |     0.066 |
-| Dependencies._add_meta()                        |    0.117 |    0.129 |     0.145 |
-| Dependencies._drop()                            |    0.075 |    0.078 |     0.121 |
-| Dependencies._remove()                          |    0.061 |    0.069 |     0.064 |
-| Dependencies._update_media()                    |    0.087 |    0.086 |     0.145 |
-| Dependencies._update_media_version(10000 files) |    0.011 |    0.011 |     0.020 |
+| Dependencies.duration(10000 files)              |    0.023 |    0.024 |     0.044 |
+| Dependencies.format(10000 files)                |    0.026 |    0.024 |     0.049 |
+| Dependencies.removed(10000 files)               |    0.024 |    0.023 |     0.045 |
+| Dependencies.sampling_rate(10000 files)         |    0.024 |    0.023 |     0.044 |
+| Dependencies.type(10000 files)                  |    0.024 |    0.023 |     0.045 |
+| Dependencies.version(10000 files)               |    0.026 |    0.023 |     0.049 |
+| Dependencies._add_attachment()                  |    0.060 |    0.063 |     0.231 |
+| Dependencies._add_media(10000 files)            |    0.059 |    0.064 |     0.080 |
+| Dependencies._add_meta()                        |    0.050 |    0.068 |     0.066 |
+| Dependencies._drop()                            |    0.077 |    0.085 |     0.138 |
+| Dependencies._remove()                          |    0.063 |    0.066 |     0.069 |
+| Dependencies._update_media()                    |    0.089 |    0.087 |     0.172 |
+| Dependencies._update_media_version(10000 files) |    0.011 |    0.011 |     0.025 |
 
 
 ## audb.Dependencies loading/writing to file


### PR DESCRIPTION
Increases the speed for adding new tables to a database.

Now

![image](https://github.com/audeering/audb/assets/173624/ae7b964d-d45d-4967-afae-420a5fa10fc1)

Before

![image](https://github.com/audeering/audb/assets/173624/136a6f38-00ca-4464-8356-a6ae0bd0a93f)
