### PR TITLE
Add audb.Dependencies.__eq__()

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -81,6 +81,18 @@ class Dependencies:
         """
         return file in self._df.index
 
+    def __eq__(self, other: "Dependencies") -> bool:
+        r"""Check if two dependencies table are equal.
+
+        Args:
+            other: dependency table to compare against
+
+        Returns:
+            ``True`` if both dependency tables have the same entries
+
+        """
+        return self._df.equals(other._df)
+
     def __getitem__(self, file: str) -> typing.List:
         r"""File information.
 

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -82,7 +82,7 @@ class Dependencies:
         return file in self._df.index
 
     def __eq__(self, other: "Dependencies") -> bool:
-        r"""Check if two dependencies table are equal.
+        r"""Check if two dependency tables are equal.
 
         Args:
             other: dependency table to compare against

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ graphviz_output_format = "svg"
 apipages_hidden_methods = [
     "__call__",
     "__contains__",
+    "__eq__",
     "__getitem__",
     "__len__",
 ]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -99,11 +99,20 @@ def test_contains(deps):
 
 
 def test_equals(deps):
+    # empty table vs. empty table
+    empty_deps = audb.Dependencies()
+    assert empty_deps == empty_deps
+    assert empty_deps == audb.Dependencies()
+    # empty table vs. example table
     assert deps != audb.Dependencies()
+    # example table vs. example table
     assert deps == deps
     _deps = audb.Dependencies()
-    _deps._df = deps._df
+    _deps._df = deps._df.copy()
     assert deps == _deps
+    # example table vs. different table
+    _deps._df.loc["db.files.csv", "channels"] = 4
+    assert deps != _deps
 
 
 def test_get_item(deps):

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -98,6 +98,14 @@ def test_contains(deps):
     assert "not.csv" not in deps
 
 
+def test_equals(deps):
+    assert deps != audb.Dependencies()
+    assert deps == deps
+    _deps = audb.Dependencies()
+    _deps._df = deps._df
+    assert deps == _deps
+
+
 def test_get_item(deps):
     assert deps["db.files.csv"] == list(ROWS[0].values())[1:]
     assert deps["file.wav"] == list(ROWS[1].values())[1:]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -100,14 +100,13 @@ def test_contains(deps):
 
 def test_equals(deps):
     # empty table vs. empty table
-    empty_deps = audb.Dependencies()
-    assert empty_deps == empty_deps
-    assert empty_deps == audb.Dependencies()
+    _deps = audb.Dependencies()
+    assert _deps == _deps
+    assert _deps == audb.Dependencies()
     # empty table vs. example table
     assert deps != audb.Dependencies()
     # example table vs. example table
     assert deps == deps
-    _deps = audb.Dependencies()
     _deps._df = deps._df.copy()
     assert deps == _deps
     # example table vs. different table


### PR DESCRIPTION
As discussed in https://github.com/audeering/audb/pull/372#pullrequestreview-1889881352 it would be nice to have the `__eq__()` method for `audb.Dependencies` to compare two dependency tables.

This pull requests implements `audb.Dependencies.__eq__()` by relying on `pandas.DataFrame.equals()` to compare for equality.

![image](https://github.com/audeering/audb/assets/173624/a855292d-fa55-4329-8b6b-5de1ef5d4ad2)
