### PR TITLE
Store Dependencies as parquet file

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -189,7 +189,7 @@ def cached(
             if (
                 define.DEPENDENCIES_FILE not in files
                 and define.LEGACY_DEPENDENCIES_FILE not in files
-                and define.LEGACY_CACHED_DEPENDENCIES_FILE not in files
+                and define.CACHED_DEPENDENCIES_FILE not in files
             ):
                 # Skip all cache entries
                 # that don't contain a dependency file
@@ -265,7 +265,7 @@ def dependencies(
             file_found = False
             for deps_file in [
                 define.DEPENDENCIES_FILE,
-                define.LEGACY_CACHED_DEPENDENCIES_FILE,
+                define.CACHED_DEPENDENCIES_FILE,
             ]:
                 deps_path = os.path.join(db_root, deps_file)
                 if os.path.exists(deps_path):
@@ -285,17 +285,17 @@ def dependencies(
                     version,
                     verbose=verbose,
                 )
+                # Load parquet or csv from tmp dir
+                # and store as pickle in cache
                 deps_path = os.path.join(tmp_root, define.DEPENDENCIES_FILE)
                 legacy_path = os.path.join(tmp_root, define.LEGACY_DEPENDENCIES_FILE)
-                cached_path = os.path.join(db_root, define.DEPENDENCIES_FILE)
+                cached_path = os.path.join(db_root, define.CACHED_DEPENDENCIES_FILE)
                 if os.path.exists(deps_path):
-                    # Copy parquet file from tmp dir to cache
-                    audeer.move_file(deps_path, cached_path)
-                    deps.load(cached_path)
+                    deps.load(deps_path)
                 else:
-                    # Load CSV file from tmp dir and store as parquet in cache
                     deps.load(legacy_path)
-                    deps.save(cached_path)
+                # Store as pickle in cache
+                deps.save(cached_path)
 
     return deps
 

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -257,23 +257,13 @@ def dependencies(
         version,
         cache_root=cache_root,
     )
+    cached_path = os.path.join(db_root, define.CACHED_DEPENDENCIES_FILE)
 
     deps = Dependencies()
 
     with FolderLock(db_root):
         try:
-            file_found = False
-            for deps_file in [
-                define.DEPENDENCIES_FILE,
-                define.CACHED_DEPENDENCIES_FILE,
-            ]:
-                deps_path = os.path.join(db_root, deps_file)
-                if os.path.exists(deps_path):
-                    deps.load(deps_path)
-                    file_found = True
-                    break
-            if not file_found:
-                raise FileNotFoundError
+            deps.load(cached_path)
         except (AttributeError, FileNotFoundError, ValueError, EOFError):
             # If loading cached file fails, load again from backend
             backend = utils.lookup_backend(name, version)

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -279,7 +279,6 @@ def dependencies(
                 # and store as pickle in cache
                 deps_path = os.path.join(tmp_root, define.DEPENDENCIES_FILE)
                 legacy_path = os.path.join(tmp_root, define.LEGACY_DEPENDENCIES_FILE)
-                cached_path = os.path.join(db_root, define.CACHED_DEPENDENCIES_FILE)
                 if os.path.exists(deps_path):
                     deps.load(deps_path)
                 else:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -189,7 +189,7 @@ def cached(
             if (
                 define.DEPENDENCIES_FILE not in files
                 and define.LEGACY_DEPENDENCIES_FILE not in files
-                and define.CACHED_DEPENDENCIES_FILE not in files
+                and define.LEGACY_CACHED_DEPENDENCIES_FILE not in files
             ):
                 # Skip all cache entries
                 # that don't contain a dependency file
@@ -265,7 +265,7 @@ def dependencies(
             file_found = False
             for deps_file in [
                 define.DEPENDENCIES_FILE,
-                define.CACHED_DEPENDENCIES_FILE,
+                define.LEGACY_CACHED_DEPENDENCIES_FILE,
             ]:
                 deps_path = os.path.join(db_root, deps_file)
                 if os.path.exists(deps_path):

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -185,18 +185,15 @@ def cached(
             flavor_id_paths = audeer.list_dir_names(version_path)
 
             # Skip old audb cache (e.g. 1 as flavor)
-            files = audeer.list_file_names(version_path)
-            deps_path = os.path.join(version_path, define.DEPENDENCIES_FILE)
-            deps_path_cached = os.path.join(
-                version_path,
-                define.CACHED_DEPENDENCIES_FILE,
-            )
-            if deps_path not in files and deps_path_cached not in files:
+            files = audeer.list_file_names(version_path, basenames=True)
+            if (
+                define.DEPENDENCIES_FILE not in files
+                and define.LEGACY_DEPENDENCIES_FILE not in files
+                and define.CACHED_DEPENDENCIES_FILE not in files
+            ):
                 # Skip all cache entries
-                # that don't contain a db.csv or db.pkl file
+                # that don't contain a dependency file
                 # as those stem from audb<1.0.0.
-                # We only look for db.csv
-                # as we switched to db.pkl with audb>=1.0.5
                 continue  # pragma: no cover
 
             for flavor_id_path in flavor_id_paths:

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -10,7 +10,8 @@ DB = "db"
 HEADER_FILE = f"{DB}.yaml"
 
 # Dependencies
-DEPENDENCIES_FILE = f"{DB}.csv"
+DEPENDENCIES_FILE = f"{DB}.parquet"
+LEGACY_DEPENDENCIES_FILE = f"{DB}.csv"
 CACHED_DEPENDENCIES_FILE = f"{DB}.pkl"
 
 # Cache lock

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -11,8 +11,8 @@ HEADER_FILE = f"{DB}.yaml"
 
 # Dependencies
 DEPENDENCIES_FILE = f"{DB}.parquet"
+CACHED_DEPENDENCIES_FILE = f"{DB}.pkl"
 LEGACY_DEPENDENCIES_FILE = f"{DB}.csv"
-LEGACY_CACHED_DEPENDENCIES_FILE = f"{DB}.pkl"
 
 # Cache lock
 CACHED_VERSIONS_TIMEOUT = 10  # Timeout to acquire access to cached versions

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -12,7 +12,7 @@ HEADER_FILE = f"{DB}.yaml"
 # Dependencies
 DEPENDENCIES_FILE = f"{DB}.parquet"
 LEGACY_DEPENDENCIES_FILE = f"{DB}.csv"
-CACHED_DEPENDENCIES_FILE = f"{DB}.pkl"
+LEGACY_CACHED_DEPENDENCIES_FILE = f"{DB}.pkl"
 
 # Cache lock
 CACHED_VERSIONS_TIMEOUT = 10  # Timeout to acquire access to cached versions

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -48,16 +48,16 @@ DEPEND_FIELD_NAMES = {
 }
 
 DEPEND_FIELD_DTYPES = {
-    DependField.ARCHIVE: "string",
-    DependField.BIT_DEPTH: "int32",
-    DependField.CHANNELS: "int32",
-    DependField.CHECKSUM: "string",
-    DependField.DURATION: "float64",
-    DependField.FORMAT: "string",
-    DependField.REMOVED: "int32",
-    DependField.SAMPLING_RATE: "int32",
-    DependField.TYPE: "int32",
-    DependField.VERSION: "string",
+    DependField.ARCHIVE: "string[pyarrow]",
+    DependField.BIT_DEPTH: "int32[pyarrow]",
+    DependField.CHANNELS: "int32[pyarrow]",
+    DependField.CHECKSUM: "string[pyarrow]",
+    DependField.DURATION: "float64[pyarrow]",
+    DependField.FORMAT: "string[pyarrow]",
+    DependField.REMOVED: "int32[pyarrow]",
+    DependField.SAMPLING_RATE: "int32[pyarrow]",
+    DependField.TYPE: "int32[pyarrow]",
+    DependField.VERSION: "string[pyarrow]",
 }
 
 DEPEND_INDEX_DTYPE = "object"

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -79,6 +79,8 @@ class Dependencies:
                 ("version", pa.string()),
             ]
         )
+        # Store location of last loaded dependency file
+        self._path = None
 
     def __call__(self) -> pd.DataFrame:
         r"""Return dependencies as a table.
@@ -352,6 +354,7 @@ class Dependencies:
         # with old pickle files in cache
         # that might use `string` as dtype
         self._df.index = self._df.index.astype(define.DEPEND_INDEX_DTYPE)
+        self._path = path
 
     def removed(
         self,

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -331,6 +331,12 @@ class Dependencies:
             )
         if extension == "pkl":
             self._df = pd.read_pickle(path)
+            # Correct dtype of index
+            # to make backward compatiple
+            # with old pickle files in cache
+            # that might use `string` as dtype
+            if self._df.index.dtype != define.DEPEND_INDEX_DTYPE:
+                self._df.index = self._df.index.astype(define.DEPEND_INDEX_DTYPE)
 
         elif extension == "csv":
             table = csv.read_csv(
@@ -346,12 +352,6 @@ class Dependencies:
         elif extension == "parquet":
             table = parquet.read_table(path)
             self._df = self._table_to_dataframe(table)
-
-        # Set dtype of index for both CSV and PKL
-        # to make backward compatiple
-        # with old pickle files in cache
-        # that might use `string` as dtype
-        self._df.index = self._df.index.astype(define.DEPEND_INDEX_DTYPE)
 
     def removed(
         self,
@@ -633,6 +633,7 @@ class Dependencies:
         )
         df.set_index("file", inplace=True)
         df.index.name = None
+        df.index = df.index.astype(define.DEPEND_INDEX_DTYPE)
         return df
 
     def _update_media(

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -338,7 +338,15 @@ class Dependencies:
             )
             self._df = table.to_pandas(
                 deduplicate_objects=False,
-                types_mapper=pd.ArrowDtype,  # use pyarrow dtypes
+                # Convert to pyarrow dtypes,
+                # but ensure we use pd.StringDtype("pyarrow")
+                # and not pd.ArrowDtype(pa.string())
+                # see https://pandas.pydata.org/docs/user_guide/pyarrow.html
+                types_mapper={
+                    pa.string(): pd.StringDtype("pyarrow"),
+                    pa.int32(): pd.ArrowDtype(pa.int32()),
+                    pa.float64(): pd.ArrowDtype(pa.float64()),
+                }.get,  # we have to provide a callable, not a dict
             )
             self._df.set_index("file", inplace=True)
             self._df.index.name = None

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -388,7 +388,7 @@ class Dependencies:
 
         Args:
             path: path to file.
-                File extension can be ``csv`` or ``pkl``
+                File extension can be ``csv``, ``pkl``, or ``parquet``
 
         """
         path = audeer.path(path)

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -79,8 +79,6 @@ class Dependencies:
                 ("version", pa.string()),
             ]
         )
-        # Store location of last loaded dependency file
-        self._path = None
 
     def __call__(self) -> pd.DataFrame:
         r"""Return dependencies as a table.
@@ -354,7 +352,6 @@ class Dependencies:
         # with old pickle files in cache
         # that might use `string` as dtype
         self._df.index = self._df.index.astype(define.DEPEND_INDEX_DTYPE)
-        self._path = path
 
     def removed(
         self,

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -407,7 +407,6 @@ def load_to(
         verbose=verbose,
     )
 
-    print(audeer.list_file_names(db_root_tmp, recursive=True))
     # remove the temporal directory
     # to signal all files were correctly loaded
     try:

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -390,8 +390,10 @@ def load_to(
 
     # save dependencies
 
+    dep_path_tmp = os.path.join(db_root_tmp, define.DEPENDENCIES_FILE)
+    deps.save(dep_path_tmp)
     audeer.move_file(
-        deps._path,
+        dep_path_tmp,
         os.path.join(db_root, define.DEPENDENCIES_FILE),
     )
 
@@ -405,6 +407,7 @@ def load_to(
         verbose=verbose,
     )
 
+    print(audeer.list_file_names(db_root_tmp, recursive=True))
     # remove the temporal directory
     # to signal all files were correctly loaded
     try:

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -390,10 +390,8 @@ def load_to(
 
     # save dependencies
 
-    dep_path_tmp = os.path.join(db_root_tmp, define.DEPENDENCIES_FILE)
-    deps.save(dep_path_tmp)
     audeer.move_file(
-        dep_path_tmp,
+        deps._path,
         os.path.join(db_root, define.DEPENDENCIES_FILE),
     )
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -652,14 +652,13 @@ def publish(
             cache_root=cache_root,
             verbose=verbose,
         )
-        if audeer.md5(deps_path) != audeer.md5(previous_deps._path):
+        if not deps().equals(previous_deps()):
             raise RuntimeError(
                 f"You want to depend on '{previous_version}' "
                 f"of {db.name}, "
-                f"but the MD5 sum of your "
-                f"'{deps_file}' file "
+                f"but the dependency file '{deps_file}' "
                 f"in {db_root} "
-                f"does not match the MD5 sum of the corresponding file "
+                f"does not match the dependency file "
                 f"for the requested version in the repository. "
                 f"Did you forgot to call "
                 f"'audb.load_to({db_root}, {db.name}, "

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -615,10 +615,12 @@ def publish(
             previous_version = None
 
     # load database and dependencies
-    deps_path = os.path.join(db_root, define.DEPENDENCIES_FILE)
     deps = Dependencies()
-    if os.path.exists(deps_path):
-        deps.load(deps_path)
+    for deps_file in [define.DEPENDENCIES_FILE, define.LEGACY_DEPENDENCIES_FILE]:
+        deps_path = os.path.join(db_root, deps_file)
+        if os.path.exists(deps_path):
+            deps.load(deps_path)
+            break
 
     # check if database folder depends on the right version
 
@@ -626,7 +628,7 @@ def publish(
     if previous_version is None and len(deps) > 0:
         raise RuntimeError(
             f"You did not set a dependency to a previous version, "
-            f"but you have a '{define.DEPENDENCIES_FILE}' file present "
+            f"but you have a '{deps_file}' file present "
             f"in {db_root}."
         )
 
@@ -644,32 +646,26 @@ def publish(
 
     # dependencies do not match version
     if previous_version is not None and len(deps) > 0:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            previous_deps_path = os.path.join(
-                tmp_dir,
-                define.DEPENDENCIES_FILE,
+        previous_deps = dependencies(
+            db.name,
+            version=previous_version,
+            cache_root=cache_root,
+            verbose=verbose,
+        )
+        if audeer.md5(deps_path) != audeer.md5(previous_deps._path):
+            raise RuntimeError(
+                f"You want to depend on '{previous_version}' "
+                f"of {db.name}, "
+                f"but the MD5 sum of your "
+                f"'{deps_file}' file "
+                f"in {db_root} "
+                f"does not match the MD5 sum of the corresponding file "
+                f"for the requested version in the repository. "
+                f"Did you forgot to call "
+                f"'audb.load_to({db_root}, {db.name}, "
+                f"version='{previous_version}') "
+                f"or modified the file manually?"
             )
-            previous_deps = dependencies(
-                db.name,
-                version=previous_version,
-                cache_root=cache_root,
-                verbose=verbose,
-            )
-            previous_deps.save(previous_deps_path)
-            if audeer.md5(deps_path) != audeer.md5(previous_deps_path):
-                raise RuntimeError(
-                    f"You want to depend on '{previous_version}' "
-                    f"of {db.name}, "
-                    f"but the MD5 sum of your "
-                    f"'{define.DEPENDENCIES_FILE}' file "
-                    f"in {db_root} "
-                    f"does not match the MD5 sum of the corresponding file "
-                    f"for the requested version in the repository. "
-                    f"Did you forgot to call "
-                    f"'audb.load_to({db_root}, {db.name}, "
-                    f"version='{previous_version}') "
-                    f"or modified the file manually?"
-                )
 
     # load database with table data
     db = audformat.Database.load(
@@ -753,6 +749,7 @@ def publish(
     )
 
     # publish dependencies and header
+    deps_path = os.path.join(db_root, define.DEPENDENCIES_FILE)
     deps.save(deps_path)
     archive_file = backend.join("/", db.name, define.DB + ".zip")
     backend.put_archive(

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -37,7 +37,7 @@ if its content hasn't changed.
 We keep track of those dependencies
 and store some additional metadata about the audio files
 like duration and number of channels
-in a dependency table in a file :file:`db.csv`
+in a dependency table in a file :file:`db.parquet`
 for every version of a database.
 
 You request a :class:`audb.Dependencies` object with

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -11,20 +11,27 @@
     :hide-code:
 
     import os
-    import shutil
+    import tempfile
+
+    import audb
+    import audeer
+
+
+    _cwd_root = os.getcwd()
+    _tmp_root = tempfile.mkdtemp()
+    os.chdir(_tmp_root)
 
     folders = [
         "./age-test-1.0.0",
         "./age-test-1.1.0",
-        "./data",
+        "./data/data-local",
+        "./cache",
     ]
     for folder in folders:
-        if os.path.exists(folder):
-            shutil.rmtree(folder)
+        audeer.rmdir(folder)
+        audeer.mkdir(folder)
 
-    # create repository
-    os.mkdir("./data")
-    os.mkdir("./data/data-local")
+    audb.config.CACHE_ROOT = "./cache"
 
 
 .. _publish:
@@ -249,6 +256,5 @@ to see how to load and use a database.
 .. jupyter-execute::
     :hide-code:
 
-    for folder in folders:
-        if os.path.exists(folder):
-            shutil.rmtree(folder)
+    os.chdir(_cwd_root)
+    audeer.rmdir(_tmp_root)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     'audiofile >=1.0.0',
     'audobject >=0.5.0',
     'audresample >=0.1.6',
+    'pyarrow',
     'filelock',
     'oyaml',
 ]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -219,6 +219,10 @@ def test_load_save(deps):
     deps.save(deps_file)
     deps2 = audb.Dependencies()
     deps2.load(deps_file)
+    print(f"{deps._df=}")
+    print(f"{deps2._df=}")
+    print(f"{deps._df.archive.dtype=}")
+    print(f"{deps2._df.archive.dtype=}")
     pd.testing.assert_frame_equal(deps(), deps2())
     os.remove(deps_file)
     # Expected dtypes

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,7 +1,7 @@
-import os
-
 import pandas as pd
 import pytest
+
+import audeer
 
 import audb
 
@@ -214,20 +214,22 @@ def test_file_bases_methods(deps, files, method, expected_dtype):
             assert isinstance(result, expected_dtype)
 
 
-def test_load_save(deps):
-    deps_file = "deps.csv"
+@pytest.mark.parametrize("file", ["deps.csv", "deps.pkl", "deps.parquet"])
+def test_load_save(tmpdir, deps, file):
+    deps_file = audeer.path(tmpdir, file)
     deps.save(deps_file)
     deps2 = audb.Dependencies()
     deps2.load(deps_file)
     pd.testing.assert_frame_equal(deps(), deps2())
-    os.remove(deps_file)
-    # Expected dtypes
     assert list(deps2._df.dtypes) == list(audb.core.define.DEPEND_FIELD_DTYPES.values())
+
+
+def test_load_save_errors(deps):
     # Wrong extension or file missng
     with pytest.raises(ValueError, match=r".*'txt'.*"):
-        deps2.load("deps.txt")
+        deps.load("deps.txt")
     with pytest.raises(FileNotFoundError):
-        deps.load(deps_file)
+        deps.load("deps.csv")
 
 
 def test_len(deps):

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -219,10 +219,6 @@ def test_load_save(deps):
     deps.save(deps_file)
     deps2 = audb.Dependencies()
     deps2.load(deps_file)
-    print(f"{deps._df=}")
-    print(f"{deps2._df=}")
-    print(f"{deps._df.archive.dtype=}")
-    print(f"{deps2._df.archive.dtype=}")
     pd.testing.assert_frame_equal(deps(), deps2())
     os.remove(deps_file)
     # Expected dtypes

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -216,6 +216,14 @@ def test_file_bases_methods(deps, files, method, expected_dtype):
 
 @pytest.mark.parametrize("file", ["deps.csv", "deps.pkl", "deps.parquet"])
 def test_load_save(tmpdir, deps, file):
+    """Test consistency of dependency table after save/load cycle.
+
+    Dependency values and data types
+    should remain identical
+    when first storing and then loading from a file.
+    This should hold for all possible file formats.
+
+    """
     deps_file = audeer.path(tmpdir, file)
     deps.save(deps_file)
     deps2 = audb.Dependencies()

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -232,6 +232,24 @@ def test_load_save(tmpdir, deps, file):
     assert list(deps2._df.dtypes) == list(audb.core.define.DEPEND_FIELD_DTYPES.values())
 
 
+def test_load_save_backward_compatibility(tmpdir, deps):
+    """Test backward compatibility with old pickle cache files.
+
+    As the dtype of the index has changed,
+    we need to make sure this is corrected
+    when loading old cache files.
+
+    """
+    deps_file = audeer.path(tmpdir, "deps.pkl")
+    # Change dtype of index from object to string
+    # to mimic previous behavior
+    deps._df.index = deps._df.index.astype("string")
+    deps.save(deps_file)
+    deps2 = audb.Dependencies()
+    deps2.load(deps_file)
+    assert deps2._df.index.dtype == audb.core.define.DEPEND_INDEX_DTYPE
+
+
 def test_load_save_errors(deps):
     """Test possible errors when loading/saving."""
     # Wrong file extension

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -233,9 +233,11 @@ def test_load_save(tmpdir, deps, file):
 
 
 def test_load_save_errors(deps):
-    # Wrong extension or file missng
+    """Test possible errors when loading/saving."""
+    # Wrong file extension
     with pytest.raises(ValueError, match=r".*'txt'.*"):
         deps.load("deps.txt")
+    # File missing
     with pytest.raises(FileNotFoundError):
         deps.load("deps.csv")
 

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -129,8 +129,8 @@ def dbs(tmpdir_factory, persistent_repository):
     db.save(db_root)
     audformat.testing.create_audio_files(db)
     shutil.copy(
-        audeer.path(previous_db_root, "db.csv"),
-        audeer.path(db_root, "db.csv"),
+        audeer.path(previous_db_root, audb.core.define.DEPENDENCIES_FILE),
+        audeer.path(db_root, audb.core.define.DEPENDENCIES_FILE),
     )
     audb.publish(
         db_root,
@@ -156,8 +156,8 @@ def dbs(tmpdir_factory, persistent_repository):
     db.save(db_root)
     audformat.testing.create_audio_files(db)
     shutil.copy(
-        audeer.path(previous_db_root, "db.csv"),
-        audeer.path(db_root, "db.csv"),
+        audeer.path(previous_db_root, audb.core.define.DEPENDENCIES_FILE),
+        audeer.path(db_root, audb.core.define.DEPENDENCIES_FILE),
     )
     audb.publish(
         db_root,
@@ -192,8 +192,8 @@ def dbs(tmpdir_factory, persistent_repository):
     db.save(db_root)
 
     shutil.copy(
-        os.path.join(previous_db_root, "db.csv"),
-        os.path.join(db_root, "db.csv"),
+        os.path.join(previous_db_root, audb.core.define.DEPENDENCIES_FILE),
+        os.path.join(db_root, audb.core.define.DEPENDENCIES_FILE),
     )
     audb.publish(
         db_root,
@@ -220,8 +220,8 @@ def dbs(tmpdir_factory, persistent_repository):
     db.save(db_root)
     audformat.testing.create_audio_files(db)
     shutil.copy(
-        os.path.join(previous_db_root, "db.csv"),
-        os.path.join(db_root, "db.csv"),
+        os.path.join(previous_db_root, audb.core.define.DEPENDENCIES_FILE),
+        os.path.join(db_root, audb.core.define.DEPENDENCIES_FILE),
     )
     audb.publish(
         db_root,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -823,7 +823,7 @@ def test_publish_error_messages(
                 dbs[version],
                 audb.core.define.DEPENDENCIES_FILE,
             )
-            shutil.copyfile(deps._path, path)
+            deps.save(path)
         audb.publish(
             dbs[version],
             version,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1120,10 +1120,10 @@ def test_update_database(dbs, persistent_repository):
     error_msg = (
         f"You want to depend on '{audb.latest_version(DB_NAME)}' "
         f"of {DB_NAME}, "
-        f"but the MD5 sum of your "
-        f"'{audb.core.define.DEPENDENCIES_FILE}' file "
+        f"but the dependency file "
+        f"'{audb.core.define.DEPENDENCIES_FILE}' "
         f"in {dbs[version]} "
-        f"does not match the MD5 sum of the corresponding file "
+        f"does not match the dependency file "
         f"for the requested version in the repository. "
         f"Did you forgot to call "
         f"'audb.load_to({dbs[version]}, {DB_NAME}, "

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -823,7 +823,7 @@ def test_publish_error_messages(
                 dbs[version],
                 audb.core.define.DEPENDENCIES_FILE,
             )
-            deps.save(path)
+            shutil.copyfile(deps._path, path)
         audb.publish(
             dbs[version],
             version,


### PR DESCRIPTION
Closes #300 

**Summary**:
* Speed up loading and saving of the dependency table
* Store dependency table as `parquet` files on the server and in cache

This pull request uses **`pyarrow` dtypes** in the columns fo the dataframe representing the dependency table. This, in combination with **`pyarrow.Table` as an intermediate representation** for CSV and parquet files, results in faster reading and writing of CSV, pickle and parquet files:

| task | before | pull request |
| --- | --- | --- |
| reading csv | 1.158 s | 0.113 s |
| reading pickle | 0.255 s | 0.092 s |
| reading parquet | - | 0.085 s |
| | |
| writing csv | 2.026 s | 0.277 s |
| writing pickle | 0.649 s | 0.294 s |
| writing parquet | - | 0.273 s |

Results are for a dependency table holding 1,000,000 entries, see [Loading and writing to a file benchmark](https://github.com/audeering/audb/tree/dev/benchmarks#audbdependencies-loadingwriting-to-file) for full results.

In addition, this pull request **stores dependency tables as parquet files** as reading/writing to them is not slower than for pickle files. Parquet files are also smaller, which means faster transfers, and we can later add support for loading only parts of the file for very huge datasets. Unfortunately, it is still faster to load from pickle in cache, so we continue storing the depednency table as pickle file in cache.
For parquet support we add read abilitites to `audb.Dependencies.load()`, write abilities to `audb.Dependencies.save()`, and extra code that looks for legacy csv files coming from the server (on the server it is always stored in a ZIP file, so the filename on the server does not change). As loading a dependency table from a parquet file and writing it again at another place might change its MD5 sum, I also adjusted the code to compare dependency tables by directly comparing their dataframes.

This pull request **adds `pyarrow` as a dependency** of `audb`, which has the downside of adding a package that is 70 MB in size, and might not be easy to install on all systems. As `pandas` is also planing to add `pyarrow` as a dependency in 3.0, you can find a long discusson about pro and cons at https://github.com/pandas-dev/pandas/issues/54466 and https://github.com/pandas-dev/pandas/issues/57073. One outcome will most likely be that there will be a smaller package than `pyarrow` that can be used as a replacement for `pyarrow`. At the moment I would argue that the speed improvements we gain and the addition of `parquet` as a file format provide a big advantage that anyway justify adding `pyarrow` as a dependency of `audb`.

---

**Real world benchmark**

I also tested the speedup for loading real world datasets from the cache.
The parquet column corresponds to the case that we use `parquet` instead of `pickle` for storing files in cache.
The results are given as the average execution time averaged over 10 runs with standard deviation.

| dataset | before | pull request | parquet |
| --- | --- | --- | --- |
| mozillacommonvoice | 0.465±0.027 s | 0.257±0.033 s | 0.613±0.025 s |
| voxceleb2 | 0.234±0.008 s | 0.127±0.008 s | 0.280±0.011 s |
| librispeech | 0.071±0.007 s | 0.034±0.005 s | 0.086±0.007 s |
| imda-nsc-read-speech-balanced | 0.494±0.018 s | 0.283±0.036 s | 0.552±0.016 s |
| emodb | 0.008±0.018 s | 0.006±0.011 s | 0.010±0.012 s |

As can be seen, the current implementation of using pickle files in cache is the fastest solution,
whereas using parquet files in cache is slower than loading was before.

---

I updated the "Database depednencies" section in the documentation as we mention the dependency file there.

![image](https://github.com/audeering/audb/assets/173624/a63c0407-07a1-4c74-a975-9b7564acb6b9)

And the docstrings of `audb.Dependencies.load()` and `audb.Dependencies.save()`.

![image](https://github.com/audeering/audb/assets/173624/042b509e-4089-447b-8d32-f33ef1b545bf)

![image](https://github.com/audeering/audb/assets/173624/a925e09e-5268-4ffd-925f-6c5c777db429)

---

**NOTE**: the speed improvement for loading and saving CSV files with the help of `pyarrow` can also easily be added to `audformat`, without the need of using `pyarrow` dtypes in the `pandas` dataframes representing the tables of a dataset.

/cc @frankenjoe 