### PR TITLE
Add map argument to audb.load_table()

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1685,18 +1685,20 @@ def load_table(
             that is not part of the database
 
     Examples:
-        >>> df = load_table(
-        ...     "emodb",
-        ...     "emotion",
-        ...     version="1.4.1",
-        ...     verbose=False,
-        ... )
+        >>> df = load_table("emodb", "emotion", version="1.4.1", verbose=False)
         >>> df[:3]
                            emotion  emotion.confidence
         file
         wav/03a01Fa.wav  happiness                0.90
         wav/03a01Nc.wav    neutral                1.00
         wav/03a01Wa.wav      anger                0.95
+        >>> df = load_table("emodb", "files", version="1.4.1", verbose=False)
+        >>> df[:3]
+                                         duration speaker transcription
+        file
+        wav/03a01Fa.wav    0 days 00:00:01.898250       3           a01
+        wav/03a01Nc.wav    0 days 00:00:01.611250       3           a01
+        wav/03a01Wa.wav 0 days 00:00:01.877812500       3           a01
         >>> df = load_table(
         ...     "emodb",
         ...     "files",

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1697,7 +1697,6 @@ def load_table(
         wav/03a01Fa.wav  happiness                0.90
         wav/03a01Nc.wav    neutral                1.00
         wav/03a01Wa.wav      anger                0.95
-
         >>> df = load_table(
         ...     "emodb",
         ...     "files",

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1755,7 +1755,7 @@ def load_table(
             version,
         )
 
-        # Find misc tables used in schemes of the requested table
+        # Find only those misc tables used in schemes of the requested table
         scheme_misc_tables = []
         for column_id, column in db[table].columns.items():
             if column.scheme_id is not None:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -46,6 +46,7 @@ def dbs(tmpdir_factory, persistent_repository, storage_format):
         dictionary containing root folder for each version
 
     """
+    # Fix seed for audformat.testing
     random.seed(1)
 
     # Collect single database paths


### PR DESCRIPTION
Adds the `map` argument to `audb.load_table()` to provide the user the possibility to map values of columns if they contain respective scheme labels. Without the new added argument, a user would have to use `db = audb.load()` + `db.get(map=)` instead.

It also fixes a bug inside `audb.load_table()` to only load misc tables, that are needed by a scheme of the selected table. Before, it was downloading all misc tables that were used as labels inside any scheme of the database.

![image](https://github.com/user-attachments/assets/1e4030df-ad2f-4f50-a910-993237b537f4)