### PR TITLE
CI: avoid using multi-threading in Mac runners

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import platform
 
 import pytest
 
@@ -8,7 +9,14 @@ import audeer
 import audb
 
 
-pytest.NUM_WORKERS = 5
+if platform.system() == "Darwin":
+    # Avoid multi-threading on MacOS runner,
+    # as it might fail from time to time
+    # (memory issue?), see
+    # https://github.com/audeering/audresample/issues/57
+    pytest.NUM_WORKERS = 1
+else:
+    pytest.NUM_WORKERS = 5
 
 
 @pytest.fixture(scope="package", autouse=True)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,8 +3,3 @@ pytest
 pytest-cov
 pytest-console-scripts
 pytest-doctestplus
-# We experienced an error on MacOS runners,
-# see https://github.com/audeering/audresample/issues/57
-# In https://github.com/apple/ml-stable-diffusion/issues/8
-# it is proposed to use version 4.66.1 of tqdm to fix this.
-tqdm==4.66.1


### PR DESCRIPTION
The fix proposed in https://github.com/audeering/audb/pull/394 did not work. We revert it here.

We now try to solve the issue by avoiding using multi-threading on MacOS.