### PR TITLE
Ensure dependency table index has no name

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -325,6 +325,7 @@ class Dependencies:
                 na_filter=False,
                 dtype=dtype_mapping,
             )
+            self._df.index.name = None
         # Set dtype of index for both CSV and PKL
         # to make backward compatiple
         # with old pickle files in cache

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -45,6 +45,7 @@ def deps():
     df.set_index("file", inplace=True)
     # Ensure correct dtype
     df.index = df.index.astype(audb.core.define.DEPEND_INDEX_DTYPE)
+    df.index.name = None
     for name, dtype in zip(
         audb.core.define.DEPEND_FIELD_NAMES.values(),
         audb.core.define.DEPEND_FIELD_DTYPES.values(),
@@ -75,6 +76,7 @@ def test_init(deps):
 def test_call(deps):
     expected_df = pd.DataFrame.from_records(ROWS).set_index("file")
     expected_df.index = expected_df.index.astype(audb.core.define.DEPEND_INDEX_DTYPE)
+    expected_df.index.name = None
     for name, dtype in zip(
         audb.core.define.DEPEND_FIELD_NAMES.values(),
         audb.core.define.DEPEND_FIELD_DTYPES.values(),
@@ -235,7 +237,6 @@ def test_len(deps):
 def test_str(deps):
     expected_str = (
         "               archive  bit_depth  channels  ... sampling_rate  type version\n"  # noqa: E501
-        "file                                         ...                            \n"  # noqa: E501
         "db.files.csv  archive1          0         0  ...             0     0   1.0.0\n"  # noqa: E501
         "file.wav      archive2         16         2  ...         16000     1   1.0.0\n"  # noqa: E501
         "\n"


### PR DESCRIPTION
In the latest version of `audb` (v1.6.3) and below the index of the dependency table had no name:

```python
>>> audb.__version__
'1.6.3'
>>> deps = audb.dependencies("emodb", version="1.4.1")
>>> deps().index.name is None
True
```

But somewhere in https://github.com/audeering/audb/pull/360 or before we introduced the name `file`.

This pull requests reverts this and adjusts the tests introduced in https://github.com/audeering/audb/pull/360 accordingly.