### PR TITLE
Speedup audb.available() for S3/Minio

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -77,10 +77,9 @@ def available(
                             # we do not include the dataset
                             pass
 
-                elif repository.backend in ["minio", "s3"]:
-                    # We can be much faster
-                    # by avoiding using ls(),
-                    # which would recursively lists all files
+                elif repository.backend in ["minio", "s3"]:  # pragma: nocover
+                    # Avoid `ls(recursive=True)` for S3 and MinIO
+                    # as this is slow for large databases
                     for obj in backend._client.list_objects(repository.name):
                         name = obj.object_name
                         header_file = f"/{name}/{define.HEADER_FILE}"

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -91,7 +91,7 @@ def available(
                                 "attachment",
                                 "media",
                                 "meta",
-                            ] and backend.exist(header_file):
+                            ] and backend.exists(header_file):
                                 add_database(name, version, repository)
 
                 else:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -81,7 +81,7 @@ def available(
                     # We can be much faster
                     # by avoiding using ls(),
                     # which would recursively lists all files
-                    for obj in backend.list_objects(repository.name):
+                    for obj in backend._client.list_objects(repository.name):
                         name = obj.object_name
                         header_file = f"/{name}/{define.HEADER_FILE}"
                         for _, version in backend_interface.ls(header_file):

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -84,8 +84,15 @@ def available(
                     for obj in backend._client.list_objects(repository.name):
                         name = obj.object_name
                         header_file = f"/{name}/{define.HEADER_FILE}"
-                        for _, version in backend_interface.ls(header_file):
-                            add_database(name, version, repository)
+                        for _obj in backend._client.list_objects(repository.name, name):
+                            version = _obj.object_name.split("/")[1]
+                            header_file = f"/{name}/{version}/{define.HEADER_FILE}"
+                            if version not in [
+                                "attachment",
+                                "media",
+                                "meta",
+                            ] and backend.exist(header_file):
+                                add_database(name, version, repository)
 
                 else:
                     for path, version in backend_interface.ls("/"):

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -77,7 +77,7 @@ def available(
                             # we do not include the dataset
                             pass
 
-                elif repository.backend in ["minio", "s3"]:  # pragma: nocover
+                elif repository.backend in ["minio", "s3"]:
                     # Avoid `ls(recursive=True)` for S3 and MinIO
                     # as this is slow for large databases
                     for obj in backend._client.list_objects(repository.name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,11 +185,14 @@ def persistent_repository(tmpdir_factory):
 
 @pytest.fixture(scope="module", autouse=False)
 def private_and_public_repository():
-    r"""Private and public repository on Artifactory.
+    r"""Private and public repositories.
 
     Configure the following repositories:
+
     * data-private: repo on public Artifactory without access
+    * audb-private: repo on public S3 without access
     * data-public: repo on public Artifactory with anonymous access
+    * audb-public: repo on public S3 with anonymous access
     * data-public2: repo on public Artifactory with anonymous access
 
     Note, that the order of the repos is important.
@@ -197,13 +200,15 @@ def private_and_public_repository():
     until it finds the requested database.
 
     """
-    host = "https://audeering.jfrog.io/artifactory"
-    backend = "artifactory"
     current_repositories = audb.config.REPOSITORIES
+    public_artifactory_host = "https://audeering.jfrog.io/artifactory"
+    public_s3_host = "s3.dualstack.eu-north-1.amazonaws.com"
     audb.config.REPOSITORIES = [
-        audb.Repository("data-private", host, backend),
-        audb.Repository("data-public", host, backend),
-        audb.Repository("data-public2", host, backend),
+        audb.Repository("data-private", public_artifactory_host, "artifactory"),
+        audb.Repository("audb-private", public_s3_host, "s3"),
+        audb.Repository("data-public", public_artifactory_host, "artifactory"),
+        audb.Repository("audb-public", public_s3_host, "s3"),
+        audb.Repository("data-public2", public_artifactory_host, "artifactory"),
     ]
 
     yield repository


### PR DESCRIPTION
This speeds up `audb.available()` for the S3 and MinIO backends by avoiding listing all files recursively, but focusing on the database names and the versions of the database header files.

Execution time for running `audb.available()` for the repositories `audb-public` (containing 7 smaller datasets) and `audb-internal` (containing 1 big dataset).

| Branch | audb-public | audb-internal |
| --- | --- | --- |
| speedup-available-s3 | 1.6 s | 0.4 s |
| main | 1.7 s | 45.0 s |

<details><summary> Benchmark code </summary>

```python
import audb
import time


repository = audb.Repository("audb-public", "s3.dualstack.eu-north-1.amazonaws.com", "s3")
audb.config.REPOSITORIES = [repository]
t0 = time.time()
df = audb.available()
t = time.time() - t0
print(f"Execution time: {t:.1f}s")
```

<details>

The pull request also makes sure `audb.available()` is tested for two S3 repositories as well, besides the Artifactory repositories.


## Summary by Sourcery

Enhancements:
- Optimize the audb.available() function for S3 and MinIO backends by avoiding recursive file listing and focusing on database names and header file versions.

## Summary by Sourcery

Enhancements:
- Optimize the audb.available() function for S3 and MinIO backends by avoiding recursive file listing and focusing on database names and header file versions.