### PR TITLE
TST: fix tests for audformat>=1.3.0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,3 +241,10 @@ def non_existing_repository():
 def hide_default_repositories():
     r"""Hide default audb repositories during testing."""
     audb.config.REPOSITORIES = []
+
+
+# ===== STORAGE FORMAT =====
+@pytest.fixture(scope="module", autouse=False)
+def storage_format():
+    """Storage format of tables."""
+    yield "csv"

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -33,11 +33,6 @@ def assert_database_tmp_folder_is_deleted():
     assert len([d for d in dirs if d.endswith("~")]) == 0
 
 
-@pytest.fixture(scope="module", autouse=False)
-def storage_format():
-    yield "csv"
-
-
 @pytest.fixture(
     scope="module",
     autouse=True,

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -17,7 +17,7 @@ DB_VERSION = "1.0.0"
     scope="module",
     autouse=True,
 )
-def dbs(tmpdir_factory, persistent_repository):
+def dbs(tmpdir_factory, persistent_repository, storage_format):
     # Collect single database paths
     # and return them in the end
     paths = {}
@@ -64,7 +64,7 @@ def dbs(tmpdir_factory, persistent_repository):
     audeer.touch(db_root, "file.txt")
     audeer.touch(db_root, "folder/file1.txt")
     audeer.touch(db_root, "folder/file2.txt")
-    db.save(db_root)
+    db.save(db_root, storage_format=storage_format)
     audformat.testing.create_audio_files(db)
 
     audb.publish(

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -77,7 +77,7 @@ def dbs(tmpdir_factory, persistent_repository, storage_format):
     return paths
 
 
-def test_load_only_metadata(dbs):
+def test_load_only_metadata(dbs, storage_format):
     db_original = audformat.Database.load(dbs[DB_VERSION])
 
     db = audb.load(
@@ -103,7 +103,7 @@ def test_load_only_metadata(dbs):
 
     # Delete table1
     # to force downloading from backend again
-    os.remove(os.path.join(db.meta["audb"]["root"], "db.table1.csv"))
+    os.remove(os.path.join(db.meta["audb"]["root"], f"db.table1.{storage_format}"))
     os.remove(os.path.join(db.meta["audb"]["root"], "db.table1.pkl"))
     db = audb.load(
         DB_NAME,

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1064,7 +1064,7 @@ def test_publish_error_version(tmpdir, repository):
         audb.publish(db_path, "2.0.0", repository, previous_version="1.0.0?")
 
 
-def test_publish_text_media_files(tmpdir, dbs, repository):
+def test_publish_text_media_files(tmpdir, dbs, repository, storage_format):
     r"""Test publishing databases containing text files as media files."""
     # Create a database, containing text media file
     build_dir = audeer.path(tmpdir, "./build")
@@ -1079,7 +1079,7 @@ def test_publish_text_media_files(tmpdir, dbs, repository):
     db["files"] = audformat.Table(index)
     db["files"]["speaker"] = audformat.Column(scheme_id="speaker")
     db["files"]["speaker"].set(["adam"])
-    db.save(build_dir)
+    db.save(build_dir, storage_format=storage_format)
 
     # Publish database, containing text media file
     version = "1.0.0"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1085,7 +1085,7 @@ def test_publish_text_media_files(tmpdir, dbs, repository, storage_format):
     version = "1.0.0"
     deps = audb.publish(build_dir, version, repository)
 
-    assert deps.tables == ["db.files.csv"]
+    assert deps.tables == [f"db.files.{storage_format}"]
     file = "data/file1.txt"
     assert deps.media == [file]
     assert deps.bit_depth(file) == 0


### PR DESCRIPTION
In `audformat` 1.3.0 the default storage format of tables was changed from csv to parquet. This pull requests adjusts two tests, that expected a table to be stored always as csv before. It reuses the already existing `storage_format` fixture.