### PR TITLE
Replace artifactory by minio for public repo

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -41,8 +41,8 @@ def available(
         >>> df.loc[["air", "emodb"]]
               backend                                   host   repository version
         name
-        air     minio  s3.dualstack.eu-north-1.amazonaws.com  audb-public   1.4.2
-        emodb   minio  s3.dualstack.eu-north-1.amazonaws.com  audb-public   1.4.1
+        air        s3  s3.dualstack.eu-north-1.amazonaws.com  audb-public   1.4.2
+        emodb      s3  s3.dualstack.eu-north-1.amazonaws.com  audb-public   1.4.1
 
     """  # noqa: E501
     databases = []
@@ -569,7 +569,7 @@ def repository(
 
     Examples:
         >>> audb.repository("emodb", "1.4.1")
-        Repository('audb-public', 's3.dualstack.eu-north-1.amazonaws.com', 'minio')
+        Repository('audb-public', 's3.dualstack.eu-north-1.amazonaws.com', 's3')
 
     """  # noqa: E501
     if not versions(name):

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -39,10 +39,10 @@ def available(
     Examples:
         >>> df = audb.available(only_latest=True)
         >>> df.loc[["air", "emodb"]]
-                   backend                                    host   repository version
+              backend                                   host   repository version
         name
-        air    artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.2
-        emodb  artifactory  https://audeering.jfrog.io/artifactory  data-public   1.4.1
+        air     minio  s3.dualstack.eu-north-1.amazonaws.com  audb-public   1.4.2
+        emodb   minio  s3.dualstack.eu-north-1.amazonaws.com  audb-public   1.4.1
 
     """  # noqa: E501
     databases = []
@@ -63,7 +63,7 @@ def available(
         try:
             backend_interface = repository.create_backend_interface()
             with backend_interface.backend as backend:
-                if repository.backend == "artifactory":
+                if repository.backend == "artifactory":  # pragma: nocover
                     # avoid backend_interface.ls('/')
                     # which is very slow on Artifactory
                     # see https://github.com/audeering/audbackend/issues/132
@@ -569,7 +569,7 @@ def repository(
 
     Examples:
         >>> audb.repository("emodb", "1.4.1")
-        Repository('data-public', 'https://audeering.jfrog.io/artifactory', 'artifactory')
+        Repository('audb-public', 's3.dualstack.eu-north-1.amazonaws.com', 'minio')
 
     """  # noqa: E501
     if not versions(name):
@@ -598,7 +598,7 @@ def versions(
         try:
             backend_interface = repository.create_backend_interface()
             with backend_interface.backend as backend:
-                if repository.backend == "artifactory":
+                if repository.backend == "artifactory":  # pragma: nocover
                     # Do not use `backend_interface.versions()` on Artifactory,
                     # as calling `backend_interface.ls()` is slow on Artifactory,
                     # see https://github.com/devopshq/artifactory/issues/423.
@@ -616,7 +616,7 @@ def versions(
                                 header = p.joinpath(f"db-{version}.yaml")
                                 if header.exists():
                                     vs.extend([version])
-                    except Exception:  # pragma: nocover
+                    except Exception:
                         # Might happen,
                         # if a database is not available on the backend,
                         # or we don't have read permissions.

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -53,7 +53,7 @@ def public_repository():
         audb.Repository(
             name="audb-public",
             host="s3.dualstack.eu-north-1.amazonaws.com",
-            backend="minio",
+            backend="s3",
         ),
     ]
 

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -51,9 +51,9 @@ def public_repository():
     r"""Provide access to the public Artifactory repository."""
     audb.config.REPOSITORIES = [
         audb.Repository(
-            name="data-public",
-            host="https://audeering.jfrog.io/artifactory",
-            backend="artifactory",
+            name="audb-public",
+            host="s3.dualstack.eu-north-1.amazonaws.com",
+            backend="minio",
         ),
     ]
 

--- a/audb/core/etc/audb.yaml
+++ b/audb/core/etc/audb.yaml
@@ -2,7 +2,7 @@ cache_root: ~/audb
 shared_cache_root: /data/audb
 repositories:
   - name: audb-public
-    backend: minio
+    backend: s3
     host: s3.dualstack.eu-north-1.amazonaws.com
   - name: data-local
     backend: file-system

--- a/audb/core/etc/audb.yaml
+++ b/audb/core/etc/audb.yaml
@@ -1,9 +1,9 @@
 cache_root: ~/audb
 shared_cache_root: /data/audb
 repositories:
-  - name: data-public
-    backend: artifactory
-    host: https://audeering.jfrog.io/artifactory
+  - name: audb-public
+    backend: minio
+    host: s3.dualstack.eu-north-1.amazonaws.com
   - name: data-local
     backend: file-system
     host: ~/audb-host

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -120,7 +120,7 @@ class Repository:
         """
         backend_class = self.backend_registry[self.backend]
         backend = backend_class(self.host, self.name)
-        if self.backend in ["artifactory", "minio"]:
+        if self.backend == "artifactory":
             interface = audbackend.interface.Maven(backend)
         else:
             interface = audbackend.interface.Versioned(backend)

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -120,7 +120,7 @@ class Repository:
         """
         backend_class = self.backend_registry[self.backend]
         backend = backend_class(self.host, self.name)
-        if self.backend == "artifactory":
+        if self.backend in ["artifactory", "minio"]:
             interface = audbackend.interface.Maven(backend)
         else:
             interface = audbackend.interface.Versioned(backend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import audb
 
 
 PUBLIC_HOST = "s3.dualstack.eu-north-1.amazonaws.com"
-PUBLIC_BACKEND = "minio"
+PUBLIC_BACKEND = "s3"
 
 
 if platform.system() == "Darwin":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,10 @@ import audeer
 import audb
 
 
+PUBLIC_HOST = "s3.dualstack.eu-north-1.amazonaws.com"
+PUBLIC_BACKEND = "minio"
+
+
 if platform.system() == "Darwin":
     # Avoid multi-threading on MacOS runner,
     # as it might fail from time to time
@@ -218,23 +222,21 @@ def private_and_public_repository():
 
 @pytest.fixture(scope="module", autouse=False)
 def non_existing_repository():
-    r"""Non-existing repository on Artifactory.
+    r"""Non-existing repository.
 
     Configure the following repositories:
     * non-existing: non-exsiting repo on public Artifactory
-    * data-public: repo on public Artifactory with anonymous access
+    * audb-public: repo on public Artifactory with anonymous access
 
     Note, that the order of the repos is important.
     audb will visit the repos in the given order
     until it finds the requested database.
 
     """
-    host = "https://audeering.jfrog.io/artifactory"
-    backend = "artifactory"
     current_repositories = audb.config.REPOSITORIES
     audb.config.REPOSITORIES = [
-        audb.Repository("non-existing", host, backend),
-        audb.Repository("data-public", host, backend),
+        audb.Repository("non-existing", PUBLIC_HOST, PUBLIC_BACKEND),
+        audb.Repository("audb-public", PUBLIC_HOST, PUBLIC_BACKEND),
     ]
 
     yield repository


### PR DESCRIPTION
Adds support for S3 and MinIO backends, and switches the default repository to one hosted on AWS S3. It continues to support Artifactory backends.

## Summary by Sourcery

Add support for S3 and MinIO backends and switch the default repository to AWS S3, while continuing to support Artifactory backends.

New Features:
- Add support for S3 and MinIO backends.

Enhancements:
- Switch the default repository to one hosted on AWS S3 while maintaining support for Artifactory backends.