### PR TITLE
Add support for TXT files as media files

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -459,13 +459,18 @@ def _get_media_from_backend(
                 src_path = os.path.join(db_root_tmp, file)
                 file = flavor.destination(file)
                 dst_path = os.path.join(db_root_tmp, file)
-                flavor(
-                    src_path,
-                    dst_path,
-                    src_bit_depth=bit_depth,
-                    src_channels=channels,
-                    src_sampling_rate=sampling_rate,
-                )
+                try:
+                    flavor(
+                        src_path,
+                        dst_path,
+                        src_bit_depth=bit_depth,
+                        src_channels=channels,
+                        src_sampling_rate=sampling_rate,
+                    )
+                except RuntimeError:
+                    raise RuntimeError(
+                        f"Media file '{file}' does not support requesting a flavor."
+                    )
                 if src_path != dst_path:
                     os.remove(src_path)
 
@@ -1001,6 +1006,10 @@ def load(
             ``format``,
             or ``sampling_rate``
             is requested
+        RuntimeError: if a flavor is requested,
+            but the dataset contains media files,
+            that don't contain audio,
+            e.g. text files
 
     Examples:
         >>> db = audb.load(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1007,7 +1007,7 @@ def load(
             or ``sampling_rate``
             is requested
         RuntimeError: if a flavor is requested,
-            but the dataset contains media files,
+            but the database contains media files,
             that don't contain audio,
             e.g. text files
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -324,8 +324,7 @@ def _media_values(
         checksum: checksum of the media file
 
     Returns:
-        Tuple with a row to be added to the dependency table,
-        containing entries for `
+        row to be added to the dependency table as tuple
 
     """
     dependency_type = define.DependType.MEDIA

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1093,6 +1093,10 @@ def test_publish_text_media_files(tmpdir, dbs, repository):
     assert list(db) == ["files"]
     assert os.path.exists(audeer.path(db.root, file))
 
+    error_msg = f"Media file '{file}' does not support requesting a flavor."
+    with pytest.raises(RuntimeError, match=error_msg):
+        db = audb.load(name, version=version, channels=[0], verbose=False)
+
 
 def test_update_database(dbs, persistent_repository):
     version = "2.1.0"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -45,6 +45,7 @@ def dbs(tmpdir_factory):
     #
     # tables:
     #   - emotion
+    #   - files
     # misc tables:
     #   - misc-in-scheme
     #   - misc-not-in-scheme
@@ -133,6 +134,7 @@ def dbs(tmpdir_factory):
     #
     # tables:
     #   - emotion
+    #   - files
     # misc tables:
     #   - misc-in-scheme
     #   - misc-not-in-scheme
@@ -179,6 +181,7 @@ def dbs(tmpdir_factory):
     #
     # tables:
     #   - emotion
+    #   - files
     # misc tables:
     #   - misc-in-scheme
     #   - misc-not-in-scheme
@@ -208,6 +211,7 @@ def dbs(tmpdir_factory):
     #
     # tables:
     #   - emotion
+    #   - files
     # misc tables:
     #   - misc-in-scheme
     #   - misc-not-in-scheme
@@ -232,6 +236,7 @@ def dbs(tmpdir_factory):
     #
     # tables:
     #   - emotion
+    #   - files
     # misc tables:
     #   - misc-in-scheme
     #   - misc-not-in-scheme
@@ -267,6 +272,7 @@ def dbs(tmpdir_factory):
     #
     # tables:
     #   - emotion
+    #   - files
     # misc tables:
     #   - misc-in-scheme
     #   - misc-not-in-scheme
@@ -1072,7 +1078,7 @@ def test_publish_text_media_files(tmpdir, dbs, repository):
     index = audformat.filewise_index(["data/file1.txt"])
     db["files"] = audformat.Table(index)
     db["files"]["speaker"] = audformat.Column(scheme_id="speaker")
-    db["files"]["speaker"].set(["speaker-a"])
+    db["files"]["speaker"].set(["adam"])
     db.save(build_dir)
 
     # Publish database, containing text media file
@@ -1091,6 +1097,45 @@ def test_publish_text_media_files(tmpdir, dbs, repository):
     db = audb.load(name, version=version, verbose=False, full_path=False)
     assert db.files == [file]
     assert list(db) == ["files"]
+    assert os.path.exists(audeer.path(db.root, file))
+
+    error_msg = f"Media file '{file}' does not support requesting a flavor."
+    with pytest.raises(RuntimeError, match=error_msg):
+        db = audb.load(name, version=version, channels=[0], verbose=False)
+
+    # Publish database, containing text and media files
+    audeer.rmdir(build_dir)
+    shutil.copytree(dbs["1.0.0"], build_dir)  # start with db containing audio files
+    db = audformat.Database.load(build_dir)
+    speaker = db["files"]["speaker"].get()
+    files = list(db.files)
+    tables = list(db)
+    data_dir = audeer.mkdir(build_dir, "data")
+    with open(audeer.path(data_dir, "file1.txt"), "w") as file:
+        file.write("Text written by a person.\n")
+    index = audformat.filewise_index(["data/file1.txt"])
+    db["files"].extend_index(index, inplace=True)
+    db["files"]["speaker"] = audformat.Column(scheme_id="speaker")
+    db["files"]["speaker"].set(list(speaker.values) + ["adam"])
+    db.name = name
+    db.save(build_dir)
+
+    # Publish database, containing text media file
+    version = "2.0.0"
+    deps = audb.publish(build_dir, version, repository, previous_version=None)
+
+    assert deps.table_ids == tables
+    file = "data/file1.txt"
+    assert deps.media == files + [file]
+    assert deps.bit_depth(file) == 0
+    assert deps.channels(file) == 0
+    assert deps.duration(file) == 0.0
+    assert deps.format(file) == "txt"
+    assert deps.sampling_rate(file) == 0
+
+    db = audb.load(name, version=version, verbose=False, full_path=False)
+    assert db.files == files + [file]
+    assert list(db) == tables
     assert os.path.exists(audeer.path(db.root, file))
 
     error_msg = f"Media file '{file}' does not support requesting a flavor."


### PR DESCRIPTION
Motivated by https://github.com/audeering/audformat/issues/376#issuecomment-2076772215

We want to support publishing databases, that do contain media files, that don't support audio/video related metadata (e.g. sampling rate). In `audformat` we can store such data anyway, the only problem was so far the dependency table in `audb`. Because when publishing a database, `audb.core.publish._media_values()` was trying to run `audiofile.sampling_rate(file)` on all media files, which obviously fails for non audio/video files.

There are two ways to solve this:
* Catch the `RuntimeError` thrown by `audiofile.sampling_rate(file)` and treat the file automatically as non audio/video file
* Set explicitly which non audio/video files should be supported

I have opted for the first solution at the moment, as in `audformat` we also support every file extension at the moment.
An implementation of the second approach can be inspected at d6e9c7f.

---

In `audb.load()` we now raise a `RuntimeError` when a database is loaded with a requested flavor (e.g. `sampling_rate=16000`), but contains text files. From the docstring of `audb.load()`:

![image](https://github.com/audeering/audb/assets/173624/80814aa6-aaa3-4358-ad73-58fd01e0798f)

Here the question is if we should change this, and instead of raising an error, only convert files to the requested flavor that we can convert. On the other hand, a user might expect that when using `sampling_rate=16000` the loaded database will contain only files, that can be passed on to a model working with audio files provided in a sampling rate of 16000 Hz. For that reason, it felt saver to me, to raise an error.