### PR TITLE
DOC: correct text on database structure on backend

### DIFF
--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -138,12 +138,18 @@ We can compare this with the files stored in the repository.
 
     list_files(repository.host)
 
-As you can see all media files are stored inside the :file:`media/` folder,
-all tables inside the :file:`meta/` folder,
-the database header inside the :file:`db/` folder
-as :file:`db-1.0.0.yaml`,
-and the database dependency file inside the :file:`db/` folder
-inside :file:`db-1.0.0.zip`.
+As you can see all media files are stored
+inside the ``media/`` folder,
+all tables inside the ``meta/`` folder,
+the database header in the file ``db.yaml``,
+and the database dependencies
+in the file ``db.parquet``.
+Note,
+that the structure of the folders
+used for versioning
+depends on the backend,
+and differs slightly
+for an Artifactory backend.
 
 To load the database,
 or see which databases are available in your repository,


### PR DESCRIPTION
Corrects the wording of the part of the documentation, that discusses how the database files are stored on the backend.

New resulting documentation output:

![image](https://github.com/audeering/audb/assets/173624/fc6d04d7-8e81-4a8c-b7cf-850ad632a401)
