### PR TITLE
Ensure correct dtypes in dependency table

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -108,7 +108,7 @@ class Dependencies:
             ``True`` if both dependency tables have the same entries
 
         """
-        return self._df.equals(other._df.astype(self._df.dtypes))
+        return self._df.equals(other._df)
 
     def __getitem__(self, file: str) -> typing.List:
         r"""File information.

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -586,9 +586,10 @@ class Dependencies:
             with correct dtypes
 
         """
-        # Check if we have an old cache,
-        # by checking the dtype of index,
-        # which changed to `object` in version 1.7.0
+        # Check the dtype of index,
+        # to decide if we need to update dtypes,
+        # as dtype of index changed to `object`
+        # in version 1.7.0 of audb.
         if df.index.dtype != define.DEPEND_INDEX_DTYPE:
             df.index = df.index.astype(define.DEPEND_INDEX_DTYPE, copy=False)
             columns = define.DEPEND_FIELD_NAMES.values()

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -594,10 +594,8 @@ class Dependencies:
             df.index = df.index.astype(define.DEPEND_INDEX_DTYPE, copy=False)
             columns = define.DEPEND_FIELD_NAMES.values()
             dtypes = define.DEPEND_FIELD_DTYPES.values()
-            df = df.astype(
-                {name: dtype for name, dtype in zip(columns, dtypes)},
-                copy=False,
-            )
+            mapping = {column: dtype for column, dtype in zip(columns, dtypes)}
+            df = df.astype(mapping, copy=False)
         return df
 
     def _table_to_dataframe(self, table: pa.Table) -> pd.DataFrame:

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -262,15 +262,66 @@ def test_load_save_backward_compatibility(tmpdir, deps):
     we need to make sure this is corrected
     when loading old cache files.
 
+    Old behaviour (audb<1.7):
+
+    archive          string[python]
+    bit_depth                 int32
+    channels                  int32
+    checksum         string[python]
+    duration                float64
+    format           string[python]
+    removed                   int32
+    sampling_rate             int32
+    type                      int32
+    version          string[python]
+
+    New behaviour (audb>=1.7):
+
+    archive          string[pyarrow]
+    bit_depth         int32[pyarrow]
+    channels          int32[pyarrow]
+    checksum         string[pyarrow]
+    duration         double[pyarrow]
+    format           string[pyarrow]
+    removed           int32[pyarrow]
+    sampling_rate     int32[pyarrow]
+    type              int32[pyarrow]
+    version          string[pyarrow]
+
     """
     deps_file = audeer.path(tmpdir, "deps.pkl")
+
+    deps_old = audb.Dependencies()
+    deps_old._df = deps._df.copy()
+
     # Change dtype of index from object to string
     # to mimic previous behavior
-    deps._df.index = deps._df.index.astype("string")
-    deps.save(deps_file)
+    deps_old._df.index = deps_old._df.index.astype("string")
+    # Change dtype of columns
+    # to mimic previous behavior
+    deps_old._df = deps_old._df.astype(
+        {
+            "archive": "string",
+            "bit_depth": "int32",
+            "channels": "int32",
+            "checksum": "string",
+            "duration": "float64",
+            "format": "string",
+            "removed": "int32",
+            "sampling_rate": "int32",
+            "type": "int32",
+            "version": "string",
+        }
+    )
+    deps_old.save(deps_file)
+
+    # Check that we get the correct dtypes,
+    # when loading from cache
     deps2 = audb.Dependencies()
     deps2.load(deps_file)
     assert deps2._df.index.dtype == audb.core.define.DEPEND_INDEX_DTYPE
+    pd.testing.assert_frame_equal(deps._df, deps2._df)
+    assert deps == deps2
 
 
 def test_load_save_errors(deps):


### PR DESCRIPTION
Closes #414 

Before, it could happen that the dtypes of a dependency table loaded from cache file, depend on the `audb` version used to store the cache file. This resulted in issues, as `Dependencies.__eq__()` require that the dtypes match as well.

In #414, I proposed to relax `Dependencies.__eq__()` to not compare the dtypes. But I think it is better to ensure, that the loaded dependency table has always the same dtypes. I updated the code here, to set the correct dtypes, when loading a dependency table from cache.

To achieve this, I introduced a new static method `audb.Dependencies._set_dtypes()`, which is reused at 4 different positions.