### PR TITLE
Update progress bar at least every second

### DIFF
--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -94,3 +94,6 @@ class Format:
 FORMATS = [Format.WAV, Format.FLAC]
 BIT_DEPTHS = [16, 24, 32]
 SAMPLING_RATES = [8000, 16000, 22500, 44100, 48000]
+
+# Progress bar
+MAXIMUM_REFRESH_TIME = 1  # force progress bar to update every second

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -261,6 +261,7 @@ def _get_attachments_from_cache(
             num_workers=num_workers,
             progress_bar=verbose,
             task_description="Copy attachments",
+            maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
         )
 
         audeer.rmdir(db_root_tmp)
@@ -341,6 +342,7 @@ def _get_files_from_cache(
                 num_workers=num_workers,
                 progress_bar=verbose,
                 task_description=f"Copy {files_type}",
+                maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
             )
 
             audeer.rmdir(db_root_tmp)
@@ -398,6 +400,7 @@ def _get_attachments_from_backend(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Load attachments",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
     audeer.rmdir(db_root_tmp)
@@ -490,6 +493,7 @@ def _get_media_from_backend(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Load media",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
     audeer.rmdir(db_root_tmp)
@@ -543,6 +547,7 @@ def _get_tables_from_backend(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Load tables",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
     audeer.rmdir(db_root_tmp)
@@ -849,6 +854,7 @@ def _update_path(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Update file path",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -60,6 +60,7 @@ def _find_media(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Find media",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
     return media
@@ -97,6 +98,7 @@ def _find_tables(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Find tables",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
     return tables
@@ -146,6 +148,7 @@ def _get_attachments(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Load attachments",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
 
@@ -194,6 +197,7 @@ def _get_media(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Get media",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
 
@@ -242,6 +246,7 @@ def _get_tables(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Get tables",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -34,6 +34,7 @@ def _check_for_duplicates(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Check tables for duplicates",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
 
@@ -227,6 +228,7 @@ def _find_media(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Find media",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
     # Add updated and new media to dependencies
     # and sort them by paths
@@ -396,6 +398,7 @@ def _put_attachments(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Put attachments",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
 
@@ -472,6 +475,7 @@ def _put_media(
             num_workers=num_workers,
             progress_bar=verbose,
             task_description="Put media",
+            maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
         )
         deps._update_media_version(update_media, version)
 
@@ -501,6 +505,7 @@ def _put_tables(
         num_workers=num_workers,
         progress_bar=verbose,
         task_description="Put tables",
+        maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 requires-python = '>=3.8'
 dependencies = [
     'audbackend[artifactory] >=2.0.0',
-    'audeer >=2.0.0',
+    'audeer >=2.1.0',
     'audformat >=1.1.1',
     'audiofile >=1.0.0',
     'audobject >=0.5.0',


### PR DESCRIPTION
With the new release 2.1.0 of `audeer` we can no enforce an update of a progress bar. We set the value here to have an update at least every second.

This changes

![audb](https://github.com/audeering/audb/assets/173624/acfdcf1a-307d-4cdc-98ce-61a09fb01be7)

to

![audb](https://github.com/audeering/audb/assets/173624/84f97a01-6c86-4283-8c06-7266cf90c7d6)

