### PR TITLE
Undo list of files in deps methods (revert #370)

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -220,95 +220,77 @@ class Dependencies:
         """
         return self._df[self._df["type"] == define.DependType.META].index.tolist()
 
-    def archive(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[str, typing.List[str]]:
-        r"""Name of archive a file belong to.
+    def archive(self, file: str) -> str:
+        r"""Name of archive the file belongs to.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            archive name(s)
+            archive name
 
         """
-        return self._column_loc("archive", files)
+        return self._df.archive[file]
 
-    def bit_depth(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[int, typing.List[int]]:
+    def bit_depth(self, file: str) -> int:
         r"""Bit depth of media file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            bit depth(s)
+            bit depth
 
         """
-        return self._column_loc("bit_depth", files, int)
+        return self._column_loc("bit_depth", file, int)
 
-    def channels(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[int, typing.List[int]]:
+    def channels(self, file: str) -> int:
         r"""Number of channels of media file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            number(s) of channels
+            number of channels
 
         """
-        return self._column_loc("channels", files, int)
+        return self._column_loc("channels", file, int)
 
-    def checksum(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[str, typing.List[str]]:
+    def checksum(self, file: str) -> str:
         r"""Checksum of file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            checksum of file(s)
+            checksum of file
 
         """
-        return self._column_loc("checksum", files)
+        return self._column_loc("checksum", file)
 
-    def duration(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[float, typing.List[float]]:
+    def duration(self, file: str) -> float:
         r"""Duration of file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            duration(s) in seconds
+            duration in seconds
 
         """
-        return self._column_loc("duration", files, float)
+        return self._column_loc("duration", file, float)
 
-    def format(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[str, typing.List[str]]:
+    def format(self, file: str) -> str:
         r"""Format of file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            file format(s) (always lower case)
+            file format (always lower case)
 
         """
-        return self._column_loc("format", files)
+        return self._column_loc("format", file)
 
     def load(self, path: str):
         r"""Read dependencies from file.
@@ -365,35 +347,29 @@ class Dependencies:
             table = parquet.read_table(path)
             self._df = self._table_to_dataframe(table)
 
-    def removed(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[bool, typing.List[bool]]:
+    def removed(self, file: str) -> bool:
         r"""Check if file is marked as removed.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
             ``True`` if file was removed
 
         """
-        return self._column_loc("removed", files, bool)
+        return self._column_loc("removed", file, bool)
 
-    def sampling_rate(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[int, typing.List[int]]:
+    def sampling_rate(self, file: str) -> int:
         r"""Sampling rate of media file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            sampling rate(s) in Hz
+            sampling rate in Hz
 
         """
-        return self._column_loc("sampling_rate", files, int)
+        return self._column_loc("sampling_rate", file, int)
 
     def save(self, path: str):
         r"""Write dependencies to file.
@@ -420,35 +396,29 @@ class Dependencies:
             table = self._dataframe_to_table(self._df, file_column=True)
             parquet.write_table(table, path)
 
-    def type(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[int, typing.List[int]]:
+    def type(self, file: str) -> int:
         r"""Type of file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            type(s)
+            type
 
         """
-        return self._column_loc("type", files, int)
+        return self._column_loc("type", file, int)
 
-    def version(
-        self,
-        files: typing.Union[str, typing.Sequence[str]],
-    ) -> typing.Union[str, typing.List[str]]:
+    def version(self, file: str) -> str:
         r"""Version of file.
 
         Args:
-            files: relative file path(s)
+            file: relative file path
 
         Returns:
-            version string(s)
+            version string
 
         """
-        return self._column_loc("version", files)
+        return self._column_loc("version", file)
 
     def _add_attachment(
         self,
@@ -552,21 +522,10 @@ class Dependencies:
         dtype: typing.Callable = None,
     ) -> typing.Union[typing.Any, typing.List[typing.Any]]:
         r"""Column content for selected files."""
-        # Single file
-        if isinstance(files, str):
-            value = self._df.at[files, column]
-            if dtype is not None:
-                value = dtype(value)
-            return value
-
-        # Multiple files
-        else:
-            values = self._df.loc[files, column]
-            if dtype is not None:
-                values = [dtype(value) for value in values]
-            else:
-                values = values.tolist()
-            return values
+        value = self._df.at[files, column]
+        if dtype is not None:
+            value = dtype(value)
+        return value
 
     def _dataframe_to_table(
         self,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,45 +50,35 @@ using `pyarrow` dtypes).
 | method                                          |   string |   object |   pyarrow |
 |-------------------------------------------------|----------|----------|-----------|
 | Dependencies.\_\_call__()                       |    0.000 |    0.000 |     0.000 |
-| Dependencies.\_\_contains__(10000 files)        |    0.004 |    0.005 |     0.004 |
-| Dependencies.\_\_get_item__(10000 files)        |    0.319 |    0.225 |     0.871 |
+| Dependencies.\_\_contains__(10000 files)        |    0.005 |    0.004 |     0.004 |
+| Dependencies.\_\_get_item__(10000 files)        |    0.322 |    0.224 |     0.900 |
 | Dependencies.\_\_len__()                        |    0.000 |    0.000 |     0.000 |
-| Dependencies.\_\_str__()                        |    0.005 |    0.005 |     0.006 |
-| Dependencies.archives                           |    0.142 |    0.112 |     0.140 |
-| Dependencies.attachments                        |    0.024 |    0.018 |     0.017 |
-| Dependencies.attachment_ids                     |    0.027 |    0.018 |     0.019 |
-| Dependencies.files                              |    0.011 |    0.011 |     0.010 |
-| Dependencies.media                              |    0.105 |    0.070 |     0.064 |
-| Dependencies.removed_media                      |    0.102 |    0.062 |     0.063 |
-| Dependencies.table_ids                          |    0.032 |    0.026 |     0.023 |
-| Dependencies.tables                             |    0.024 |    0.017 |     0.017 |
-| Dependencies.archive(10000 files)               |    0.028 |    0.026 |     0.050 |
-| Dependencies.archive([10000 files])             |    0.008 |    0.008 |     0.008 |
-| Dependencies.bit_depth(10000 files)             |    0.024 |    0.024 |     0.044 |
-| Dependencies.bit_depth([10000 files])           |    0.002 |    0.002 |     0.004 |
-| Dependencies.channels(10000 files)              |    0.024 |    0.024 |     0.045 |
-| Dependencies.channels([10000 files])            |    0.002 |    0.002 |     0.005 |
-| Dependencies.checksum(10000 files)              |    0.025 |    0.024 |     0.048 |
-| Dependencies.checksum([10000 files])            |    0.002 |    0.002 |     0.002 |
-| Dependencies.duration(10000 files)              |    0.024 |    0.025 |     0.044 |
-| Dependencies.duration([10000 files])            |    0.003 |    0.003 |     0.004 |
-| Dependencies.format(10000 files)                |    0.026 |    0.023 |     0.049 |
-| Dependencies.format([10000 files])              |    0.002 |    0.002 |     0.002 |
-| Dependencies.removed(10000 files)               |    0.024 |    0.024 |     0.044 |
-| Dependencies.removed([10000 files])             |    0.002 |    0.002 |     0.004 |
-| Dependencies.sampling_rate(10000 files)         |    0.024 |    0.024 |     0.046 |
-| Dependencies.sampling_rate([10000 files])       |    0.002 |    0.002 |     0.004 |
-| Dependencies.type(10000 files)                  |    0.024 |    0.024 |     0.044 |
-| Dependencies.type([10000 files])                |    0.002 |    0.002 |     0.004 |
-| Dependencies.version(10000 files)               |    0.026 |    0.024 |     0.049 |
-| Dependencies.version([10000 files])             |    0.002 |    0.002 |     0.002 |
-| Dependencies._add_attachment()                  |    0.055 |    0.055 |     0.178 |
-| Dependencies._add_media(10000 files)            |    0.055 |    0.055 |     0.066 |
-| Dependencies._add_meta()                        |    0.120 |    0.124 |     0.122 |
-| Dependencies._drop()                            |    0.076 |    0.076 |     0.118 |
-| Dependencies._remove()                          |    0.068 |    0.069 |     0.065 |
-| Dependencies._update_media()                    |    0.081 |    0.079 |     0.138 |
-| Dependencies._update_media_version(10000 files) |    0.012 |    0.011 |     0.021 |
+| Dependencies.\_\_str__()                        |    0.006 |    0.005 |     0.006 |
+| Dependencies.archives                           |    0.144 |    0.116 |     0.152 |
+| Dependencies.attachments                        |    0.030 |    0.018 |     0.018 |
+| Dependencies.attachment_ids                     |    0.029 |    0.018 |     0.018 |
+| Dependencies.files                              |    0.030 |    0.011 |     0.046 |
+| Dependencies.media                              |    0.129 |    0.073 |     0.095 |
+| Dependencies.removed_media                      |    0.117 |    0.070 |     0.087 |
+| Dependencies.table_ids                          |    0.037 |    0.026 |     0.023 |
+| Dependencies.tables                             |    0.029 |    0.017 |     0.017 |
+| Dependencies.archive(10000 files)               |    0.045 |    0.042 |     0.065 |
+| Dependencies.bit_depth(10000 files)             |    0.024 |    0.024 |     0.045 |
+| Dependencies.channels(10000 files)              |    0.023 |    0.023 |     0.045 |
+| Dependencies.checksum(10000 files)              |    0.026 |    0.023 |     0.047 |
+| Dependencies.duration(10000 files)              |    0.023 |    0.023 |     0.043 |
+| Dependencies.format(10000 files)                |    0.026 |    0.023 |     0.047 |
+| Dependencies.removed(10000 files)               |    0.023 |    0.023 |     0.043 |
+| Dependencies.sampling_rate(10000 files)         |    0.023 |    0.023 |     0.043 |
+| Dependencies.type(10000 files)                  |    0.023 |    0.023 |     0.043 |
+| Dependencies.version(10000 files)               |    0.026 |    0.023 |     0.047 |
+| Dependencies._add_attachment()                  |    0.055 |    0.062 |     0.220 |
+| Dependencies._add_media(10000 files)            |    0.057 |    0.057 |     0.066 |
+| Dependencies._add_meta()                        |    0.117 |    0.129 |     0.145 |
+| Dependencies._drop()                            |    0.075 |    0.078 |     0.121 |
+| Dependencies._remove()                          |    0.061 |    0.069 |     0.064 |
+| Dependencies._update_media()                    |    0.087 |    0.086 |     0.145 |
+| Dependencies._update_media_version(10000 files) |    0.011 |    0.011 |     0.020 |
 
 
 ## audb.Dependencies loading/writing to file

--- a/benchmarks/benchmark-dependencies-methods.py
+++ b/benchmarks/benchmark-dependencies-methods.py
@@ -253,21 +253,9 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
-    method = f"Dependencies.archive([{n_files} files])"
-    t0 = time.time()
-    deps.archive(_files)
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
     method = f"Dependencies.bit_depth({n_files} files)"
     t0 = time.time()
     [deps.bit_depth(file) for file in _files]
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
-    method = f"Dependencies.bit_depth([{n_files} files])"
-    t0 = time.time()
-    deps.bit_depth(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -277,21 +265,9 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
-    method = f"Dependencies.channels([{n_files} files])"
-    t0 = time.time()
-    deps.channels(_files)
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
     method = f"Dependencies.checksum({n_files} files)"
     t0 = time.time()
     [deps.checksum(file) for file in _files]
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
-    method = f"Dependencies.checksum([{n_files} files])"
-    t0 = time.time()
-    deps.checksum(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -301,21 +277,9 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
-    method = f"Dependencies.duration([{n_files} files])"
-    t0 = time.time()
-    deps.duration(_files)
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
     method = f"Dependencies.format({n_files} files)"
     t0 = time.time()
     [deps.format(file) for file in _files]
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
-    method = f"Dependencies.format([{n_files} files])"
-    t0 = time.time()
-    deps.format(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -325,21 +289,9 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
-    method = f"Dependencies.removed([{n_files} files])"
-    t0 = time.time()
-    deps.removed(_files)
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
     method = f"Dependencies.sampling_rate({n_files} files)"
     t0 = time.time()
     [deps.sampling_rate(file) for file in _files]
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
-    method = f"Dependencies.sampling_rate([{n_files} files])"
-    t0 = time.time()
-    deps.sampling_rate(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 
@@ -349,21 +301,9 @@ for dtype in dtypes:
     t = time.time() - t0
     results.at[method, dtype] = t
 
-    method = f"Dependencies.type([{n_files} files])"
-    t0 = time.time()
-    deps.type(_files)
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
     method = f"Dependencies.version({n_files} files)"
     t0 = time.time()
     [deps.version(file) for file in _files]
-    t = time.time() - t0
-    results.at[method, dtype] = t
-
-    method = f"Dependencies.version([{n_files} files])"
-    t0 = time.time()
-    deps.version(_files)
     t = time.time() - t0
     results.at[method, dtype] = t
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -36,6 +36,14 @@ ROWS = [
 ]
 
 
+def get_entries(column):
+    return [row[column] for row in ROWS]
+
+
+def test_get_entries():
+    assert get_entries("archive") == ["archive1", "archive2"]
+
+
 @pytest.fixture(
     scope="function",
 )
@@ -116,11 +124,11 @@ def test_get_item(deps):
 
 
 def test_archives(deps):
-    assert deps.archives == ["archive1", "archive2"]
+    assert deps.archives == get_entries("archive")
 
 
 def test_files(deps):
-    assert deps.files == ["db.files.csv", "file.wav"]
+    assert deps.files == get_entries("file")
 
 
 def test_media(deps):
@@ -139,95 +147,74 @@ def test_tables(deps):
     assert deps.tables == ["db.files.csv"]
 
 
-@pytest.mark.parametrize(
-    "files",
-    [
-        "",
-        "non-existing",
-        [""],
-        ["non-existing"],
-    ],
-)
-@pytest.mark.parametrize(
-    "method, expected_error",
-    [
-        ("archive", KeyError),
-        ("bit_depth", KeyError),
-        ("channels", KeyError),
-        ("checksum", KeyError),
-        ("duration", KeyError),
-        ("format", KeyError),
-        ("removed", KeyError),
-        ("sampling_rate", KeyError),
-        ("type", KeyError),
-        ("version", KeyError),
-    ],
-)
-def test_error_file_based_methods(deps, files, method, expected_error):
-    """Test errors for all file based methods of audb.Dependencies.
-
-    Test all methods that have ``files`` as argument,
-    and return an entry from a column
-    of the dependency table
-    for the selected files.
-
-    """
-    deps_method = getattr(deps, method)
-    with pytest.raises(expected_error):
-        deps_method(files)
+def test_archive(deps):
+    files = get_entries("file")
+    archives = get_entries("archive")
+    for file, archive in zip(files, archives):
+        assert deps.archive(file) == archive
+        assert isinstance(deps.archive(file), str)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.archive("non.existing")
 
 
-@pytest.mark.parametrize(
-    "files",
-    [
-        "db.files.csv",
-        "file.wav",
-        ["db.files.csv"],
-        ["db.files.csv", "file.wav"],
-    ],
-)
-@pytest.mark.parametrize(
-    "method, expected_dtype",
-    [
-        ("archive", str),
-        ("bit_depth", int),
-        ("channels", int),
-        ("checksum", str),
-        ("duration", float),
-        ("format", str),
-        ("removed", bool),
-        ("sampling_rate", int),
-        ("type", int),
-        ("version", str),
-    ],
-)
-def test_file_bases_methods(deps, files, method, expected_dtype):
-    """Test all file based methods of audb.Dependencies.
+def test_bit_depth(deps):
+    files = get_entries("file")
+    bit_depths = get_entries("bit_depth")
+    for file, bit_depth in zip(files, bit_depths):
+        assert deps.bit_depth(file) == bit_depth
+        assert isinstance(deps.bit_depth(file), int)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.bit_depth("non.existing")
 
-    Test all methods that have ``files`` as argument,
-    and return an entry from a column
-    of the dependency table
-    for the selected files.
 
-    """
-    deps_method = getattr(deps, method)
-    result = deps_method(files)
-    if not isinstance(files, list):
-        for row in ROWS:
-            if row["file"] == files:
-                assert result == row[method]
-                assert isinstance(result, expected_dtype)
-                break
-    else:
-        expected = []
-        for file in files:
-            for row in ROWS:
-                if row["file"] == file:
-                    expected.append(row[method])
-                    break
-        assert result == expected
-        for result in result:
-            assert isinstance(result, expected_dtype)
+def test_channels(deps):
+    files = get_entries("file")
+    channels = get_entries("channels")
+    for file, channel in zip(files, channels):
+        assert deps.channels(file) == channel
+        assert isinstance(deps.channels(file), int)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.channels("non.existing")
+
+
+def test_checksum(deps):
+    files = get_entries("file")
+    checksums = get_entries("checksum")
+    for file, checksum in zip(files, checksums):
+        assert deps.checksum(file) == checksum
+        assert isinstance(deps.checksum(file), str)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.checksum("non.existing")
+
+
+def test_duration(deps):
+    files = get_entries("file")
+    durations = get_entries("duration")
+    for file, duration in zip(files, durations):
+        assert deps.duration(file) == duration
+        assert isinstance(deps.duration(file), float)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.duration("non.existing")
+
+
+def test_format(deps):
+    files = get_entries("file")
+    formats = get_entries("format")
+    for file, format in zip(files, formats):
+        assert deps.format(file) == format
+        assert isinstance(deps.format(file), str)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.format("non.existing")
+
+
+def test_removed(deps):
+    files = get_entries("file")
+    removeds = get_entries("removed")
+    for file, removed in zip(files, removeds):
+        assert deps.removed(file) == removed
+        assert isinstance(deps.removed(file), bool)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.removed("non.existing")
 
 
 @pytest.mark.parametrize("file", ["deps.csv", "deps.pkl", "deps.parquet"])
@@ -274,6 +261,36 @@ def test_load_save_errors(deps):
     # File missing
     with pytest.raises(FileNotFoundError):
         deps.load("deps.csv")
+
+
+def test_sampling_rate(deps):
+    files = get_entries("file")
+    sampling_rates = get_entries("sampling_rate")
+    for file, sampling_rate in zip(files, sampling_rates):
+        assert deps.sampling_rate(file) == sampling_rate
+        assert isinstance(deps.sampling_rate(file), int)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.sampling_rate("non.existing")
+
+
+def test_type(deps):
+    files = get_entries("file")
+    types = get_entries("type")
+    for file, type in zip(files, types):
+        assert deps.type(file) == type
+        assert isinstance(deps.type(file), int)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.type("non.existing")
+
+
+def test_version(deps):
+    files = get_entries("file")
+    versions = get_entries("version")
+    for file, version in zip(files, versions):
+        assert deps.version(file) == version
+        assert isinstance(deps.version(file), str)
+    with pytest.raises(KeyError, match="non.existing"):
+        deps.version("non.existing")
 
 
 def test_len(deps):


### PR DESCRIPTION
This reverts commit dd476f19ef61c2ac71fe07e7aa656619db29d1b6.

As discussed in https://github.com/audeering/audb/pull/375#issuecomment-2092815946, using `files` instead of `file` in the dependency methods (as introduced in #370) does not provide a real world speed improvement, and complicates the public API.
Hence, we revert the changes here.