### PR TITLE
Skip broken datasets in audb.available()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -51,16 +51,21 @@ def available(
                 # see https://github.com/audeering/audbackend/issues/132
                 for p in backend._repo.path:
                     name = p.name
-                    for version in [str(x).split("/")[-1] for x in p / "db"]:
-                        databases.append(
-                            [
-                                name,
-                                repository.backend,
-                                repository.host,
-                                repository.name,
-                                version,
-                            ]
-                        )
+                    try:
+                        for version in [str(x).split("/")[-1] for x in p / "db"]:
+                            databases.append(
+                                [
+                                    name,
+                                    repository.backend,
+                                    repository.host,
+                                    repository.name,
+                                    version,
+                                ]
+                            )
+                    except FileNotFoundError:  # pragma: nocover
+                        # If the `db` folder does not exist,
+                        # we do not include the dataset
+                        pass
             else:
                 for path, version in backend.ls("/"):
                     if path.endswith(define.HEADER_FILE):

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -62,7 +62,7 @@ def available(
                                     version,
                                 ]
                             )
-                    except FileNotFoundError:  # pragma: nocover
+                    except FileNotFoundError:
                         # If the `db` folder does not exist,
                         # we do not include the dataset
                         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,7 @@ def private_and_public_repository():
     Configure the following repositories:
     * data-private: repo on public Artifactory without access
     * data-public: repo on public Artifactory with anonymous access
+    * data-public2: repo on public Artifactory with anonymous access
 
     Note, that the order of the repos is important.
     audb will visit the repos in the given order
@@ -194,6 +195,7 @@ def private_and_public_repository():
     audb.config.REPOSITORIES = [
         audb.Repository("data-private", host, backend),
         audb.Repository("data-public", host, backend),
+        audb.Repository("data-public2", host, backend),
     ]
 
     yield repository

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,3 +42,4 @@ def test_available_broken_dataset(private_and_public_repository):
     """
     df = audb.available(only_latest=True)
     assert len(df) > 0
+    assert "broken-dataset" not in df

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,3 +29,16 @@ def test_available(repository):
     ]
     df = audb.available()
     assert len(df) == 0
+
+
+def test_available_broken_dataset(private_and_public_repository):
+    """Test for listing datasets, including a broken one.
+
+    This uses the public repositories,
+    from which ``data-public2``
+    includes ``broken-dataset``,
+    which has a missing ``db`` folder.
+
+    """
+    df = audb.available(only_latest=True)
+    assert len(df) > 0


### PR DESCRIPTION
Closes #382 

This makes sure we skip broken datasets in Artifactory repositories when running `audb.available()`.

To test this, I published a broken dataset in the `data-public2` repo on https://audeering.jfrog.io, which is not used otherwise.
The dataset is named `broken-dataset` and is missing a `db` folder:

![image](https://github.com/audeering/audb/assets/173624/9fe9461f-5f67-4040-8cac-f58d5762390b)