### PR TITLE
Add 24000 Hz as supported sampling rate

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -332,7 +332,7 @@ def exists(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
 
@@ -416,7 +416,7 @@ def flavor_path(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
 
     Returns:
         flavor path relative to cache folder

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -91,7 +91,7 @@ class Format:
 
 FORMATS = [Format.WAV, Format.FLAC]
 BIT_DEPTHS = [16, 24, 32]
-SAMPLING_RATES = [8000, 16000, 22500, 44100, 48000]
+SAMPLING_RATES = [8000, 16000, 22500, 24000, 44100, 48000]
 
 # Progress bar
 MAXIMUM_REFRESH_TIME = 1  # force progress bar to update every second

--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -41,7 +41,7 @@ class Flavor(audobject.Object):
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down on selection
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
 
     Raises:
         ValueError: if a non-supported ``bit_depth``,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1458,7 +1458,6 @@ def load_header_to(
     local_header = os.path.join(db_root, define.HEADER_FILE)
     if overwrite or not os.path.exists(local_header):
         backend_interface = lookup_backend(name, version)
-        print(f"jetzt backend interface in load_header_to: {backend_interface}")
         remote_header = backend_interface.join("/", name, define.HEADER_FILE)
         if add_audb_meta:
             db_root_tmp = database_tmp_root(db_root)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1057,7 +1057,7 @@ def load(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
         attachments: load only attachment files
             for the attachments
             matching the regular expression
@@ -1458,6 +1458,7 @@ def load_header_to(
     local_header = os.path.join(db_root, define.HEADER_FILE)
     if overwrite or not os.path.exists(local_header):
         backend_interface = lookup_backend(name, version)
+        print(f"jetzt backend interface in load_header_to: {backend_interface}")
         remote_header = backend_interface.join("/", name, define.HEADER_FILE)
         if add_audb_meta:
             db_root_tmp = database_tmp_root(db_root)
@@ -1521,7 +1522,7 @@ def load_media(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
         num_workers: number of parallel jobs or 1 for sequential

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -481,7 +481,7 @@ def stream(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
         full_path: replace relative with absolute file paths
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -140,6 +140,7 @@ The following properties can be changed.
       - 8000
       - 16000
       - 22500
+      - 24000
       - 44100
       - 48000
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -226,7 +226,7 @@ def test_mixdown(db_root, mixdown):
 
 @pytest.mark.parametrize(
     "sampling_rate",
-    [None, 16000],
+    [None, 16000, 24000],
 )
 def test_sampling_rate(db_root, sampling_rate):
     db = audb.load(

--- a/tests/test_flavor.py
+++ b/tests/test_flavor.py
@@ -31,7 +31,7 @@ import audb
             None,
             audb.core.define.Format.WAV,
             True,
-            16000,
+            24000,
         ),
         pytest.param(
             0,


### PR DESCRIPTION
resolve #466

## Summary by Sourcery

Introduce support for 24000 Hz sampling rate across the codebase, update relevant documentation, and add corresponding test cases.

New Features:
- Add support for 24000 Hz sampling rate in various functions across the codebase.

Enhancements:
- Include a debug print statement in the load_header_to function to display the backend interface.

Documentation:
- Update documentation to reflect the addition of 24000 Hz as a supported sampling rate.

Tests:
- Add test cases for the new 24000 Hz sampling rate to ensure functionality.