### PR TITLE
Depend on audbackend>=2.0.0

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -758,7 +758,7 @@ def filter_deps(
 
 
 def download_dependencies(
-    backend: typing.Type[audbackend.Backend],
+    backend_interface: typing.Type[audbackend.interface.Base],
     name: str,
     version: str,
     verbose: bool,
@@ -772,7 +772,7 @@ def download_dependencies(
     loaded from that file.
 
     Args:
-        backend: backend interface
+        backend_interface: backend interface
         name: database name
         version: database version
         verbose: if ``True`` a message is shown during download
@@ -785,22 +785,22 @@ def download_dependencies(
         # Load `db.parquet` file,
         # or if non-existent `db.zip`
         # from backend
-        remote_deps_file = backend.join("/", name, define.DEPENDENCIES_FILE)
-        if backend.exists(remote_deps_file, version):
+        remote_deps_file = backend_interface.join("/", name, define.DEPENDENCIES_FILE)
+        if backend_interface.exists(remote_deps_file, version):
             local_deps_file = os.path.join(tmp_root, define.DEPENDENCIES_FILE)
-            backend.get_file(
+            backend_interface.get_file(
                 remote_deps_file,
                 local_deps_file,
                 version,
                 verbose=verbose,
             )
         else:
-            remote_deps_file = backend.join("/", name, define.DB + ".zip")
+            remote_deps_file = backend_interface.join("/", name, define.DB + ".zip")
             local_deps_file = os.path.join(
                 tmp_root,
                 define.LEGACY_DEPENDENCIES_FILE,
             )
-            backend.get_archive(
+            backend_interface.get_archive(
                 remote_deps_file,
                 tmp_root,
                 version,
@@ -813,7 +813,7 @@ def download_dependencies(
 
 
 def upload_dependencies(
-    backend: typing.Type[audbackend.Backend],
+    backend_interface: typing.Type[audbackend.interface.Base],
     deps: Dependencies,
     db_root: str,
     name: str,
@@ -826,7 +826,7 @@ def upload_dependencies(
     and upload it to the backend.
 
     Args:
-        backend: backend interface
+        backend_interface: backend interface
         deps: dependency object
         db_root: database root folder
         name: database name
@@ -834,6 +834,6 @@ def upload_dependencies(
 
     """
     local_deps_file = os.path.join(db_root, define.DEPENDENCIES_FILE)
-    remote_deps_file = backend.join("/", name, define.DEPENDENCIES_FILE)
+    remote_deps_file = backend_interface.join("/", name, define.DEPENDENCIES_FILE)
     deps.save(local_deps_file)
-    backend.put_file(local_deps_file, remote_deps_file, version)
+    backend_interface.put_file(local_deps_file, remote_deps_file, version)

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -1,6 +1,151 @@
+import typing
+
 import audbackend
 
 
-class Repository(audbackend.Repository):
-    __doc__ = audbackend.Repository.__doc__
-    pass
+class Repository:
+    r"""Repository object.
+
+    It stores all information
+    needed to address a repository:
+    the repository name,
+    host,
+    and the backend name.
+    With :meth:`Repository.create_backend_interface`
+    it also provides a method
+    to create a backend interface
+    to access the repository.
+
+    Args:
+        name: repository name
+        host: repository host
+        backend: repository backend
+
+    Examples:
+        >>> Repository("data-local", "/data", "file-system")
+        Repository('data-local', '/data', 'file-system')
+
+    """
+
+    backend_registry = {
+        "file-system": audbackend.backend.FileSystem,
+        "artifactory": audbackend.backend.Artifactory,
+    }
+    r"""Backend registry.
+
+    Holds mapping between registered backend names,
+    and their corresponding backend classes.
+
+    """
+
+    def __init__(
+        self,
+        name: str,
+        host: str,
+        backend: str,
+    ):
+        self.name = name
+        r"""Repository name."""
+        self.host = host
+        r"""Repository host."""
+        self.backend = backend
+        r"""Repository backend name."""
+
+    def __eq__(self, other) -> bool:
+        """Compare two repository instances.
+
+        Args:
+            other: repository instance
+
+        Returns:
+            ``True`` if the string representation of the repositories matches
+
+        """
+        return str(self) == str(other)
+
+    def __repr__(self):  # noqa: D105
+        return (
+            f"Repository("
+            f"'{self.name}', "
+            f"'{self.host}', "
+            f"'{self.backend}'"
+            f")"
+        )
+
+    def create_backend_interface(self) -> typing.Type[audbackend.interface.Base]:
+        r"""Create backend interface to access repository.
+
+        When :attr:`Repository.backend` equals ``artifactory``,
+        it creates an instance of :class:`audbackend.backend.Artifactory`
+        and wraps an :class:`audbackend.interface.Maven` interface
+        around it.
+        The files will then be stored
+        with the following structure on the Artifactory backend
+        (shown by the example of version 1.0.0 of the emodb dataset)::
+
+            emodb/db/1.0.0/db-1.0.0.yaml   <-- header
+            emodb/db/1.0.0/db-1.0.0.zip    <-- dependency table
+            emodb/attachment/.../1.0.0/... <-- attachments
+            emodb/media/.../1.0.0/...      <-- media files
+            emodb/meta/.../1.0.0/...       <-- tables
+
+        When :attr:`Repository.backend` equals ``file-system``,
+        it creates an instance of :class:`audbackend.backend.FileSystem`
+        and wraps an :class:`audbackend.interface.Versioned` interface
+        around it.
+        The files will then be stored
+        with the following structure on the Artifactory backend
+        (shown by the example of version 1.0.0 of the emodb dataset)::
+
+            emodb/1.0.0/db.yaml            <-- header
+            emodb/1.0.0/db.zip             <-- dependency table
+            emodb/attachment/1.0.0/...     <-- attachments
+            emodb/media/1.0.0/...          <-- media files
+            emodb/meta/1.0.0/...           <-- tables
+
+        The returned backend instance
+        has not yet established a connection to the backend.
+        To establish a connection,
+        use the backend with a ``with`` statement,
+        or use the ``open()`` and ``close()`` methods of the backend class.
+        The backend is stored as the inside the ``backend`` attribute
+        of the returned backend interface.
+
+        Returns:
+            interface to repository
+
+        """
+        backend_class = self.backend_registry[self.backend]
+        backend = backend_class(self.host, self.name)
+        if self.backend == "artifactory":
+            interface = audbackend.interface.Maven(backend)
+        else:
+            interface = audbackend.interface.Versioned(backend)
+        return interface
+
+    @classmethod
+    def register(
+        cls,
+        backend_name: str,
+        backend_class: typing.Type[audbackend.backend.Base],
+    ):
+        r"""Register backend class.
+
+        Adds an entry to the dictionary
+        stored in the class variable :data:`Repository.backend_registry`,
+        mapping a backend name
+        to an actual backend class.
+
+        Args:
+            backend_name: name of the backend,
+                e.g. ``"file-system"``
+            backend_class: class of the backend,
+                that should be associated with ``backend_name``,
+                e.g. ``"audbackend.backend.Filesystem"``
+
+        Examples:
+            >>> import audbackend
+            >>> Repository.register("file-system", audbackend.backend.FileSystem)
+
+        """
+        cls.backend_registry[backend_name] = backend_class

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -4,4 +4,4 @@ Authentication
 Using Artifactory as backend
 requires authentication.
 For more information,
-see :class:`audbackend.Artifactory`.
+see :class:`audbackend.backend.Artifactory`.

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -90,7 +90,7 @@ Containing a few random annotations.
 Publish the first version
 -------------------------
 
-We define a repository on the :class:`audbackend.FileSystem` backend
+We define a repository on the local file system
 to publish the database to.
 
 .. jupyter-execute::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
-    'audbackend[artifactory] >=1.0.0',
+    'audbackend[artifactory] @ git+https://github.com/audeering/audbackend.git@dev',
     'audeer >=2.0.0',
     'audformat >=1.1.1',
     'audiofile >=1.0.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
-    'audbackend[artifactory] @ git+https://github.com/audeering/audbackend.git@dev',
+    'audbackend[artifactory] >=2.0.0',
     'audeer >=2.0.0',
     'audformat >=1.1.1',
     'audiofile >=1.0.0',

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -15,7 +15,7 @@ import audb
 DB_NAME = "test_lock"
 
 
-class SlowFileSystem(audbackend.FileSystem):
+class SlowFileSystem(audbackend.backend.FileSystem):
     r"""Emulate a slow file system.
 
     Introduces a short delay when getting a file from the backend.
@@ -28,13 +28,10 @@ class SlowFileSystem(audbackend.FileSystem):
         super()._get_file(*args)
 
 
-audbackend.register(
-    "slow-file-system",
-    SlowFileSystem,
-)
+audb.Repository.register("slow-file-system", SlowFileSystem)
 
 
-class CrashFileSystem(audbackend.FileSystem):
+class CrashFileSystem(audbackend.backend.FileSystem):
     r"""Emulate a file system that crashes.
 
     Raises an exception when getting a file from the backend.
@@ -45,10 +42,7 @@ class CrashFileSystem(audbackend.FileSystem):
         raise RuntimeError()
 
 
-audbackend.register(
-    "crash-file-system",
-    CrashFileSystem,
-)
+audb.Repository.register("crash-file-system", CrashFileSystem)
 
 
 def lock_paths(cache):

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -407,7 +407,7 @@ def test_publish(tmpdir, dbs, persistent_repository, version):
         num_workers=pytest.NUM_WORKERS,
         verbose=False,
     )
-    backend = audb.core.utils.lookup_backend(DB_NAME, version)
+    backend_interface = audb.core.utils.lookup_backend(DB_NAME, version)
     number_of_media_files_in_custom_archives = len(set(archives.keys()))
     number_of_custom_archives = len(set(archives.values()))
     number_of_media_files = len(deps.media)
@@ -456,8 +456,8 @@ def test_publish(tmpdir, dbs, persistent_repository, version):
 
     for file in db.files:
         name = archives[file] if file in archives else file
-        file_path = backend.join("/", db.name, "media", name)
-        backend.exists(file_path, version)
+        file_path = backend_interface.join("/", db.name, "media", name)
+        backend_interface.exists(file_path, version)
         path = os.path.join(dbs[version], file)
         assert deps.checksum(file) == audeer.md5(path)
         if deps.format(file) in [

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,103 @@
+import pytest
+
+import audbackend
+
+import audb
+
+
+@pytest.mark.parametrize(
+    "repository1, repository2, expected",
+    [
+        (
+            audb.Repository("repo", "host", "file-system"),
+            audb.Repository("repo", "host", "file-system"),
+            True,
+        ),
+        (
+            audb.Repository("repo1", "host", "file-system"),
+            audb.Repository("repo2", "host", "file-system"),
+            False,
+        ),
+    ],
+)
+def test_repository_eq(repository1, repository2, expected):
+    """Test the Repository.__eq__().
+
+    Two repository instances are equal,
+    if their string representation matches.
+
+    Args:
+        repository1: repository instance
+        repository2: repository instance
+        expected: expected return value of ``Repository.__eq__()``
+
+    """
+    assert (repository1 == repository2) == expected
+
+
+@pytest.mark.parametrize(
+    "backend, host, repo, expected",
+    [
+        (
+            "file-system",
+            "host",
+            "repo",
+            "Repository('repo', 'host', 'file-system')",
+        ),
+    ],
+)
+def test_repository_repr(backend, host, repo, expected):
+    """Test string representation of Repository.
+
+    Args:
+        backend: backend name
+        host: host
+        repo: repository name
+        expected: expected string representation
+
+    """
+    repository = audb.Repository(repo, host, backend)
+    assert str(repository) == expected
+
+
+@pytest.mark.parametrize(
+    "backend, host, repo, expected_backend, expected_interface",
+    [
+        (
+            "file-system",
+            "host",
+            "repo",
+            audbackend.backend.FileSystem,
+            audbackend.interface.Versioned,
+        ),
+        (
+            "artifactory",
+            "host",
+            "repo",
+            audbackend.backend.Artifactory,
+            audbackend.interface.Maven,
+        ),
+    ],
+)
+def test_repository_create_backend_interface(
+    backend,
+    host,
+    repo,
+    expected_backend,
+    expected_interface,
+):
+    """Test creation of backend interface.
+
+    Args:
+        backend: backend name
+        host: host
+        repo: repository name
+        expected_backend: expected backend class
+        expected_interface: expected backend interface class
+
+    """
+    repository = audb.Repository(repo, host, backend)
+    backend_interface = repository.create_backend_interface()
+    assert isinstance(backend_interface, expected_interface)
+    assert isinstance(backend_interface.backend, expected_backend)
+    assert not backend_interface.backend.opened


### PR DESCRIPTION
Updates the code to use the new API of `audbackend` 2.0.0.

The main changes in `audbackend` 2.0.0 affecting `audb` are:

* The new abstraction layer of **interfaces** is introduced. A **backend** object is now only responsible for accessing the backend. The **interface** is responsible for managing how the files are stored on the backend, e.g. versioning them by storing them in a correspoinding folder structure. For `audb` we use the `audbackend.interface.Maven` for versioning on the `audbackend.backend.Artifactory` backend.
* Authentication on the backend is only done when explicitly opening a connection to a backend, using `audbackend.backend.Base.open()` or using the `with` statement. This also means it is desired to use `audbackend.backend.Base.close()` when the backend is no longer needed.
* `audbackend.Repository` was removed as `audbackend` is no longer using string names like `artifactory` to address a backend. As we still use names in `audb` to address a backend, e.g. in the config file, we need to handle this here directly.
To do so, it implements now its own version of `audb.Repository` and does no longer rely on `audbackend.Repository`, so we can deprecate that as well.

![image](https://github.com/audeering/audb/assets/173624/77f2ea22-23ae-45c3-9029-603f07105247)
