### PR TITLE
Fix audb.versions() for non-existing repositories

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -607,6 +607,10 @@ def versions(
         try:
             backend = utils.access_backend(repository)
         except audbackend.BackendError:
+            # If the backend cannot be accessed,
+            # e.g. host or repository do not exist,
+            # we skip it
+            # and continue with the next repository
             continue
         if isinstance(backend, audbackend.Artifactory):
             import artifactory

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -604,7 +604,10 @@ def versions(
     """
     vs = []
     for repository in config.REPOSITORIES:
-        backend = utils.access_backend(repository)
+        try:
+            backend = utils.access_backend(repository)
+        except audbackend.BackendError:
+            continue
         if isinstance(backend, audbackend.Artifactory):
             import artifactory
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,5 @@
 import os
 
-import pandas as pd
-
 import audeer
 import audformat
 
@@ -75,10 +73,6 @@ def test_versions(tmpdir, repository):
     version = "1.0.0"
     build_dir = audeer.mkdir(tmpdir, "build")
     db = audformat.Database(name)
-    index = pd.Index(["a"], name="speaker")
-    db["table"] = audformat.MiscTable(index)
-    db["table"]["column"] = audformat.Column()
-    db["table"]["column"].set([0])
     db.save(build_dir)
     audb.publish(build_dir, version, repository)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,14 +61,13 @@ def test_versions(tmpdir, repository):
 
     """
     # Add non existing repository to the list of configured repositories
-    audb.config.REPOSITORIES += [
-        audb.Repository(
-            name="non-existing-repo",
-            host="non-existing-host",
-            backend="file-system",
-        )
-    ]
-    # Publish a dataset to the existing repository
+    non_existing_repository = audb.Repository(
+        name="non-existing-repo",
+        host="non-existing-host",
+        backend="file-system",
+    )
+    audb.config.REPOSITORIES += [non_existing_repository]
+    # Publish a dataset to an existing repository
     name = "mydb"
     version = "1.0.0"
     build_dir = audeer.mkdir(tmpdir, "build")


### PR DESCRIPTION
Closes #389 

In functions that do not rely on `audb.core.utils._lookup()` to access a backend, we need to handle the case of non existing repositories ourselves. This is the case in `audb.available()`, `audb.publish()`, and `audb.versions()`. In `audb.available()` we did handle the case already, and just skipped non-existing repositories. In `audb.publish()` an error is raised if the repository does not exist. In `audb.versions()` it should skip non-existing repositories, which was not the case before, and it introduced by this pull request.

In addition, I added a test that fails for the current `main` branch and is fixed by the changes proposed here.