### PR TITLE
TST: relax test for audb.Dependencies.__str__()

### DIFF
--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -322,10 +322,11 @@ def test_str(deps):
         "               archive  bit_depth  channels  ... sampling_rate  type version\n"  # noqa: E501
         "db.files.csv  archive1          0         0  ...             0     0   1.0.0\n"  # noqa: E501
         "file.wav      archive2         16         2  ...         16000     1   1.0.0\n"  # noqa: E501
-        "\n"
-        "[2 rows x 10 columns]"
     )
-    assert str(deps) == expected_str
+    # Check only the beginning of the returned string,
+    # as the end might vary,
+    # see https://github.com/audeering/audb/issues/422
+    assert str(deps).startswith(expected_str)
 
 
 # === Test hidden methods ===

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 import pytest
 
@@ -318,16 +320,17 @@ def test_len(deps):
 
 
 def test_str(deps):
-    expected_str = (
-        "               archive  bit_depth  channels  ... sampling_rate  type version\n"  # noqa: E501
-        "db.files.csv  archive1          0         0  ...             0     0   1.0.0\n"  # noqa: E501
-        "file.wav      archive2         16         2  ...         16000     1   1.0.0\n"  # noqa: E501
-    )
-    # Check only the beginning of the returned string,
-    # as the end might vary,
+    r"""Test string representation of dependency table."""
+    # Check only parts of the returned string,
+    # as the representation might vary,
     # see https://github.com/audeering/audb/issues/422
-    assert str(deps).startswith(expected_str)
-    assert deps._df.to_string().startswith(expected_str)
+    expected_str = re.compile(
+        "               archive  bit_depth  channels .+? type version\n"
+        "db.files.csv  archive1          0         0 .+? 0   1.0.0\n"
+        "file.wav      archive2         16         2 .+? 1   1.0.0.*?"
+    )
+    assert expected_str.match(str(deps))
+    assert expected_str.match(deps._df.to_string())
 
 
 # === Test hidden methods ===

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -327,6 +327,7 @@ def test_str(deps):
     # as the end might vary,
     # see https://github.com/audeering/audb/issues/422
     assert str(deps).startswith(expected_str)
+    assert deps._df.to_string().startswith(expected_str)
 
 
 # === Test hidden methods ===


### PR DESCRIPTION
Closes #422 

This relaxes the test for the string representation of the dependency table (`audb.Dependencies.__str__()`), to test only that the actual content is correct, and omitting possible additional information at the end of the string (i.e. `https://github.com/audeering/audb/issues/422`), which might depend on your `pandas` configuration.