### PR TITLE
Fix audb.available() for S3 / Minio backends

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -81,9 +81,11 @@ def available(
                     # Avoid `ls(recursive=True)` for S3 and MinIO
                     # as this is slow for large databases
                     for obj in backend._client.list_objects(repository.name):
-                        name = obj.object_name
+                        name = obj.object_name[:-1]  # remove "/" at end
                         header_file = f"/{name}/{define.HEADER_FILE}"
-                        for _obj in backend._client.list_objects(repository.name, name):
+                        for _obj in backend._client.list_objects(
+                            repository.name, f"{name}/"
+                        ):
                             version = _obj.object_name.split("/")[1]
                             header_file = f"/{name}/{version}/{define.HEADER_FILE}"
                             if version not in [


### PR DESCRIPTION
This fixes the code introduced in https://github.com/audeering/audb/pull/458 for S3/Minio backends and `audb.available()`.

We still cannot add a test for it, this will be done later when we are ready for https://github.com/audeering/audb/pull/450.