### PR TITLE
CI: enhance name of test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install requested pandas version
       run: |
         pip install "${{ matrix.pandas }}"
-      if: ${{ matrix.pandas }}
+      if: matrix.pandas == 'pandas==2.1.4'
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install requested pandas version
       run: |
         pip install "${{ matrix.pandas }}"
-      if: matrix.pandas
+      if: ${{ matrix.pandas }}
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,27 +13,27 @@ jobs:
     strategy:
       matrix:
         include:
-          # Ubuntu
+          # Different platforms
+          - os: ubuntu-latest
+            python-version: '3.10'
+          - os: macOS-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.10'
+          # Other Python versions
           - os: ubuntu-latest
             python-version: '3.8'
           - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.11'
+          # Other pandas versions
           - os: ubuntu-latest
             python-version: '3.10'
             pandas: 'pandas==2.0.3'
           - os: ubuntu-latest
             python-version: '3.10'
             pandas: 'pandas==2.1.4'
-          - os: ubuntu-latest
-            python-version: '3.11'
-          # MacOS
-          - os: macOS-latest
-            python-version: '3.10'
-          # Windows
-          - os: windows-latest
-            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,14 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.9'
             pandas: 'pandas==2.0.3'
-          - os: ubuntu-latest
-            python-version: '3.10'
-            pandas: 'pandas==2.1.4'
+        # - os: ubuntu-latest
+        #    python-version: '3.10'
+        #    pandas: 'pandas==2.0.3'
+        #  - os: ubuntu-latest
+        #    python-version: '3.10'
+        #    pandas: 'pandas==2.1.4'
 
     steps:
     - uses: actions/checkout@v4
@@ -54,7 +57,7 @@ jobs:
     - name: Install requested pandas version
       run: |
         pip install "${{ matrix.pandas }}"
-      if: matrix.pandas == 'pandas==2.1.4'
+      if: matrix.pandas == 'pandas==2.0.3'
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,9 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.9'
             pandas: 'pandas==2.0.3'
-        # - os: ubuntu-latest
-        #    python-version: '3.10'
-        #    pandas: 'pandas==2.0.3'
-        #  - os: ubuntu-latest
-        #    python-version: '3.10'
-        #    pandas: 'pandas==2.1.4'
+          - os: ubuntu-latest
+            python-version: '3.9'
+            pandas: 'pandas==2.1.4'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,9 @@ jobs:
         pip install -r requirements.txt
 
     - name: Install requested pandas version
-      run: pip install "${{ matrix.pandas }}"
-      if: ${{ matrix.pandas }}
+      run: |
+        pip install "${{ matrix.pandas }}"
+      if: matrix.pandas
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,24 +14,17 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macOS-latest, windows-latest ]
         python-version: [ '3.10' ]
-        pandas: ['pandas']
         include:
           - os: ubuntu-latest
             python-version: '3.8'
-            pandas: 'pandas'
-            tasks: tests
           - os: ubuntu-latest
             python-version: '3.9'
-            pandas: 'pandas'
-            tasks: tests
           - os: ubuntu-latest
             python-version: '3.10'
             pandas: 'pandas==2.0.3'
-            tasks: tests
           - os: ubuntu-latest
             python-version: '3.10'
             pandas: 'pandas==2.1.4'
-            tasks: tests
 
     steps:
     - uses: actions/checkout@v4
@@ -57,7 +50,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install "${{ matrix.pandas }}"
+
+    - name: Install requested pandas version
+      run: pip install "${{ matrix.pandas }}"
+      if: ${{ matrix.pandas }}
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,28 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        python-version: [ '3.10' ]
         include:
+          # Ubuntu
           - os: ubuntu-latest
             python-version: '3.8'
           - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.10'
+          - os: ubuntu-latest
+            python-version: '3.10'
             pandas: 'pandas==2.0.3'
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.10'
             pandas: 'pandas==2.1.4'
+          - os: ubuntu-latest
+            python-version: '3.11'
+          # MacOS
+          - os: macOS-latest
+            python-version: '3.10'
+          # Windows
+          - os: windows-latest
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Install requested pandas version
       run: |
         pip install "${{ matrix.pandas }}"
-      if: matrix.pandas == 'pandas==2.0.3'
+      if: matrix.pandas
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo


### PR DESCRIPTION
Improves on the names of the CI jobs by changing them from 

![image](https://github.com/audeering/audb/assets/173624/12c70a69-aea0-44bb-82dd-8812b5e8dd51)

to

![image](https://github.com/audeering/audb/assets/173624/210686fc-7a32-4764-86b3-252b605cdefb)

Which means we display `pandas==<version>` only if a different `pandas` version is selected, and remove `tests` from the display string.