### PR TITLE
Register s3 backend

### DIFF
--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -17,8 +17,7 @@ class Repository:
     Args:
         name: repository name
         host: repository host
-        backend: repository backend,
-            for storage on S3 use the `"minio"` backend
+        backend: repository backend
 
     Examples:
         >>> Repository("data-local", "/data", "file-system")
@@ -30,6 +29,7 @@ class Repository:
         "artifactory": audbackend.backend.Artifactory,
         "file-system": audbackend.backend.FileSystem,
         "minio": audbackend.backend.Minio,
+        "s3": audbackend.backend.Minio,
     }
     r"""Backend registry.
 


### PR DESCRIPTION
Closes #455

To make it easier for the user to setup a S3 storage, I registered it as an backend as well (using the same backend as `minio`):

![image](https://github.com/user-attachments/assets/1757ab88-a1e0-472e-99b4-565e9f8a851d)

When configuring a repository, the user can now write:

```python
audb.Repository("repo", "s3.dualstack.some-region.amazonaws.com", "s3")
```
instead of having to write
```python
audb.Repository("repo", "s3.dualstack.some-region.amazonaws.com", "minio")
```