### PR TITLE
Column locator sequence input

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -519,11 +519,13 @@ class Dependencies:
         r"""Column content for selected files.
 
         Args:
-        column: one of the names in self._schema
-        files: rows to query, index is a filename
-        dtype: convert data to dtype
+            column: one of the names in ``Dependencies._schema``
+            files: rows to query, index is a filename
+            dtype: convert data to dtype
 
-        Returns: scalar value or list
+        Returns:
+            scalar value or list
+
         """
         # note: pandas series is not a sequence
         is_sequence = isinstance(files, collections.abc.Sequence)

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -1,4 +1,3 @@
-import collections
 import errno
 import os
 import re
@@ -513,32 +512,23 @@ class Dependencies:
     def _column_loc(
         self,
         column: str,
-        files: typing.Union[str, typing.Sequence[str]],
+        file: str,
         dtype: typing.Callable = None,
-    ) -> typing.Union[typing.Any, typing.List[typing.Any]]:
-        r"""Column content for selected files.
+    ) -> typing.Any:
+        r"""Column content for selected file.
 
         Args:
             column: one of the names in ``Dependencies._schema``
-            files: rows to query, index is a filename
+            file: row to query, index is a filename
             dtype: convert data to dtype
 
         Returns:
-            scalar value or list
+            scalar value
 
         """
-        # note: pandas series is not a sequence
-        is_sequence = isinstance(files, collections.abc.Sequence)
-        files = [files] if is_sequence and isinstance(files, str) else files
-
+        value = self._df.at[file, column]
         if dtype is not None:
-            value = self._df.loc[files][column].astype(dtype).tolist()
-        else:
-            value = self._df.loc[files][column].tolist()
-
-        if len(value) == 1:
-            return value[0]
-
+            value = dtype(value)
         return value
 
     def _dataframe_to_table(

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -351,7 +351,7 @@ def test_sampling_rate(deps):
     [
         ("file.wav", "format", None, str, "wav"),
         (["file.wav"], "format", None, str, "wav"),
-        (["file.wav", "db.files.csv"], "format", None, str,  ['wav', 'csv']),
+        (["file.wav", "db.files.csv"], "format", None, str, ['wav', 'csv']),
         (["file.wav", "db.files.csv"], "sampling_rate", float, float, [16000.0, 0.0]),
     ],
 )

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -358,7 +358,8 @@ def test_sampling_rate(deps):
 def test_column_locator(files, column, dt, expected_type, expected_result, deps):
     r"""Test columns locators.
 
-    Verify that non-scalar input to fhe files argument works
+    Verify that non-scalar input to fhe files argument works.
+
     """
     actual = deps._column_loc(column, files, dt)
     # test return types

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -346,35 +346,6 @@ def test_sampling_rate(deps):
         deps.sampling_rate("non.existing")
 
 
-@pytest.mark.parametrize(
-    "files, column, dt, expected_type, expected_result",
-    [
-        ("file.wav", "format", None, str, "wav"),
-        (["file.wav"], "format", None, str, "wav"),
-        (["file.wav", "db.files.csv"], "format", None, str, ['wav', 'csv']),
-        (["file.wav", "db.files.csv"], "sampling_rate", float, float, [16000.0, 0.0]),
-    ],
-)
-def test_column_locator(files, column, dt, expected_type, expected_result, deps):
-    r"""Test columns locators.
-
-    Verify that non-scalar input to fhe files argument works.
-
-    """
-    actual = deps._column_loc(column, files, dt)
-    # test return types
-    assert all([x for x in map(lambda x: type(x) == expected_type, actual)])
-    # test return values
-    assert actual == expected_result
-
-
-def test_column_locator_throws_invalid_type(deps):
-    """Test column locator: invalid dtype raises."""
-    files = get_entries("file")
-    with pytest.raises(ValueError, match="could not convert"):
-        deps._column_loc("format", files, float)
-
-
 def test_type(deps):
     files = get_entries("file")
     types = get_entries("type")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -346,6 +346,27 @@ def test_sampling_rate(deps):
         deps.sampling_rate("non.existing")
 
 
+@pytest.mark.parametrize(
+    "files, column, dt, expected_type, expected_result",
+    [
+        ("file.wav", "format", None, str, "wav"),
+        (["file.wav"], "format", None, str, "wav"),
+        (["file.wav", "db.files.csv"], "format", None, str,  ['wav', 'csv']),
+        (["file.wav", "db.files.csv"], "sampling_rate", float, float, [16000.0, 0.0]),
+    ],
+)
+def test_column_locator(files, column, dt, expected_type, expected_result, deps):
+    r"""Test columns locators.
+
+    Verify that non-scalar input to fhe files argument works
+    """
+    actual = deps._column_loc(column, files, dt)
+    # test return types
+    assert all([x for x in map(lambda x: type(x) == expected_type, actual)])
+    # test return values
+    assert actual == expected_result
+
+
 def test_type(deps):
     files = get_entries("file")
     types = get_entries("type")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -367,6 +367,13 @@ def test_column_locator(files, column, dt, expected_type, expected_result, deps)
     assert actual == expected_result
 
 
+def test_column_locator_throws_invalid_type(deps):
+    """Test column locator: invalid dtype raises."""
+    files = get_entries("file")
+    with pytest.raises(ValueError, match="could not convert"):
+        deps._column_loc("format", files, float)
+
+
 def test_type(deps):
     files = get_entries("file")
     types = get_entries("type")


### PR DESCRIPTION
# Goal

close #407: Typing provided squence type input to `Dependencies._column_loc` but it wasn't implemented.

## Solution 

There was a mismatch between the type hints suggesting that it is possible to use sequence input and output. 
We have chosen to update the type hints as the suggested vectorized implenentation did not provide large benefits.

Therefore this corrects the type hints allowing only scalar in- and putput.









