### PR TITLE
publish: fix updating of multi-file archives

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -410,7 +410,7 @@ def _put_media(
                             backend.get_archive(
                                 archive_file,
                                 tmp_root,
-                                previous_version,
+                                deps.version(missing_files[0]),
                             )
                             for missing_file in missing_files:
                                 src_path = os.path.join(tmp_root, missing_file)


### PR DESCRIPTION
Closes #377 

When removing a file when publishing a new version of a database, and that file was part of an archive that contains other files, `audb.publish()` needs to download the archive, modify it, and publish it with a new version. When looking for that archive it wrongly used `previous_version` before instead of getting the version information from the dependency table.

It also adds a test, which fails for the current `main` branch.

/cc @ChristianGeng 