### PR TITLE
DOC: hide Repository.backends

### DIFF
--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -25,16 +25,16 @@ class Repository:
 
     """
 
-    backends = {
+    _backends = {
         "file-system": audbackend.backend.FileSystem,
         "minio": audbackend.backend.Minio,
         "s3": audbackend.backend.Minio,
     }
 
     if hasattr(audbackend.backend, "Artifactory"):
-        backends["artifactory"] = audbackend.backend.Artifactory
+        _backends["artifactory"] = audbackend.backend.Artifactory
 
-    backend_registry = backends
+    backend_registry = _backends
     r"""Backend registry.
 
     Holds mapping between registered backend names,


### PR DESCRIPTION
In https://github.com/audeering/audb/pull/460 we introduced the variable `audb.Repository.backends` to store the "standard" list of backends later handed to `audb.Repository.backend_registry`. As this variable should not popup in he documentation, it should be a hidden variable, hence it is renamed to ``audb.Repository._backends` in this pull request.

## Summary by Sourcery

Enhancements:
- Rename 'audb.Repository.backends' to 'audb.Repository._backends' to hide it from documentation.