### PR TITLE
Fix index dtype of empty dependency table

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -64,6 +64,7 @@ class Dependencies:
         ):
             data[name] = pd.Series(dtype=dtype)
         self._df = pd.DataFrame(data)
+        self._df.index = self._df.index.astype(define.DEPEND_INDEX_DTYPE)
         # pyarrow schema
         # used for reading and writing files
         self._schema = pa.schema(

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -63,7 +63,18 @@ def deps():
     return deps
 
 
-def test_init():
+def test_instantiation():
+    r"""Test instantiation of audb.Dependencies.
+
+    During instantiation of ``audb.Dependencies``
+    an empty dataframe is created under ``self._df``,
+    that stores the dependency table.
+    This test ensures,
+    that the dataframe
+    contains the correct column names and data types,
+    and the correct name and data type of its index.
+
+    """
     deps = audb.Dependencies()
     expected_columns = [
         "archive",

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -63,7 +63,8 @@ def deps():
     return deps
 
 
-def test_init(deps):
+def test_init():
+    deps = audb.Dependencies()
     expected_columns = [
         "archive",
         "bit_depth",
@@ -76,6 +77,14 @@ def test_init(deps):
         "type",
         "version",
     ]
+    expected_df = pd.DataFrame(columns=expected_columns)
+    expected_df.index = expected_df.index.astype(audb.core.define.DEPEND_INDEX_DTYPE)
+    for name, dtype in zip(
+        audb.core.define.DEPEND_FIELD_NAMES.values(),
+        audb.core.define.DEPEND_FIELD_DTYPES.values(),
+    ):
+        expected_df[name] = expected_df[name].astype(dtype)
+    pd.testing.assert_frame_equal(deps._df, expected_df)
     assert list(deps._df.columns) == expected_columns
     df = deps()
     assert list(df.columns) == expected_columns


### PR DESCRIPTION
When publishing an empty database, the changes introduced in #372 lead to an error as the conversion to a `pyarrow.Table` requires the correct dtype of the index of the dependency table (`audb.Dependencies._df.index`). The index dtype needs to be `object`, see

https://github.com/audeering/audb/blob/ce571495eb3d2ae38d3f50968cfe2635fa729766/audb/core/define.py#L64

This is fixed here, by setting the index dtype explicitly, when instantiating the dependency object.
It also adjusts an existing test, to really the the initialization of the dependency table and not an already filled table, which is tested in `test_call()` already.