### PR TITLE
Fix comment using old dependency file format

### DIFF
--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -393,7 +393,7 @@ def test_publish(tmpdir, dbs, persistent_repository, version):
             audb.latest_version(DB_NAME)
 
     # Copy database folder to build folder
-    # to avoid storing `db.csv` files
+    # to avoid storing dependency table files
     # inside the database folders
     build_dir = audeer.path(tmpdir, "build")
     shutil.copytree(dbs[version], build_dir)


### PR DESCRIPTION
In one comment in the code we were still referring to the old dependency table file (`db.csv`), but since https://github.com/audeering/audb/pull/398 the new file is `db.parquet`. I re-phrashed the comment to be independent of the actual file name.