### PR TITLE
Add pickle_tables argument to load functions

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -527,7 +527,7 @@ def _get_tables_from_backend(
     db_root: str,
     deps: Dependencies,
     backend_interface: typing.Type[audbackend.interface.Base],
-    pickle_table: bool,
+    pickle_tables: bool,
     num_workers: typing.Optional[int],
     verbose: bool,
 ):
@@ -539,7 +539,7 @@ def _get_tables_from_backend(
         db_root: database root
         deps: database dependencies
         backend_interface: backend interface
-        pickle_table: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -586,7 +586,7 @@ def _get_tables_from_backend(
         table_files = [table_file]
 
         # Cache table as PKL file
-        if pickle_table:
+        if pickle_tables:
             pickle_file = f"db.{table}.pkl"
             table_path = os.path.join(db_root_tmp, f"db.{table}")
             db[table].load(table_path)
@@ -703,7 +703,7 @@ def _load_files(
     deps: Dependencies,
     flavor: Flavor,
     cache_root: str,
-    pickle_table: bool,
+    pickle_tables: bool,
     num_workers: int,
     verbose: bool,
 ) -> typing.Optional[CachedVersions]:
@@ -734,7 +734,7 @@ def _load_files(
         deps: database dependency object
         flavor: database flavor object
         cache_root: root path of cache
-        pickle_table: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -796,7 +796,7 @@ def _load_files(
                     db_root,
                     deps,
                     backend_interface,
-                    pickle_table,
+                    pickle_tables,
                     num_workers,
                     verbose,
                 )
@@ -999,7 +999,7 @@ def load(
     media: typing.Union[str, typing.Sequence[str]] = None,
     removed_media: bool = False,
     full_path: bool = True,
-    pickle_table: bool = True,
+    pickle_tables: bool = True,
     cache_root: str = None,
     num_workers: typing.Optional[int] = 1,
     timeout: float = -1,
@@ -1069,7 +1069,7 @@ def load(
             misc tables will be empty
         removed_media: keep rows that reference removed media
         full_path: replace relative with absolute file paths
-        pickle_table: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -1206,7 +1206,7 @@ def load(
                         deps,
                         flavor,
                         cache_root,
-                        pickle_table,
+                        pickle_tables,
                         num_workers,
                         verbose,
                     )
@@ -1632,7 +1632,7 @@ def load_table(
     table: str,
     *,
     version: str = None,
-    pickle_table: bool = True,
+    pickle_tables: bool = True,
     cache_root: str = None,
     num_workers: typing.Optional[int] = 1,
     verbose: bool = True,
@@ -1651,7 +1651,7 @@ def load_table(
         name: name of database
         table: load table from database
         version: version of database
-        pickle_table: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -1738,7 +1738,7 @@ def load_table(
                     deps,
                     Flavor(),
                     cache_root,
-                    pickle_table,
+                    pickle_tables,
                     num_workers,
                     verbose,
                 )

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -527,7 +527,7 @@ def _get_tables_from_backend(
     db_root: str,
     deps: Dependencies,
     backend_interface: typing.Type[audbackend.interface.Base],
-    pickle_cache: bool,
+    pickle_tables: bool,
     num_workers: typing.Optional[int],
     verbose: bool,
 ):
@@ -539,7 +539,7 @@ def _get_tables_from_backend(
         db_root: database root
         deps: database dependencies
         backend_interface: backend interface
-        pickle_cache: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -586,7 +586,7 @@ def _get_tables_from_backend(
         table_files = [table_file]
 
         # Cache table as PKL file
-        if pickle_cache:
+        if pickle_tables:
             pickle_file = f"db.{table}.pkl"
             table_path = os.path.join(db_root_tmp, f"db.{table}")
             db[table].load(table_path)
@@ -703,7 +703,7 @@ def _load_files(
     deps: Dependencies,
     flavor: Flavor,
     cache_root: str,
-    pickle_cache: bool,
+    pickle_tables: bool,
     num_workers: int,
     verbose: bool,
 ) -> typing.Optional[CachedVersions]:
@@ -734,7 +734,7 @@ def _load_files(
         deps: database dependency object
         flavor: database flavor object
         cache_root: root path of cache
-        pickle_cache: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -796,7 +796,7 @@ def _load_files(
                     db_root,
                     deps,
                     backend_interface,
-                    pickle_cache,
+                    pickle_tables,
                     num_workers,
                     verbose,
                 )
@@ -999,8 +999,8 @@ def load(
     media: typing.Union[str, typing.Sequence[str]] = None,
     removed_media: bool = False,
     full_path: bool = True,
+    pickle_tables: bool = True,
     cache_root: str = None,
-    pickle_cache: bool = True,
     num_workers: typing.Optional[int] = 1,
     timeout: float = -1,
     verbose: bool = True,
@@ -1069,14 +1069,14 @@ def load(
             misc tables will be empty
         removed_media: keep rows that reference removed media
         full_path: replace relative with absolute file paths
-        cache_root: cache folder where databases are stored.
-            If not set :meth:`audb.default_cache_root` is used
-        pickle_cache: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
             This allows for faster loading,
             when loading from cache
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5
@@ -1206,7 +1206,7 @@ def load(
                         deps,
                         flavor,
                         cache_root,
-                        pickle_cache,
+                        pickle_tables,
                         num_workers,
                         verbose,
                     )
@@ -1632,8 +1632,8 @@ def load_table(
     table: str,
     *,
     version: str = None,
+    pickle_tables: bool = True,
     cache_root: str = None,
-    pickle_cache: bool = True,
     num_workers: typing.Optional[int] = 1,
     verbose: bool = True,
 ) -> pd.DataFrame:
@@ -1651,14 +1651,14 @@ def load_table(
         name: name of database
         table: load table from database
         version: version of database
-        cache_root: cache folder where databases are stored.
-            If not set :meth:`audb.default_cache_root` is used
-        pickle_cache: if ``True``,
+        pickle_tables: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
             This allows for faster loading,
             when loading from cache
+        cache_root: cache folder where databases are stored.
+            If not set :meth:`audb.default_cache_root` is used
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5
@@ -1738,7 +1738,7 @@ def load_table(
                     deps,
                     Flavor(),
                     cache_root,
-                    pickle_cache,
+                    pickle_tables,
                     num_workers,
                     verbose,
                 )

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -540,6 +540,9 @@ def _get_tables_from_backend(
         deps: database dependencies
         backend_interface: backend interface
         pickle_tables: if ``True``,
+            tables are cached locally
+            in their original format
+            and as pickle files.
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -735,9 +738,9 @@ def _load_files(
         flavor: database flavor object
         cache_root: root path of cache
         pickle_tables: if ``True``,
-            tables are stored in their original format,
-            and as pickle files
-            in the cache.
+            tables are cached locally
+            in their original format
+            and as pickle files.
             This allows for faster loading,
             when loading from cache
         num_workers: number of workers to use
@@ -1070,9 +1073,9 @@ def load(
         removed_media: keep rows that reference removed media
         full_path: replace relative with absolute file paths
         pickle_tables: if ``True``,
-            tables are stored in their original format,
-            and as pickle files
-            in the cache.
+            tables are cached locally
+            in their original format
+            and as pickle files.
             This allows for faster loading,
             when loading from cache
         cache_root: cache folder where databases are stored.
@@ -1652,9 +1655,9 @@ def load_table(
         table: load table from database
         version: version of database
         pickle_tables: if ``True``,
-            tables are stored in their original format,
-            and as pickle files
-            in the cache.
+            tables are cached locally
+            in their original format
+            and as pickle files.
             This allows for faster loading,
             when loading from cache
         cache_root: cache folder where databases are stored.

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1742,7 +1742,6 @@ def load_table(
                     num_workers,
                     verbose,
                 )
-            table = audformat.Table()
-            table.load(table_file)
+            db[table].load(table_file)
 
-    return table._df
+    return db[table]._df

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -527,7 +527,7 @@ def _get_tables_from_backend(
     db_root: str,
     deps: Dependencies,
     backend_interface: typing.Type[audbackend.interface.Base],
-    pickle_tables: bool,
+    pickle_table: bool,
     num_workers: typing.Optional[int],
     verbose: bool,
 ):
@@ -539,7 +539,7 @@ def _get_tables_from_backend(
         db_root: database root
         deps: database dependencies
         backend_interface: backend interface
-        pickle_tables: if ``True``,
+        pickle_table: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -586,7 +586,7 @@ def _get_tables_from_backend(
         table_files = [table_file]
 
         # Cache table as PKL file
-        if pickle_tables:
+        if pickle_table:
             pickle_file = f"db.{table}.pkl"
             table_path = os.path.join(db_root_tmp, f"db.{table}")
             db[table].load(table_path)
@@ -703,7 +703,7 @@ def _load_files(
     deps: Dependencies,
     flavor: Flavor,
     cache_root: str,
-    pickle_tables: bool,
+    pickle_table: bool,
     num_workers: int,
     verbose: bool,
 ) -> typing.Optional[CachedVersions]:
@@ -734,7 +734,7 @@ def _load_files(
         deps: database dependency object
         flavor: database flavor object
         cache_root: root path of cache
-        pickle_tables: if ``True``,
+        pickle_table: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -796,7 +796,7 @@ def _load_files(
                     db_root,
                     deps,
                     backend_interface,
-                    pickle_tables,
+                    pickle_table,
                     num_workers,
                     verbose,
                 )
@@ -999,7 +999,7 @@ def load(
     media: typing.Union[str, typing.Sequence[str]] = None,
     removed_media: bool = False,
     full_path: bool = True,
-    pickle_tables: bool = True,
+    pickle_table: bool = True,
     cache_root: str = None,
     num_workers: typing.Optional[int] = 1,
     timeout: float = -1,
@@ -1069,7 +1069,7 @@ def load(
             misc tables will be empty
         removed_media: keep rows that reference removed media
         full_path: replace relative with absolute file paths
-        pickle_tables: if ``True``,
+        pickle_table: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -1206,7 +1206,7 @@ def load(
                         deps,
                         flavor,
                         cache_root,
-                        pickle_tables,
+                        pickle_table,
                         num_workers,
                         verbose,
                     )
@@ -1632,7 +1632,7 @@ def load_table(
     table: str,
     *,
     version: str = None,
-    pickle_tables: bool = True,
+    pickle_table: bool = True,
     cache_root: str = None,
     num_workers: typing.Optional[int] = 1,
     verbose: bool = True,
@@ -1651,7 +1651,7 @@ def load_table(
         name: name of database
         table: load table from database
         version: version of database
-        pickle_tables: if ``True``,
+        pickle_table: if ``True``,
             tables are stored in their original format,
             and as pickle files
             in the cache.
@@ -1738,7 +1738,7 @@ def load_table(
                     deps,
                     Flavor(),
                     cache_root,
-                    pickle_tables,
+                    pickle_table,
                     num_workers,
                     verbose,
                 )

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1721,14 +1721,14 @@ def load_table(
 
         # Load table
         tables = _misc_tables_used_in_scheme(db) + [table]
-        for table in tables:
-            table_file = os.path.join(db_root, f"db.{table}")
+        for _table in tables:
+            table_file = os.path.join(db_root, f"db.{_table}")
             if not (
                 os.path.exists(f"{table_file}.csv")
                 or os.path.exists(f"{table_file}.pkl")
             ):
                 _load_files(
-                    [table],
+                    [_table],
                     "table",
                     backend_interface,
                     db_root,
@@ -1742,6 +1742,6 @@ def load_table(
                     num_workers,
                     verbose,
                 )
-            db[table].load(table_file)
+            db[_table].load(table_file)
 
     return db[table]._df

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -472,6 +472,10 @@ def load_to(
     # save database and PKL tables
 
     if pickle_tables:
+        # Store database header,
+        # and add table as pickle files
+        # (tables are already stored in their original format).
+        # Uses `num_workers` to save tables in parallel.
         db.save(
             db_root,
             storage_format=audformat.define.TableStorageFormat.PICKLE,
@@ -480,6 +484,8 @@ def load_to(
             verbose=verbose,
         )
     else:
+        # Store database header
+        # (tables are already stored)
         db.save(
             db_root,
             header_only=True,

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -312,6 +312,7 @@ def load_to(
     *,
     version: str = None,
     only_metadata: bool = False,
+    pickle_tables: bool = True,
     cache_root: str = None,
     num_workers: typing.Optional[int] = 1,
     verbose: bool = True,
@@ -331,6 +332,12 @@ def load_to(
         name: name of database
         version: version string, latest if ``None``
         only_metadata: load only header and tables of database
+        pickle_tables: if ``True``,
+            tables are stored in their original format,
+            and as pickle files
+            in ``root``.
+            This allows for faster loading,
+            when loading from ``root``
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used.
             Only used to read the dependencies of the requested version
@@ -464,13 +471,20 @@ def load_to(
 
     # save database and PKL tables
 
-    db.save(
-        db_root,
-        storage_format=audformat.define.TableStorageFormat.PICKLE,
-        update_other_formats=False,
-        num_workers=num_workers,
-        verbose=verbose,
-    )
+    if pickle_tables:
+        db.save(
+            db_root,
+            storage_format=audformat.define.TableStorageFormat.PICKLE,
+            update_other_formats=False,
+            num_workers=num_workers,
+            verbose=verbose,
+        )
+    else:
+        db.save(
+            db_root,
+            header_only=True,
+            verbose=verbose,
+        )
 
     # remove the temporal directory
     # to signal all files were correctly loaded

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -333,9 +333,9 @@ def load_to(
         version: version string, latest if ``None``
         only_metadata: load only header and tables of database
         pickle_tables: if ``True``,
-            tables are stored in their original format,
-            and as pickle files
-            in ``root``.
+            tables are stored in ``root``
+            in their original format
+            and as pickle files.
             This allows for faster loading,
             when loading from ``root``
         cache_root: cache folder where databases are stored.

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -601,6 +601,69 @@ def test_load_media(cache, version, media, format):
     assert paths2 == paths
 
 
+@pytest.mark.parametrize("pickle_cache", [True, False])
+@pytest.mark.parametrize("name, version, table", [(DB_NAME, "1.0.0", "emotion")])
+class TestLoadPickle:
+    r"""Test storing tables as pickle files in cache.
+
+    When tables are first downloaded from a backend
+    with ``audb.load()`` or ``audb.load_table()``,
+    they are stored in their original format in the cache,
+    and dependent on the ``pickle_cache`` argument
+    stored as pickle as well.
+
+    """
+
+    def test_load_pickle(self, storage_format, name, version, table, pickle_cache):
+        """Test storing tables with audb.load()."""
+        db = audb.load(
+            name,
+            version=version,
+            tables=table,
+            pickle_cache=pickle_cache,
+            only_metadata=True,
+            verbose=False,
+        )
+        # Original table file exists in cache
+        assert os.path.exists(os.path.join(db.root, f"db.{table}.{storage_format}"))
+        # Pickled table file exists in cache
+        if pickle_cache:
+            assert os.path.exists(os.path.join(db.root, f"db.{table}.pkl"))
+        else:
+            assert not os.path.exists(os.path.join(db.root, f"db.{table}.pkl"))
+
+    def test_load_table_pickle(
+        self, cache, storage_format, name, version, table, pickle_cache
+    ):
+        r"""Test storing tables as pickle files in cache.
+
+        When tables are first downloaded from a backend
+        with ``audb.load()`` or ``audb.load_table()``,
+        they are stored in their original format in the cache,
+        and dependent on the ``pickle_cache`` argument
+        stored as pickle as well.
+
+        """
+        audb.load_table(
+            name,
+            table,
+            version=version,
+            pickle_cache=pickle_cache,
+            verbose=False,
+        )
+        database_cache = audeer.path(cache, name, version)
+        print(audeer.list_file_names(database_cache, recursive=True, basenames=True))
+        # Original table file exists in cache
+        assert os.path.exists(
+            os.path.join(database_cache, f"db.{table}.{storage_format}")
+        )
+        # Pickled table file exists in cache
+        if pickle_cache:
+            assert os.path.exists(audeer.path(database_cache, f"db.{table}.pkl"))
+        else:
+            assert not os.path.exists(audeer.path(database_cache, f"db.{table}.pkl"))
+
+
 @pytest.mark.parametrize(
     "version, table",
     [

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -601,26 +601,28 @@ def test_load_media(cache, version, media, format):
     assert paths2 == paths
 
 
-@pytest.mark.parametrize("pickle_cache", [True, False])
+@pytest.mark.parametrize("pickle_tables", [True, False])
 @pytest.mark.parametrize("name, version, table", [(DB_NAME, "1.0.0", "emotion")])
 class TestLoadPickle:
     r"""Test storing tables as pickle files in cache.
 
     When tables are first downloaded from a backend,
     they are stored in their original format in the cache,
-    and dependent on the ``pickle_cache`` argument
+    and dependent on the ``pickle_tables`` argument
     stored as pickle as well.
 
     """
 
-    def assert_table_exist_in_cache(self, db_root, table, storage_format, pickle_cache):
+    def assert_table_exist_in_cache(
+        self, db_root, table, storage_format, pickle_tables
+    ):
         """Assert table exists in original format and maybe as pickle.
 
         Args:
             db_root: database root folder
             table: table ID
             storage_format: storage format of table, ``"csv"`` or ``"parquet"``
-            pickle_cache: if ``True``,
+            pickle_tables: if ``True``,
                 table is asserted to exist as pickle file as well,
                 otherwise to not exist
 
@@ -629,12 +631,12 @@ class TestLoadPickle:
         assert os.path.exists(original_table)
 
         pickled_table = audeer.path(db_root, f"db.{table}.pkl")
-        if pickle_cache:
+        if pickle_tables:
             assert os.path.exists(pickled_table)
         else:
             assert not os.path.exists(pickled_table)
 
-    def test_load_pickle(self, storage_format, name, version, table, pickle_cache):
+    def test_load_pickle(self, storage_format, name, version, table, pickle_tables):
         """Test storing tables with audb.load().
 
         Args:
@@ -642,7 +644,7 @@ class TestLoadPickle:
             name: database name
             version: database version
             table: table ID
-            pickle_cache: if ``True``,
+            pickle_tables: if ``True``,
                 tables are stored as pickle files as well in cache
 
         """
@@ -650,14 +652,14 @@ class TestLoadPickle:
             name,
             version=version,
             tables=table,
-            pickle_cache=pickle_cache,
+            pickle_tables=pickle_tables,
             only_metadata=True,
             verbose=False,
         )
-        self.assert_table_exist_in_cache(db.root, table, storage_format, pickle_cache)
+        self.assert_table_exist_in_cache(db.root, table, storage_format, pickle_tables)
 
     def test_load_table_pickle(
-        self, cache, storage_format, name, version, table, pickle_cache
+        self, cache, storage_format, name, version, table, pickle_tables
     ):
         r"""Test storing tables with audb.load_table().
 
@@ -667,7 +669,7 @@ class TestLoadPickle:
             name: database name
             version: database version
             table: table ID
-            pickle_cache: if ``True``,
+            pickle_tables: if ``True``,
                 tables are stored as pickle files as well in cache
 
         """
@@ -675,11 +677,11 @@ class TestLoadPickle:
             name,
             table,
             version=version,
-            pickle_cache=pickle_cache,
+            pickle_tables=pickle_tables,
             verbose=False,
         )
         db_root = audeer.path(cache, name, version)
-        self.assert_table_exist_in_cache(db_root, table, storage_format, pickle_cache)
+        self.assert_table_exist_in_cache(db_root, table, storage_format, pickle_tables)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -601,26 +601,28 @@ def test_load_media(cache, version, media, format):
     assert paths2 == paths
 
 
-@pytest.mark.parametrize("pickle_table", [True, False])
+@pytest.mark.parametrize("pickle_tables", [True, False])
 @pytest.mark.parametrize("name, version, table", [(DB_NAME, "1.0.0", "emotion")])
 class TestLoadPickle:
     r"""Test storing tables as pickle files in cache.
 
     When tables are first downloaded from a backend,
     they are stored in their original format in the cache,
-    and dependent on the ``pickle_table`` argument
+    and dependent on the ``pickle_tables`` argument
     stored as pickle as well.
 
     """
 
-    def assert_table_exist_in_cache(self, db_root, table, storage_format, pickle_table):
+    def assert_table_exist_in_cache(
+        self, db_root, table, storage_format, pickle_tables
+    ):
         """Assert table exists in original format and maybe as pickle.
 
         Args:
             db_root: database root folder
             table: table ID
             storage_format: storage format of table, ``"csv"`` or ``"parquet"``
-            pickle_table: if ``True``,
+            pickle_tables: if ``True``,
                 table is asserted to exist as pickle file as well,
                 otherwise to not exist
 
@@ -629,12 +631,12 @@ class TestLoadPickle:
         assert os.path.exists(original_table)
 
         pickled_table = audeer.path(db_root, f"db.{table}.pkl")
-        if pickle_table:
+        if pickle_tables:
             assert os.path.exists(pickled_table)
         else:
             assert not os.path.exists(pickled_table)
 
-    def test_load_pickle(self, storage_format, name, version, table, pickle_table):
+    def test_load_pickle(self, storage_format, name, version, table, pickle_tables):
         """Test storing tables with audb.load().
 
         Args:
@@ -642,7 +644,7 @@ class TestLoadPickle:
             name: database name
             version: database version
             table: table ID
-            pickle_table: if ``True``,
+            pickle_tables: if ``True``,
                 tables are stored as pickle files as well in cache
 
         """
@@ -650,14 +652,14 @@ class TestLoadPickle:
             name,
             version=version,
             tables=table,
-            pickle_table=pickle_table,
+            pickle_tables=pickle_tables,
             only_metadata=True,
             verbose=False,
         )
-        self.assert_table_exist_in_cache(db.root, table, storage_format, pickle_table)
+        self.assert_table_exist_in_cache(db.root, table, storage_format, pickle_tables)
 
     def test_load_table_pickle(
-        self, cache, storage_format, name, version, table, pickle_table
+        self, cache, storage_format, name, version, table, pickle_tables
     ):
         r"""Test storing tables with audb.load_table().
 
@@ -667,7 +669,7 @@ class TestLoadPickle:
             name: database name
             version: database version
             table: table ID
-            pickle_table: if ``True``,
+            pickle_tables: if ``True``,
                 tables are stored as pickle files as well in cache
 
         """
@@ -675,11 +677,11 @@ class TestLoadPickle:
             name,
             table,
             version=version,
-            pickle_table=pickle_table,
+            pickle_tables=pickle_tables,
             verbose=False,
         )
         db_root = audeer.path(cache, name, version)
-        self.assert_table_exist_in_cache(db_root, table, storage_format, pickle_table)
+        self.assert_table_exist_in_cache(db_root, table, storage_format, pickle_tables)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -601,28 +601,26 @@ def test_load_media(cache, version, media, format):
     assert paths2 == paths
 
 
-@pytest.mark.parametrize("pickle_tables", [True, False])
+@pytest.mark.parametrize("pickle_table", [True, False])
 @pytest.mark.parametrize("name, version, table", [(DB_NAME, "1.0.0", "emotion")])
 class TestLoadPickle:
     r"""Test storing tables as pickle files in cache.
 
     When tables are first downloaded from a backend,
     they are stored in their original format in the cache,
-    and dependent on the ``pickle_tables`` argument
+    and dependent on the ``pickle_table`` argument
     stored as pickle as well.
 
     """
 
-    def assert_table_exist_in_cache(
-        self, db_root, table, storage_format, pickle_tables
-    ):
+    def assert_table_exist_in_cache(self, db_root, table, storage_format, pickle_table):
         """Assert table exists in original format and maybe as pickle.
 
         Args:
             db_root: database root folder
             table: table ID
             storage_format: storage format of table, ``"csv"`` or ``"parquet"``
-            pickle_tables: if ``True``,
+            pickle_table: if ``True``,
                 table is asserted to exist as pickle file as well,
                 otherwise to not exist
 
@@ -631,12 +629,12 @@ class TestLoadPickle:
         assert os.path.exists(original_table)
 
         pickled_table = audeer.path(db_root, f"db.{table}.pkl")
-        if pickle_tables:
+        if pickle_table:
             assert os.path.exists(pickled_table)
         else:
             assert not os.path.exists(pickled_table)
 
-    def test_load_pickle(self, storage_format, name, version, table, pickle_tables):
+    def test_load_pickle(self, storage_format, name, version, table, pickle_table):
         """Test storing tables with audb.load().
 
         Args:
@@ -644,7 +642,7 @@ class TestLoadPickle:
             name: database name
             version: database version
             table: table ID
-            pickle_tables: if ``True``,
+            pickle_table: if ``True``,
                 tables are stored as pickle files as well in cache
 
         """
@@ -652,14 +650,14 @@ class TestLoadPickle:
             name,
             version=version,
             tables=table,
-            pickle_tables=pickle_tables,
+            pickle_table=pickle_table,
             only_metadata=True,
             verbose=False,
         )
-        self.assert_table_exist_in_cache(db.root, table, storage_format, pickle_tables)
+        self.assert_table_exist_in_cache(db.root, table, storage_format, pickle_table)
 
     def test_load_table_pickle(
-        self, cache, storage_format, name, version, table, pickle_tables
+        self, cache, storage_format, name, version, table, pickle_table
     ):
         r"""Test storing tables with audb.load_table().
 
@@ -669,7 +667,7 @@ class TestLoadPickle:
             name: database name
             version: database version
             table: table ID
-            pickle_tables: if ``True``,
+            pickle_table: if ``True``,
                 tables are stored as pickle files as well in cache
 
         """
@@ -677,11 +675,11 @@ class TestLoadPickle:
             name,
             table,
             version=version,
-            pickle_tables=pickle_tables,
+            pickle_table=pickle_table,
             verbose=False,
         )
         db_root = audeer.path(cache, name, version)
-        self.assert_table_exist_in_cache(db_root, table, storage_format, pickle_tables)
+        self.assert_table_exist_in_cache(db_root, table, storage_format, pickle_table)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See https://github.com/audeering/audformat/issues/440 and https://github.com/audeering/audbcards/issues/100

Adds `pickle_tables` argument to `audb.load()`, `audb.load_to()` and `audb.load_table()` with default value of `True`. If `pickle_tables` is `True`, it will store a table in its original format (csv or parquet) in the cache or in `root` (in the case of `audb.load_to()`), but also load the table ones and store as pickle file. This will speed up loading the table a second time, and was the default behavior before.

With `pickle_tables` is `False` we provide the option to load tables to the cache, that do not fit into memory, and provide the user the option to avoid loading the whole table when only a few lines should be read.

![image](https://github.com/user-attachments/assets/b43f8b09-6753-4868-b280-a122442295b8)

![image](https://github.com/user-attachments/assets/b17344b6-297d-49d3-8d1c-4aa0c574c860)

![image](https://github.com/user-attachments/assets/d37608f8-b055-4d8c-af38-baa6aaefe718)

---

![image](https://github.com/user-attachments/assets/dff490ec-01eb-4f74-b616-aff8b92b8b0f)

![image](https://github.com/user-attachments/assets/d372c6eb-cc41-44d1-af50-43064ab84f4f)



