### PR TITLE
Add MinIO support with audbackend>=2.1.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,9 @@ and versioned for reproducibility.
 as it stores all databases in a `common format`_
 and manages different versions of a database.
 Databases are stored in repositories
-on local file systems
+on local file systems,
+MinIO_,
+S3_,
 or Artifactory_ servers.
 
 You can request resampling or remixing of audio content
@@ -42,11 +44,13 @@ If you want to cite **audb**, you can refer to our paper_:
     }
 
 
-.. _common format: https://audeering.github.io/audformat/
 .. _Artifactory: https://jfrog.com/artifactory/
+.. _common format: https://audeering.github.io/audformat/
 .. _installation: https://audeering.github.io/audb/install.html
-.. _quickstart: https://audeering.github.io/audb/quickstart.html
+.. _MinIO: https://min.io
 .. _paper: https://arxiv.org/abs/2303.00645
+.. _quickstart: https://audeering.github.io/audb/quickstart.html
+.. _S3: https://aws.amazon.com/s3/
 
 
 .. badges images and links:

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -26,8 +26,9 @@ class Repository:
     """
 
     backend_registry = {
-        "file-system": audbackend.backend.FileSystem,
         "artifactory": audbackend.backend.Artifactory,
+        "file-system": audbackend.backend.FileSystem,
+        "minio": audbackend.backend.Minio,
     }
     r"""Backend registry.
 
@@ -74,8 +75,7 @@ class Repository:
         r"""Create backend interface to access repository.
 
         When :attr:`Repository.backend` equals ``artifactory``,
-        it creates an instance of :class:`audbackend.backend.Artifactory`
-        and wraps an :class:`audbackend.interface.Maven` interface
+        it wraps an :class:`audbackend.interface.Maven` interface
         around it.
         The files will then be stored
         with the following structure on the Artifactory backend
@@ -87,12 +87,11 @@ class Repository:
             emodb/media/.../1.0.0/...      <-- media files
             emodb/meta/.../1.0.0/...       <-- tables
 
-        When :attr:`Repository.backend` equals ``file-system``,
-        it creates an instance of :class:`audbackend.backend.FileSystem`
-        and wraps an :class:`audbackend.interface.Versioned` interface
+        Otherwise,
+        it wraps an :class:`audbackend.interface.Versioned` interface
         around it.
         The files will then be stored
-        with the following structure on the Artifactory backend
+        with the following structure on the backend
         (shown by the example of version 1.0.0 of the emodb dataset)::
 
             emodb/1.0.0/db.yaml            <-- header

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -17,7 +17,8 @@ class Repository:
     Args:
         name: repository name
         host: repository host
-        backend: repository backend
+        backend: repository backend,
+            for storage on S3 use the `"minio"` backend
 
     Examples:
         >>> Repository("data-local", "/data", "file-system")
@@ -74,6 +75,18 @@ class Repository:
     def create_backend_interface(self) -> type[audbackend.interface.Base]:
         r"""Create backend interface to access repository.
 
+        It wraps an :class:`audbackend.interface.Versioned` interface
+        around it.
+        The files will then be stored
+        with the following structure on the backend
+        (shown by the example of version 1.0.0 of the emodb dataset)::
+
+            emodb/1.0.0/db.yaml            <-- header
+            emodb/1.0.0/db.zip             <-- dependency table
+            emodb/attachment/1.0.0/...     <-- attachments
+            emodb/media/1.0.0/...          <-- media files
+            emodb/meta/1.0.0/...           <-- tables
+
         When :attr:`Repository.backend` equals ``artifactory``,
         it wraps an :class:`audbackend.interface.Maven` interface
         around it.
@@ -86,19 +99,6 @@ class Repository:
             emodb/attachment/.../1.0.0/... <-- attachments
             emodb/media/.../1.0.0/...      <-- media files
             emodb/meta/.../1.0.0/...       <-- tables
-
-        Otherwise,
-        it wraps an :class:`audbackend.interface.Versioned` interface
-        around it.
-        The files will then be stored
-        with the following structure on the backend
-        (shown by the example of version 1.0.0 of the emodb dataset)::
-
-            emodb/1.0.0/db.yaml            <-- header
-            emodb/1.0.0/db.zip             <-- dependency table
-            emodb/attachment/1.0.0/...     <-- attachments
-            emodb/media/1.0.0/...          <-- media files
-            emodb/meta/1.0.0/...           <-- tables
 
         The returned backend instance
         has not yet established a connection to the backend.

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1,7 +1,10 @@
 Authentication
 ==============
 
-Using Artifactory as backend
-requires authentication.
+Using Artifactory,
+MinIO or S3
+as backend
+might require authentication.
 For more information,
-see :class:`audbackend.backend.Artifactory`.
+see :class:`audbackend.backend.Artifactory`
+and :class:`audbackend.backend.Minio` (for MinIO and S3).

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -31,6 +31,7 @@ to communicate with the underlying backend.
 At the moment,
 it supports to store the data
 in a folder on a local file system,
+in a bucket on MinIO_ or S3_ storage,
 or inside a `Generic repository`_
 on an `Artifactory server`_.
 
@@ -96,6 +97,8 @@ the following operations are performed:
 .. graphviz:: pics/load.dot
 
 
-.. _Generic repository: https://jfrog.com/help/r/jfrog-artifactory-documentation/repository-management
 .. _Artifactory server: https://jfrog.com/artifactory/
+.. _Generic repository: https://jfrog.com/help/r/jfrog-artifactory-documentation/repository-management
 .. _implements the required functions: https://github.com/audeering/audbackend/blob/edd23462799ae9052a43cdd045698f78e19dbcaf/audbackend/core/backend.py#L559-L659
+.. _MinIO: https://min.io
+.. _S3: https://aws.amazon.com/s3/

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -148,7 +148,7 @@ in the file ``db.parquet``.
 Note,
 that the structure of the folders
 used for versioning
-depends on the backend,
+:meth:`depends on the backend <audb.Repository.create_backend_interface>`,
 and differs slightly
 for an Artifactory backend.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[artifactory] >=2.0.0',
+    'audbackend[all] @ git+https://github.com/audeering/audbackend.git@main',
     'audeer >=2.1.0',
     'audformat >=1.2.0',
     'audiofile >=1.0.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[all] @ git+https://github.com/audeering/audbackend.git@main',
+    'audbackend[all] >=2.1.0',
     'audeer >=2.1.0',
     'audformat >=1.2.0',
     'audiofile >=1.0.0',


### PR DESCRIPTION
Adds support for MinIO and S3 backends by depending on `audbackend>=2.1.0`.

It does not moves the public repository to S3 as proposed in #450, but stays with Artifactory.

Updated README:

![image](https://github.com/user-attachments/assets/a27ace27-8963-4a20-9bcd-6ded95cac4e4)

The new backend is listed as `minio` under the registered backends:

![image](https://github.com/user-attachments/assets/140e178f-3e77-45fb-ad9d-49dea289b427)

The docstring of `audb.Repository.create_backend_interface()` has been updated to reflect that we have more than two backends now:

![image](https://github.com/user-attachments/assets/00a96a35-d9b9-41a1-88c0-a4b8c8d342f5)


## Summary by Sourcery

Integrate MinIO support by updating the backend registry and modifying the docstring to reflect the new backend options. This change depends on audbackend version 2.1.0 or higher.

New Features:
- Add support for MinIO backend by integrating audbackend>=2.1.0.

Enhancements:
- Update the backend registry to include MinIO as a registered backend.
- Modify the docstring of audb.Repository.create_backend_interface() to reflect the addition of more than two backends.