### PR TITLE
TST: fix failing runners on MacOS

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,8 @@ pytest
 pytest-cov
 pytest-console-scripts
 pytest-doctestplus
+# We experienced an error on MacOS runners,
+# see https://github.com/audeering/audresample/issues/57
+# In https://github.com/apple/ml-stable-diffusion/issues/8
+# it is proposed to use version 4.66.1 of tqdm to fix this.
+tqdm==4.66.1


### PR DESCRIPTION
Related to https://github.com/audeering/audresample/issues/57

This tries to fix the random crashes on MacOS runner, by applying the solution proposed in https://github.com/apple/ml-stable-diffusion/issues/8.