### PR TITLE
CI: use numpy<2.0.0 for older pandas versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
 
     - name: Install requested pandas version
       run: |
+        pip install "numpy<2.0.0"  # as older pandas versions might fail otherwise
         pip install "${{ matrix.pandas }}"
       if: matrix.pandas
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Install numpy<2.0.0 for pandas==2.0.3
+      run: |
+        pip install "numpy<2.0.0"
+      if: matrix.pandas == 'pandas==2.0.3'
+
     - name: Install requested pandas version
       run: |
-        pip install "numpy<2.0.0"  # as older pandas versions might fail otherwise
         pip install "${{ matrix.pandas }}"
       if: matrix.pandas
 


### PR DESCRIPTION
We just finished https://github.com/audeering/audb/pull/430 and added tests for older `pandas` versions, but a few hours ago `numpy` released version 2.0.0, which [does not work with `pandas==2.0.3`](https://github.com/audeering/audb/actions/runs/9547190299/job/26311666268). As `numpy` is not automatically downgraded when installing `pandas==2.0.3`, I downgrade it manually now.