### PR TITLE
Fix upper year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 audEERING GmbH and Contributors
+Copyright (c) 2018-present audEERING GmbH and Contributors
 
 Authors:
     Johannes Wagner


### PR DESCRIPTION
Sets `present` as current year to not have to update this every year.