### PR TITLE
Ensure correct dtype of dependency table

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -596,16 +596,11 @@ class Dependencies:
             with correct dtypes
 
         """
-        # Check the dtype of index,
-        # to decide if we need to update dtypes,
-        # as dtype of index changed to `object`
-        # in version 1.7.0 of audb.
-        if df.index.dtype != define.DEPEND_INDEX_DTYPE:
-            df.index = df.index.astype(define.DEPEND_INDEX_DTYPE, copy=False)
-            columns = define.DEPEND_FIELD_NAMES.values()
-            dtypes = define.DEPEND_FIELD_DTYPES.values()
-            mapping = {column: dtype for column, dtype in zip(columns, dtypes)}
-            df = df.astype(mapping, copy=False)
+        df.index = df.index.astype(define.DEPEND_INDEX_DTYPE, copy=False)
+        columns = define.DEPEND_FIELD_NAMES.values()
+        dtypes = define.DEPEND_FIELD_DTYPES.values()
+        mapping = {column: dtype for column, dtype in zip(columns, dtypes)}
+        df = df.astype(mapping, copy=False)
         return df
 
     def _table_to_dataframe(self, table: pa.Table) -> pd.DataFrame:


### PR DESCRIPTION
Closes #436 

When loading the dependency table from cache we did only adjust its data types if we detected that the index was not stored as data type `object` as we switched from `string` to `object` when introducing the new `pyarrow` data types for the dependency table in version 1.7.0 of `audb`.

But we forgot, that we had used `object` as data type of the index before, and switched to `string` only in version 1.6.4 of `audb`:

![image](https://github.com/audeering/audb/assets/173624/b0c17119-4713-45f0-b1e8-2fb82895f729)

Which means, if a user has a dependency table in cache stored with `audb <1.6.4` when trying to publish a new version of a database, they will run into the issue reported in #436.

To fix it, I updated the code to always apply the data type conversion now. I also checked if it had any implications on execution time (as this was the main motivation for the `if` clause before), but I was not able to find any change in execution time.