### PR TITLE
Store dependency table as parquet on backend

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -783,6 +783,7 @@ def download_dependencies(
     with tempfile.TemporaryDirectory() as tmp_root:
         # Load `db.parquet` file,
         # or if non-existent `db.zip`
+        # from backend
         remote_deps_file = backend.join("/", name, define.DEPENDENCIES_FILE)
         if backend.exists(remote_deps_file, version):
             local_deps_file = os.path.join(tmp_root, define.DEPENDENCIES_FILE)
@@ -804,8 +805,7 @@ def download_dependencies(
                 version,
                 verbose=verbose,
             )
-        # Load parquet or csv from tmp dir
-        # and store as pickle in cache
+        # Create deps object from downloaded file
         deps = Dependencies()
         deps.load(local_deps_file)
     return deps

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -764,10 +764,10 @@ def download_dependencies(
 ) -> Dependencies:
     r"""Load dependency file from backend.
 
-    This downloads the dependency file
-    for the requested database name and version
+    Download dependency file
+    for requested database
     to a temporary folder,
-    and returns an dependency object
+    and return an dependency object
     loaded from that file.
 
     Args:
@@ -820,7 +820,8 @@ def upload_dependencies(
 ):
     r"""Upload dependency file to backend.
 
-    Store a dependency file in the database root folder,
+    Store a dependency file
+    in the local database root folder,
     and upload it to the backend.
 
     Args:

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -751,15 +751,15 @@ def publish(
     # publish dependencies and header
     upload_dependencies(backend, deps, db_root, db.name, version)
     try:
-        local_header_file = os.path.join(db_root, define.HEADER_FILE)
-        remote_header_file = backend.join("/", db.name, define.HEADER_FILE)
-        backend.put_file(local_header_file, remote_header_file, version)
+        local_header = os.path.join(db_root, define.HEADER_FILE)
+        remote_header = backend.join("/", db.name, define.HEADER_FILE)
+        backend.put_file(local_header, remote_header, version)
     except Exception:  # pragma: no cover
         # after the header is published
         # the new version becomes visible,
         # so if something goes wrong here
         # we better clean up
-        if backend.exists(remote_header_file, version):
-            backend.remove_file(remote_header_file, version)
+        if backend.exists(remote_header, version):
+            backend.remove_file(remote_header, version)
 
     return deps

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -14,6 +14,7 @@ from audb.core import define
 from audb.core import utils
 from audb.core.api import dependencies
 from audb.core.dependencies import Dependencies
+from audb.core.dependencies import upload_dependencies
 from audb.core.repository import Repository
 
 
@@ -748,10 +749,7 @@ def publish(
     )
 
     # publish dependencies and header
-    local_deps_file = os.path.join(db_root, define.DEPENDENCIES_FILE)
-    remote_deps_file = backend.join("/", db.name, define.DEPENDENCIES_FILE)
-    deps.save(local_deps_file)
-    backend.put_file(local_deps_file, remote_deps_file, version)
+    upload_dependencies(backend, deps, db_root, db.name, version)
     try:
         local_header_file = os.path.join(db_root, define.HEADER_FILE)
         remote_header_file = backend.join("/", db.name, define.HEADER_FILE)

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -748,25 +748,20 @@ def publish(
     )
 
     # publish dependencies and header
-    deps_path = os.path.join(db_root, define.DEPENDENCIES_FILE)
-    deps.save(deps_path)
-    archive_file = backend.join("/", db.name, define.DB + ".zip")
-    backend.put_archive(
-        db_root,
-        archive_file,
-        version,
-        files=define.DEPENDENCIES_FILE,
-    )
+    local_deps_file = os.path.join(db_root, define.DEPENDENCIES_FILE)
+    remote_deps_file = backend.join("/", db.name, define.DEPENDENCIES_FILE)
+    deps.save(local_deps_file)
+    backend.put_file(local_deps_file, remote_deps_file, version)
     try:
-        local_header = os.path.join(db_root, define.HEADER_FILE)
-        remote_header = backend.join("/", db.name, define.HEADER_FILE)
-        backend.put_file(local_header, remote_header, version)
+        local_header_file = os.path.join(db_root, define.HEADER_FILE)
+        remote_header_file = backend.join("/", db.name, define.HEADER_FILE)
+        backend.put_file(local_header_file, remote_header_file, version)
     except Exception:  # pragma: no cover
         # after the header is published
         # the new version becomes visible,
         # so if something goes wrong here
         # we better clean up
-        if backend.exists(remote_header, version):
-            backend.remove_file(remote_header, version)
+        if backend.exists(remote_header_file, version):
+            backend.remove_file(remote_header_file, version)
 
     return deps


### PR DESCRIPTION
Closes #397 

In #372 we switched the format of the dependency table from CSV to PARQUET, which uses already the fast SNAPPY compression algorithm to reduce it's size slightly. We still did compress the file further before uploading it as ZIP to the server. The advantage was that the file was smaller, and that we can download the same ZIP file from the server, independent if the dependency table is stored as PARQUET or CSV.

In #397 we show that file reading and writing is much faster when not zipping the PARQUET file for storage on the backend.
Hence, this pull request removes zipping and puts the PARQUET file directly on the server.
To have a single source of truth implementation it introduces the `download_dependencies()` and `upload_dependencies()` functions (not part of the public API), that are then internally used inside `audb.dependencies()`, `audb.publish()`, and `audb.remove_media()`.