### PR TITLE
Allow list of files in Dependencies methods

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -188,77 +188,95 @@ class Dependencies:
         """
         return self._df[self._df["type"] == define.DependType.META].index.tolist()
 
-    def archive(self, file: str) -> str:
-        r"""Name of archive the file belongs to.
+    def archive(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[str, typing.List[str]]:
+        r"""Name of archive the file(s) belong to.
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
-            archive name
+            archive name(s)
 
         """
-        return self._df.archive[file]
+        return self._column_loc("archive", files)
 
-    def bit_depth(self, file: str) -> int:
-        r"""Bit depth of media file.
+    def bit_depth(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[int, typing.List[int]]:
+        r"""Bit depth of media file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
-            bit depth
+            bit depth(s)
 
         """
-        return self._column_loc("bit_depth", file, int)
+        return self._column_loc("bit_depth", files, int)
 
-    def channels(self, file: str) -> int:
-        r"""Number of channels of media file.
+    def channels(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[int, typing.List[int]]:
+        r"""Number of channels of media file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
             number of channels
 
         """
-        return self._column_loc("channels", file, int)
+        return self._column_loc("channels", files, int)
 
-    def checksum(self, file: str) -> str:
-        r"""Checksum of file.
+    def checksum(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[str, typing.List[str]]:
+        r"""Checksum of file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
-            checksum of file
+            checksum of file(s)
 
         """
-        return self._column_loc("checksum", file)
+        return self._column_loc("checksum", files)
 
-    def duration(self, file: str) -> float:
-        r"""Duration of file.
+    def duration(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[float, typing.List[float]]:
+        r"""Duration of file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
             duration in seconds
 
         """
-        return self._column_loc("duration", file, float)
+        return self._column_loc("duration", files, float)
 
-    def format(self, file: str) -> str:
-        r"""Format of file.
+    def format(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[str, typing.List[str]]:
+        r"""Format of file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
-            file format (always lower case)
+            file format(s) (always lower case)
 
         """
-        return self._column_loc("format", file)
+        return self._column_loc("format", files)
 
     def load(self, path: str):
         r"""Read dependencies from file.
@@ -309,29 +327,35 @@ class Dependencies:
             )
             self._df.index = self._df.index.astype("string")
 
-    def removed(self, file: str) -> bool:
+    def removed(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[bool, typing.List[bool]]:
         r"""Check if file is marked as removed.
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
             ``True`` if file was removed
 
         """
-        return self._column_loc("removed", file, bool)
+        return self._column_loc("removed", files, bool)
 
-    def sampling_rate(self, file: str) -> int:
-        r"""Sampling rate of media file.
+    def sampling_rate(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[int, typing.List[int]]:
+        r"""Sampling rate of media file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
             sampling rate in Hz
 
         """
-        return self._column_loc("sampling_rate", file, int)
+        return self._column_loc("sampling_rate", files, int)
 
     def save(self, path: str):
         r"""Write dependencies to file.
@@ -350,29 +374,35 @@ class Dependencies:
                 protocol=4,  # supported by Python >= 3.4
             )
 
-    def type(self, file: str) -> int:
-        r"""Type of file.
+    def type(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[int, typing.List[int]]:
+        r"""Type of file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
-            type
+            type(s)
 
         """
-        return self._column_loc("type", file, int)
+        return self._column_loc("type", files, int)
 
-    def version(self, file: str) -> str:
-        r"""Version of file.
+    def version(
+        self,
+        files: typing.Union[str, typing.Sequence[str]],
+    ) -> typing.Union[str, typing.List[str]]:
+        r"""Version of file(s).
 
         Args:
-            file: relative file path
+            files: relative file path(s)
 
         Returns:
-            version string
+            version string(s)
 
         """
-        return self._column_loc("version", file)
+        return self._column_loc("version", files)
 
     def _add_attachment(
         self,
@@ -475,10 +505,21 @@ class Dependencies:
         dtype: typing.Callable = None,
     ) -> typing.Union[typing.Any, typing.List[typing.Any]]:
         r"""Column content for selected files."""
-        value = self._df.at[files, column]
-        if dtype is not None:
-            value = dtype(value)
-        return value
+        # Single file
+        if isinstance(files, str):
+            value = self._df.at[files, column]
+            if dtype is not None:
+                value = dtype(value)
+            return value
+
+        # Multiple files
+        else:
+            values = self._df.loc[files, column]
+            if dtype is not None:
+                values = [dtype(value) for value in values]
+            else:
+                values = values.tolist()
+            return values
 
     def _drop(self, files: typing.Sequence[str]):
         r"""Drop files from table.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -192,7 +192,7 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[str, typing.List[str]]:
-        r"""Name of archive the file(s) belong to.
+        r"""Name of archive a file belong to.
 
         Args:
             files: relative file path(s)
@@ -207,7 +207,7 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[int, typing.List[int]]:
-        r"""Bit depth of media file(s).
+        r"""Bit depth of media file.
 
         Args:
             files: relative file path(s)
@@ -222,13 +222,13 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[int, typing.List[int]]:
-        r"""Number of channels of media file(s).
+        r"""Number of channels of media file.
 
         Args:
             files: relative file path(s)
 
         Returns:
-            number of channels
+            number(s) of channels
 
         """
         return self._column_loc("channels", files, int)
@@ -237,7 +237,7 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[str, typing.List[str]]:
-        r"""Checksum of file(s).
+        r"""Checksum of file.
 
         Args:
             files: relative file path(s)
@@ -252,13 +252,13 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[float, typing.List[float]]:
-        r"""Duration of file(s).
+        r"""Duration of file.
 
         Args:
             files: relative file path(s)
 
         Returns:
-            duration in seconds
+            duration(s) in seconds
 
         """
         return self._column_loc("duration", files, float)
@@ -267,7 +267,7 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[str, typing.List[str]]:
-        r"""Format of file(s).
+        r"""Format of file.
 
         Args:
             files: relative file path(s)
@@ -346,13 +346,13 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[int, typing.List[int]]:
-        r"""Sampling rate of media file(s).
+        r"""Sampling rate of media file.
 
         Args:
             files: relative file path(s)
 
         Returns:
-            sampling rate in Hz
+            sampling rate(s) in Hz
 
         """
         return self._column_loc("sampling_rate", files, int)
@@ -378,7 +378,7 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[int, typing.List[int]]:
-        r"""Type of file(s).
+        r"""Type of file.
 
         Args:
             files: relative file path(s)
@@ -393,7 +393,7 @@ class Dependencies:
         self,
         files: typing.Union[str, typing.Sequence[str]],
     ) -> typing.Union[str, typing.List[str]]:
-        r"""Version of file(s).
+        r"""Version of file.
 
         Args:
             files: relative file path(s)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,34 +51,44 @@ using `pyarrow` dtypes).
 |-------------------------------------------------|----------|----------|-----------|
 | Dependencies.\_\_call__()                       |    0.000 |    0.000 |     0.000 |
 | Dependencies.\_\_contains__(10000 files)        |    0.005 |    0.004 |     0.004 |
-| Dependencies.\_\_get_item__(10000 files)        |    0.322 |    0.224 |     0.900 |
+| Dependencies.\_\_get_item__(10000 files)        |    0.316 |    0.219 |     0.903 |
 | Dependencies.\_\_len__()                        |    0.000 |    0.000 |     0.000 |
-| Dependencies.\_\_str__()                        |    0.006 |    0.005 |     0.006 |
-| Dependencies.archives                           |    0.144 |    0.116 |     0.152 |
-| Dependencies.attachments                        |    0.030 |    0.018 |     0.018 |
-| Dependencies.attachment_ids                     |    0.029 |    0.018 |     0.018 |
-| Dependencies.files                              |    0.030 |    0.011 |     0.046 |
-| Dependencies.media                              |    0.129 |    0.073 |     0.095 |
-| Dependencies.removed_media                      |    0.117 |    0.070 |     0.087 |
-| Dependencies.table_ids                          |    0.037 |    0.026 |     0.023 |
-| Dependencies.tables                             |    0.029 |    0.017 |     0.017 |
-| Dependencies.archive(10000 files)               |    0.045 |    0.042 |     0.065 |
-| Dependencies.bit_depth(10000 files)             |    0.024 |    0.024 |     0.045 |
-| Dependencies.channels(10000 files)              |    0.023 |    0.023 |     0.045 |
-| Dependencies.checksum(10000 files)              |    0.026 |    0.023 |     0.047 |
-| Dependencies.duration(10000 files)              |    0.023 |    0.023 |     0.043 |
-| Dependencies.format(10000 files)                |    0.026 |    0.023 |     0.047 |
-| Dependencies.removed(10000 files)               |    0.023 |    0.023 |     0.043 |
-| Dependencies.sampling_rate(10000 files)         |    0.023 |    0.023 |     0.043 |
-| Dependencies.type(10000 files)                  |    0.023 |    0.023 |     0.043 |
-| Dependencies.version(10000 files)               |    0.026 |    0.023 |     0.047 |
-| Dependencies._add_attachment()                  |    0.055 |    0.062 |     0.220 |
-| Dependencies._add_media(10000 files)            |    0.057 |    0.057 |     0.066 |
-| Dependencies._add_meta()                        |    0.117 |    0.129 |     0.145 |
-| Dependencies._drop()                            |    0.075 |    0.078 |     0.121 |
-| Dependencies._remove()                          |    0.061 |    0.069 |     0.064 |
-| Dependencies._update_media()                    |    0.087 |    0.086 |     0.145 |
-| Dependencies._update_media_version(10000 files) |    0.011 |    0.011 |     0.020 |
+| Dependencies.\_\_str__()                        |    0.005 |    0.005 |     0.006 |
+| Dependencies.archives                           |    0.143 |    0.118 |     0.144 |
+| Dependencies.attachments                        |    0.029 |    0.018 |     0.018 |
+| Dependencies.attachment_ids                     |    0.028 |    0.017 |     0.017 |
+| Dependencies.files                              |    0.030 |    0.011 |     0.043 |
+| Dependencies.media                              |    0.132 |    0.071 |     0.086 |
+| Dependencies.removed_media                      |    0.123 |    0.068 |     0.081 |
+| Dependencies.table_ids                          |    0.035 |    0.025 |     0.023 |
+| Dependencies.tables                             |    0.028 |    0.017 |     0.017 |
+| Dependencies.archive(10000 files)               |    0.028 |    0.025 |     0.047 |
+| Dependencies.archive([10000 files])             |    0.134 |    0.008 |     0.224 |
+| Dependencies.bit_depth(10000 files)             |    0.026 |    0.024 |     0.045 |
+| Dependencies.bit_depth([10000 files])           |    0.140 |    0.002 |     0.224 |
+| Dependencies.channels(10000 files)              |    0.025 |    0.024 |     0.044 |
+| Dependencies.channels([10000 files])            |    0.140 |    0.002 |     0.224 |
+| Dependencies.checksum(10000 files)              |    0.027 |    0.025 |     0.047 |
+| Dependencies.checksum([10000 files])            |    0.142 |    0.002 |     0.220 |
+| Dependencies.duration(10000 files)              |    0.025 |    0.025 |     0.044 |
+| Dependencies.duration([10000 files])            |    0.139 |    0.002 |     0.223 |
+| Dependencies.format(10000 files)                |    0.027 |    0.023 |     0.047 |
+| Dependencies.format([10000 files])              |    0.142 |    0.002 |     0.221 |
+| Dependencies.removed(10000 files)               |    0.025 |    0.024 |     0.044 |
+| Dependencies.removed([10000 files])             |    0.140 |    0.002 |     0.224 |
+| Dependencies.sampling_rate(10000 files)         |    0.026 |    0.024 |     0.045 |
+| Dependencies.sampling_rate([10000 files])       |    0.140 |    0.002 |     0.223 |
+| Dependencies.type(10000 files)                  |    0.026 |    0.024 |     0.045 |
+| Dependencies.type([10000 files])                |    0.141 |    0.002 |     0.225 |
+| Dependencies.version(10000 files)               |    0.027 |    0.023 |     0.047 |
+| Dependencies.version([10000 files])             |    0.142 |    0.002 |     0.226 |
+| Dependencies._add_attachment()                  |    0.059 |    0.062 |     0.210 |
+| Dependencies._add_media(10000 files)            |    0.058 |    0.057 |     0.066 |
+| Dependencies._add_meta()                        |    0.115 |    0.133 |     0.145 |
+| Dependencies._drop()                            |    0.075 |    0.076 |     0.118 |
+| Dependencies._remove()                          |    0.062 |    0.069 |     0.065 |
+| Dependencies._update_media()                    |    0.087 |    0.090 |     0.144 |
+| Dependencies._update_media_version(10000 files) |    0.011 |    0.011 |     0.021 |
 
 
 ## audb.Dependencies loading/writing to file

--- a/benchmarks/benchmark-dependencies-methods.py
+++ b/benchmarks/benchmark-dependencies-methods.py
@@ -253,9 +253,21 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
+    method = f"Dependencies.archive([{n_files} files])"
+    t0 = time.time()
+    deps.archive(_files)
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
     method = f"Dependencies.bit_depth({n_files} files)"
     t0 = time.time()
     [deps.bit_depth(file) for file in _files]
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
+    method = f"Dependencies.bit_depth([{n_files} files])"
+    t0 = time.time()
+    deps.bit_depth(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -265,9 +277,21 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
+    method = f"Dependencies.channels([{n_files} files])"
+    t0 = time.time()
+    deps.channels(_files)
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
     method = f"Dependencies.checksum({n_files} files)"
     t0 = time.time()
     [deps.checksum(file) for file in _files]
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
+    method = f"Dependencies.checksum([{n_files} files])"
+    t0 = time.time()
+    deps.checksum(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -277,9 +301,21 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
+    method = f"Dependencies.duration([{n_files} files])"
+    t0 = time.time()
+    deps.duration(_files)
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
     method = f"Dependencies.format({n_files} files)"
     t0 = time.time()
     [deps.format(file) for file in _files]
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
+    method = f"Dependencies.format([{n_files} files])"
+    t0 = time.time()
+    deps.format(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -289,9 +325,21 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
+    method = f"Dependencies.removed([{n_files} files])"
+    t0 = time.time()
+    deps.removed(_files)
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
     method = f"Dependencies.sampling_rate({n_files} files)"
     t0 = time.time()
     [deps.sampling_rate(file) for file in _files]
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
+    method = f"Dependencies.sampling_rate([{n_files} files])"
+    t0 = time.time()
+    deps.sampling_rate(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -301,9 +349,21 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
+    method = f"Dependencies.type([{n_files} files])"
+    t0 = time.time()
+    deps.type(_files)
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
     method = f"Dependencies.version({n_files} files)"
     t0 = time.time()
     [deps.version(file) for file in _files]
+    t = time.time() - t0
+    results.at[method, dtype] = t
+
+    method = f"Dependencies.version([{n_files} files])"
+    t0 = time.time()
+    deps.version(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 


### PR DESCRIPTION
This add support for passing on a list of files to all file based methods of `audb.Dependencies` like `audb.Depednencies.archive(files)`.

I decided against returning always a list as results to not break backwards compatibility.
Now you always get a list back when you use a list of files as a request.
If you request with an empty list, you will also get an empty list as results.
If you request a non-existing file, it will fail with the same error in both cases.

This provides the possibility to access a huge amount of files much faster than by `[deps.archive(file) for file in files]`.
At the moment the benchmarks show that the speed enhancement can only be observed for the case of storing strings as `object` dtype. But I checked already that the same speed for the two other benchmark columns can be achieved when using always `object` as `dtype` for the index.

![image](https://github.com/audeering/audb/assets/173624/995b16df-d53d-487a-bfe1-e255a46db1db)

![image](https://github.com/audeering/audb/assets/173624/6d7009b3-0516-4458-a5e6-641a2c5fba10)


Example change to docstring:

![image](https://github.com/audeering/audb/assets/173624/e3b2a197-b539-4feb-860c-8214730d651a)

The actual code inside `audb` is not yet changed to take advantage of the new `files` argument as I first will tackle the speed issue we see when using it with storing strings as `string` dtype.