### PR TITLE
Ensure dependency loading from cache does not fail

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -271,7 +271,7 @@ def dependencies(
         try:
             deps = Dependencies()
             deps.load(cached_deps_file)
-        except (AttributeError, FileNotFoundError, ValueError, EOFError):
+        except Exception:
             # If loading cached file fails, load again from backend
             backend_interface = utils.lookup_backend(name, version)
             deps = download_dependencies(backend_interface, name, version, verbose)

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -271,7 +271,7 @@ def dependencies(
         try:
             deps = Dependencies()
             deps.load(cached_deps_file)
-        except Exception:
+        except (AttributeError, FileNotFoundError, EOFError, KeyError, ValueError):
             # If loading cached file fails, load again from backend
             backend_interface = utils.lookup_backend(name, version)
             deps = download_dependencies(backend_interface, name, version, verbose)

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -271,7 +271,7 @@ def dependencies(
         try:
             deps = Dependencies()
             deps.load(cached_deps_file)
-        except (AttributeError, FileNotFoundError, EOFError, KeyError, ValueError):
+        except (AttributeError, EOFError, FileNotFoundError, KeyError, ValueError):
             # If loading cached file fails, load again from backend
             backend_interface = utils.lookup_backend(name, version)
             deps = download_dependencies(backend_interface, name, version, verbose)


### PR DESCRIPTION
As can be seen in https://github.com/audeering/audinterface/actions/runs/9094046905/job/25009555875?pr=172 and is decribed at https://github.com/audeering/audinterface/pull/172#issuecomment-2114581095, loading of an existing dependency table from cache, stored by an older version of `audb` than 1.7, might fail with `KeyError` under Python 3.8.

I added `KeyError` to the list of the errors we catch when trying to load the cache file,
and show in https://github.com/audeering/audinterface/pull/174 that this fixes the problem we see for the test in `audinterface`.

I have opted against catching all possible errors, as we do not want to catch an Interruption initiated by the user, e.g. keyboard interruption.