### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,14 +13,15 @@ Version 1.7.0 (2024-05-10)
 * Added: experimental support for text files
   as media files
 * Added: dependency on ``pyarrow``
-* Changed: depend on ``audbackend>=2.0.0``
-* Changed: dependency table dataframe
-  returned by ``audb.Dependencies.__call__()``
-  now uses ``pyarrow`` based data types
-* Changed: dependency table
-  is now stored as PARQUET file
-  on the backend,
-  instead as a CSV file
+* Added: ``audb.Repository.backend_registry``
+  that maps repository names like ``artifactory``
+  to corresponding backend classes,
+  e.g. ``audbackend.backend.Artifactory``
+* Added: ``audb.Repository.register()``
+  to add an entry to ``audb.Repository.backend_registry``
+* Added: ``audb.Repository.create_backend_interface()``
+  returns a backend interface
+  to access files in the repository
 * Changed: improve speed
   of loading dependency table to the cache.
   E.g. for the database musan with version 1.0.0
@@ -30,8 +31,17 @@ Version 1.7.0 (2024-05-10)
   E.g. for the database musan with version 1.0.0
   time is reduced by 40%
   when using 8 threads
+* Changed: depend on ``audbackend>=2.0.0``
+* Changed: dependency table dataframe
+  returned by ``audb.Dependencies.__call__()``
+  now uses ``pyarrow`` based data types
+* Changed: dependency table
+  is now stored as PARQUET file
+  on the backend,
+  instead as a CSV file
 * Fixed: ``audb.versions()``
   for non-existing repositories
+* Fixed: documentation of ``audb.Repository.__eq__()``
 
 
 Version 1.6.5 (2024-03-28)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,33 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.7.0 (2024-05-10)
+--------------------------
+
+* Added: experimental support for text files
+  as media files
+* Added: dependency on ``pyarrow``
+* Changed: depend on ``audbackend>=2.0.0``
+* Changed: dependency table dataframe
+  returned by ``audb.Dependencies.__call__()``
+  now uses ``pyarrow`` based data types
+* Changed: dependency table
+  is now stored as PARQUET file
+  on the backend,
+  instead as a CSV file
+* Changed: improve speed
+  of loading dependency table to the cache.
+  E.g. for the database musan with version 1.0.0
+  time is reduced by 35%
+* Changed: improve speed
+  of downloading a database to the cache.
+  E.g. for the database musan with version 1.0.0
+  time is reduced by 40%
+  when using 8 threads
+* Fixed: ``audb.versions()``
+  for non-existing repositories
+
+
 Version 1.6.5 (2024-03-28)
 --------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,19 +24,19 @@ Version 1.7.0 (2024-05-10)
   to access files in the repository
 * Changed: improve speed
   of loading dependency table to the cache.
-  E.g. for the database musan with version 1.0.0
-  time is reduced by 35%
+  E.g. for version 1.0.0 of the database musan
+  loading time is reduced by 35%
 * Changed: improve speed
   of downloading a database to the cache.
-  E.g. for the database musan with version 1.0.0
-  time is reduced by 40%
+  E.g. for version 1.0.0 of the database musan
+  loading time is reduced by 40%
   when using 8 threads
 * Changed: depend on ``audbackend>=2.0.0``
 * Changed: dependency table dataframe
   returned by ``audb.Dependencies.__call__()``
   now uses ``pyarrow`` based data types
 * Changed: dependency table
-  is now stored as PARQUET file
+  is now stored as a PARQUET file
   on the backend,
   instead as a CSV file
 * Fixed: ``audb.versions()``


### PR DESCRIPTION
![image](https://github.com/audeering/audb/assets/173624/27925fd1-38f4-43b0-ae2f-d136b9e8c29c)


The benchmarks for reporting improvements in speed are done by the following code (for comparing `audb` 1.6.5 against the current branch):

<details><summary>Load musan database</summary>

```python
import time

import audb
import audeer


cache = audeer.path("./cache")
audeer.rmdir(cache)
audeer.mkdir(cache)

t0 = time.time()
db = audb.load("musan", version="1.0.0", num_workers=8, cache_root=cache, verbose=False) 
t = time.time() - t0
print(f"Loading musan to cache: {t:.2} s")

t0 = time.time()
db = audb.load("musan", version="1.0.0", num_workers=8, cache_root=cache, verbose=False) 
t = time.time() - t0
print(f"Loading musan from cache: {t:.2} s")
```

</details>

<details><summary>Load musan dependency table</summary>

```python
import time

import audb
import audeer


cache = audeer.path("./cache")
audeer.rmdir(cache)
audeer.mkdir(cache)

t0 = time.time()
deps = audb.dependencies("musan", version="1.0.0", cache_root=cache, verbose=False)
t = time.time() - t0
print(f"Loading deps for musan to cache: {t:.2} s")

t0 = time.time()
deps = audb.dependencies("musan", version="1.0.0", cache_root=cache, verbose=False)
t = time.time() - t0
print(f"Loading deps for musan from cache: {t:.2} s")
```

</details>

Loading a dependency table, that was published as a PARQUET file instead of a CSV file, will still be slightly faster, but at the moment we don't have such a database to run any benchmarks.