### PR TITLE
Depend on audbackend=>2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[all] >=2.1.0',
+    'audbackend[all] >=2.2.0',
     'audeer >=2.1.0',
     'audformat >=1.2.0',
     'audiofile >=1.0.0',


### PR DESCRIPTION
Closes https://github.com/audeering/audb/issues/459

Depends on `audbackend` >=2.2.0, which fixed the issues described in https://github.com/audeering/audb/issues/459.

## Summary by Sourcery

Build:
- Update dependency on audbackend to version 2.2.0 in pyproject.toml.