### PR TITLE
Make artifactory backend optional

### DIFF
--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -39,6 +39,8 @@ class Repository:
 
     Holds mapping between registered backend names,
     and their corresponding backend classes.
+    The ``"artifactory"`` backend is currently not available
+    under Python 3.12.
 
     """
 

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -40,7 +40,7 @@ class Repository:
     Holds mapping between registered backend names,
     and their corresponding backend classes.
     The ``"artifactory"`` backend is currently not available
-    under Python 3.12.
+    under Python >=3.12.
 
     """
 

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -25,12 +25,16 @@ class Repository:
 
     """
 
-    backend_registry = {
-        "artifactory": audbackend.backend.Artifactory,
+    backends = {
         "file-system": audbackend.backend.FileSystem,
         "minio": audbackend.backend.Minio,
         "s3": audbackend.backend.Minio,
     }
+
+    if hasattr(audbackend.backend, "Artifactory"):
+        backends["artifactory"] = audbackend.backend.Artifactory
+
+    backend_registry = backends
     r"""Backend registry.
 
     Holds mapping between registered backend names,


### PR DESCRIPTION
As the Artifactory backend does not work under Python 3.12 (https://github.com/audeering/audb/issues/432), we make it optional here and include it only when available (since `audbackend` v2.1.0, the Artifactory backend will only be installed for Python <3.12).

This will not allow a user to access all the datasets currently published on Artifactory backends under Python 3.12, but it will allow the user to import `audb` under Python 3.12 and load datasets from other backends.

I also updated the docstring, mentioning the special Python 3.12 case.

![image](https://github.com/user-attachments/assets/8d3c1f20-5827-4ac2-b999-740edd7ef7ef)


## Summary by Sourcery

Enhancements:
- Make the Artifactory backend optional by checking its availability before including it in the backend registry.