### PR TITLE
TST: update ruff and codespell

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
 
-    # Docuemntation
+    # Documentation
     - name: Install doc dependencies
       run: |
         sudo apt-get install --no-install-recommends --yes libsndfile1 sox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:


### PR DESCRIPTION
This updates ruff and codespell in the pre-commit config to its latest versions (which I think we should do once a year).

All tests are running fine with the newer versions, even though ruff have introduced some [breaking changes](https://github.com/astral-sh/ruff/blob/main/BREAKING_CHANGES.md).

## Summary by Sourcery

Update the pre-commit configuration to use the latest versions of ruff and codespell, ensuring compatibility with their latest features and changes.

Build:
- Update ruff to version 0.7.0 in the pre-commit configuration.
- Update codespell to version 2.3.0 in the pre-commit configuration.