### PR TITLE
Release 1.10.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Version 1.10.1 (2024-11-18)
 ---------------------------
 
 * Added: ``"s3"`` as a registered backend name
-* Changed: depend on ``audbackend=>2.2.0``
+* Changed: depend on ``audbackend>=2.2.0``
 * Changed: make Artifactory backend optional,
   to allow importing ``audb`` in Python>=3.12
 * Fixed:  speedup ``audb.available()`` for S3 and Minio backends

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.10.1 (2024-11-18)
+---------------------------
+
+* Added: ``"s3"`` as a registered backend name
+* Changed: depend on ``audbackend=>2.2.0``
+* Changed: make Artifactory backend optional,
+  to allow importing ``audb`` in Python>=3.12
+* Fixed:  speedup ``audb.available()`` for S3 and Minio backends
+
+
 Version 1.10.0 (2024-11-04)
 ---------------------------
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/94495d92-c996-42d3-a8fb-dba4515cfe33)


## Summary by Sourcery

Chores:
- Update the changelog in preparation for the release of version 1.10.1.