### PR TITLE
DOC: ensure to set shared cache root for publish

### DIFF
--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -32,6 +32,7 @@
         audeer.mkdir(folder)
 
     audb.config.CACHE_ROOT = "./cache"
+    audb.config.SHARED_CACHE_ROOT = "./cache"
 
 
 .. _publish:


### PR DESCRIPTION
Closes #402 

This ensures that we do not use the user specified shared cache root, when building the docs from `docs/usage.rst`.