### PR TITLE
TST: use sybil for doctests

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -36,6 +36,9 @@ def available(
         table with database name as index,
         and backend, host, repository, version as columns
 
+    ..
+        >>> import audb
+
     Examples:
         >>> df = audb.available(only_latest=True)
         >>> df.loc[["air", "emodb"]]
@@ -162,7 +165,7 @@ def cached(
         ...     full_path=False,
         ...     verbose=False,
         ... )
-        >>> df = cached()
+        >>> df = audb.cached()
         >>> print(df.iloc[0].to_string())
         name                emodb
         flavor_id        d3b62a9b
@@ -271,7 +274,7 @@ def dependencies(
         dependency object
 
     Examples:
-        >>> deps = dependencies("emodb", version="1.4.1")
+        >>> deps = audb.dependencies("emodb", version="1.4.1")
         >>> deps.version("db.emotion.csv")
         '1.1.0'
 
@@ -428,7 +431,7 @@ def flavor_path(
             is requested
 
     Examples:
-        >>> flavor_path("emodb", version="1.4.1").split(os.path.sep)
+        >>> audb.flavor_path("emodb", version="1.4.1").split(os.path.sep)
         ['emodb', '1.4.1', 'd3b62a9b']
 
     """
@@ -458,7 +461,7 @@ def latest_version(
         RuntimeError: if no version exists for the requested database
 
     Examples:
-        >>> latest_version("emodb")
+        >>> audb.latest_version("emodb")
         '1.4.1'
 
     """
@@ -589,7 +592,7 @@ def versions(
         list of versions
 
     Examples:
-        >>> versions("emodb")
+        >>> audb.versions("emodb")
         ['1.1.0', '1.1.1', '1.2.0', '1.3.0', '1.4.0', '1.4.1']
 
     """

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -36,9 +36,6 @@ def available(
         table with database name as index,
         and backend, host, repository, version as columns
 
-    ..
-        >>> import audb
-
     Examples:
         >>> df = audb.available(only_latest=True)
         >>> df.loc[["air", "emodb"]]

--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -76,11 +76,14 @@ class config:
     The :ref:`caching <caching>` related configuration values
     can be overwritten by environment variables.
 
+    ..
+        >>> import audb
+
     Examples:
-        >>> config.CACHE_ROOT
+        >>> audb.config.CACHE_ROOT
         '~/audb'
-        >>> config.CACHE_ROOT = "~/caches/audb"
-        >>> config.CACHE_ROOT
+        >>> audb.config.CACHE_ROOT = "~/caches/audb"
+        >>> audb.config.CACHE_ROOT
         '~/caches/audb'
 
     """

--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -76,9 +76,6 @@ class config:
     The :ref:`caching <caching>` related configuration values
     can be overwritten by environment variables.
 
-    ..
-        >>> import audb
-
     Examples:
         >>> audb.config.CACHE_ROOT
         '~/audb'

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -9,15 +9,9 @@ from sybil.parsers.rest import DocTestParser
 import audb
 
 
-# Collect doctests
-pytest_collect_file = sybil.Sybil(
-    parsers=[DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE)],
-    patterns=["*.py"],
-    fixtures=[
-        "cache",
-        "public_repository",
-    ],
-).pytest()
+def imports(namespace):
+    """Provide Python modules to namespace."""
+    namespace["audb"] = audb
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -67,3 +61,15 @@ def public_repository():
 
     # Remove public repo
     audb.config.REPOSITORIES.pop()
+
+
+# Collect doctests
+pytest_collect_file = sybil.Sybil(
+    parsers=[DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE)],
+    patterns=["*.py"],
+    fixtures=[
+        "cache",
+        "public_repository",
+    ],
+    setup=imports,
+).pytest()

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -20,7 +20,7 @@ pytest_collect_file = sybil.Sybil(
 ).pytest()
 
 
-@pytest.fixture(scope="package", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def cache(tmpdir_factory):
     r"""Provide a reusable cache for docstring tests.
 

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -63,7 +63,7 @@ def public_repository():
         ),
     ]
 
-    yield audb
+    yield
 
     # Remove public repo
     audb.config.REPOSITORIES.pop()

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -1,8 +1,23 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
 import os
 
 import pytest
+import sybil
+from sybil.parsers.rest import DocTestParser
 
 import audb
+
+
+# Collect doctests
+pytest_collect_file = sybil.Sybil(
+    parsers=[DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE)],
+    patterns=["*.py"],
+    fixtures=[
+        "cache",
+        "public_repository",
+    ],
+).pytest()
 
 
 @pytest.fixture(scope="package", autouse=True)
@@ -38,20 +53,8 @@ def cache(tmpdir_factory):
 
 
 @pytest.fixture(autouse=True)
-def public_repository(doctest_namespace):
-    r"""Provide access to the public Artifactory repository.
-
-    Some tests in the docstrings need access to the emodb database.
-    As all the unit tests defined under ``tests/*``
-    should not be able to see the public repository
-    as the number of available databases would then not be deterministic.
-    We provide this access here
-    with the help of the ``doctest_namespace`` fixture.
-
-    The ``conftest.py`` file has to be in the same folder
-    as the code file where the docstring is defined.
-
-    """
+def public_repository():
+    r"""Provide access to the public Artifactory repository."""
     audb.config.REPOSITORIES = [
         audb.Repository(
             name="data-public",
@@ -59,9 +62,8 @@ def public_repository(doctest_namespace):
             backend="artifactory",
         ),
     ]
-    doctest_namespace["audb"] = audb
 
-    yield
+    yield audb
 
     # Remove public repo
     audb.config.REPOSITORIES.pop()

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -33,8 +33,11 @@ class Dependencies:
     The dependencies of a database can be requested with
     :func:`audb.dependencies`.
 
+    ..
+        >>> import audb
+
     Examples:
-        >>> deps = Dependencies()
+        >>> deps = audb.Dependencies()
         >>> deps()
         Empty DataFrame
         Columns: [archive, bit_depth, channels, checksum, duration, format, removed, sampling_rate, type, version]

--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -33,9 +33,6 @@ class Dependencies:
     The dependencies of a database can be requested with
     :func:`audb.dependencies`.
 
-    ..
-        >>> import audb
-
     Examples:
         >>> deps = audb.Dependencies()
         >>> deps()

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -28,8 +28,11 @@ def attachments(
     Returns:
         attachments of database
 
+    ..
+        >>> import audb
+
     Examples:
-        >>> list(attachments("emodb", version="1.4.1"))
+        >>> list(audb.info.attachments("emodb", version="1.4.1"))
         ['bibtex']
 
     """
@@ -60,7 +63,7 @@ def author(
         author(s) of database
 
     Examples:
-        >>> author("emodb", version="1.4.1")
+        >>> audb.info.author("emodb", version="1.4.1")
         'Felix Burkhardt, Astrid Paeschke, Miriam Rolfes, Walter Sendlmeier, Benjamin Weiss'
 
     """  # noqa: E501
@@ -101,7 +104,7 @@ def bit_depths(
             that is not part of the database
 
     Examples:
-        >>> bit_depths("emodb", version="1.4.1")
+        >>> audb.info.bit_depths("emodb", version="1.4.1")
         {16}
 
     """
@@ -137,7 +140,7 @@ def channels(
             that is not part of the database
 
     Examples:
-        >>> channels("emodb", version="1.4.1")
+        >>> audb.info.channels("emodb", version="1.4.1")
         {1}
 
     """
@@ -163,7 +166,7 @@ def description(
         description of database
 
     Examples:
-        >>> desc = description("emodb", version="1.4.1")
+        >>> desc = audb.info.description("emodb", version="1.4.1")
         >>> desc.split(".")[0]  # show first sentence
         'Berlin Database of Emotional Speech'
 
@@ -205,9 +208,9 @@ def duration(
             that is not part of the database
 
     Examples:
-        >>> duration("emodb", version="1.4.1")
+        >>> audb.info.duration("emodb", version="1.4.1")
         Timedelta('0 days 00:24:47.092187500')
-        >>> duration("emodb", version="1.4.1", media=["wav/03a01Fa.wav"])
+        >>> audb.info.duration("emodb", version="1.4.1", media=["wav/03a01Fa.wav"])
         Timedelta('0 days 00:00:01.898250')
 
     """
@@ -236,7 +239,7 @@ def files(
         media files
 
     Examples:
-        >>> files("emodb", version="1.4.1")[:2]
+        >>> audb.info.files("emodb", version="1.4.1")[:2]
         ['wav/03a01Fa.wav', 'wav/03a01Nc.wav']
 
     """
@@ -272,7 +275,7 @@ def formats(
             that is not part of the database
 
     Examples:
-        >>> formats("emodb", version="1.4.1")
+        >>> audb.info.formats("emodb", version="1.4.1")
         {'wav'}
 
     """
@@ -302,7 +305,7 @@ def header(
         database object without table data
 
     Examples:
-        >>> db = header("emodb", version="1.4.1")
+        >>> db = audb.info.header("emodb", version="1.4.1")
         >>> db.name
         'emodb'
 
@@ -340,7 +343,7 @@ def languages(
         languages of database
 
     Examples:
-        >>> languages("emodb", version="1.4.1")
+        >>> audb.info.languages("emodb", version="1.4.1")
         ['deu']
 
     """
@@ -371,7 +374,7 @@ def license(
         license of database
 
     Examples:
-        >>> license("emodb", version="1.4.1")
+        >>> audb.info.license("emodb", version="1.4.1")
         'CC0-1.0'
 
     """
@@ -402,7 +405,7 @@ def license_url(
         license URL of database
 
     Examples:
-        >>> license_url("emodb", version="1.4.1")
+        >>> audb.info.license_url("emodb", version="1.4.1")
         'https://creativecommons.org/publicdomain/zero/1.0/'
 
     """
@@ -433,7 +436,7 @@ def media(
         media of database
 
     Examples:
-        >>> media("emodb", version="1.4.1")
+        >>> audb.info.media("emodb", version="1.4.1")
         microphone:
             {type: other, format: wav, channels: 1, sampling_rate: 16000}
 
@@ -465,7 +468,7 @@ def meta(
         meta information of database
 
     Examples:
-        >>> meta("emodb", version="1.4.1")
+        >>> audb.info.meta("emodb", version="1.4.1")
         pdf:
           http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.130.8506&rep=rep1&type=pdf
 
@@ -497,7 +500,7 @@ def misc_tables(
         miscellaneous tables of database
 
     Examples:
-        >>> list(misc_tables("emodb", version="1.4.1"))
+        >>> list(audb.info.misc_tables("emodb", version="1.4.1"))
         ['speaker']
 
     """  # noqa: E501
@@ -528,7 +531,7 @@ def organization(
         organization responsible for database
 
     Examples:
-        >>> organization("emodb", version="1.4.1")
+        >>> audb.info.organization("emodb", version="1.4.1")
         'audEERING'
 
     """
@@ -559,7 +562,7 @@ def raters(
         raters of database
 
     Examples:
-        >>> raters("emodb", version="1.4.1")
+        >>> audb.info.raters("emodb", version="1.4.1")
         gold:
             {type: human}
 
@@ -601,7 +604,7 @@ def sampling_rates(
             that is not part of the database
 
     Examples:
-        >>> sampling_rates("emodb", version="1.4.1")
+        >>> audb.info.sampling_rates("emodb", version="1.4.1")
         {16000}
 
     """
@@ -631,7 +634,7 @@ def schemes(
         schemes of database
 
     Examples:
-        >>> list(schemes("emodb", version="1.4.1"))
+        >>> list(audb.info.schemes("emodb", version="1.4.1"))
         ['age', 'confidence', 'duration', 'emotion', 'gender', 'language', 'speaker', 'transcription']
 
     """  # noqa: E501
@@ -662,7 +665,7 @@ def source(
         source of database
 
     Examples:
-        >>> source("emodb", version="1.4.1")
+        >>> audb.info.source("emodb", version="1.4.1")
         'http://emodb.bilderbar.info/download/download.zip'
 
     """
@@ -693,7 +696,7 @@ def splits(
         splits of database
 
     Examples:
-        >>> splits("emodb", version="1.4.1")
+        >>> audb.info.splits("emodb", version="1.4.1")
         test:
           {description: Unofficial speaker-independent test split, type: test}
         train:
@@ -727,7 +730,7 @@ def tables(
         tables of database
 
     Examples:
-        >>> list(tables("emodb", version="1.4.1"))
+        >>> list(audb.info.tables("emodb", version="1.4.1"))
         ['emotion', 'emotion.categories.test.gold_standard', 'emotion.categories.train.gold_standard', 'files']
 
     """  # noqa: E501
@@ -758,7 +761,7 @@ def usage(
         usage of database
 
     Examples:
-        >>> usage("emodb", version="1.4.1")
+        >>> audb.info.usage("emodb", version="1.4.1")
         'unrestricted'
 
     """

--- a/audb/core/info.py
+++ b/audb/core/info.py
@@ -28,9 +28,6 @@ def attachments(
     Returns:
         attachments of database
 
-    ..
-        >>> import audb
-
     Examples:
         >>> list(audb.info.attachments("emodb", version="1.4.1"))
         ['bibtex']

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1116,6 +1116,9 @@ def load(
             that don't contain audio,
             e.g. text files
 
+    ..
+        >>> import audb
+
     Examples:
         >>> db = audb.load(
         ...     "emodb",
@@ -1328,7 +1331,7 @@ def load_attachment(
             that is not part of the database
 
     Examples:
-        >>> paths = load_attachment(
+        >>> paths = audb.load_attachment(
         ...     "emodb",
         ...     "bibtex",
         ...     version="1.4.1",
@@ -1545,7 +1548,7 @@ def load_media(
             is requested
 
     Examples:
-        >>> paths = load_media(
+        >>> paths = audb.load_media(
         ...     "emodb",
         ...     ["wav/03a01Fa.wav"],
         ...     version="1.4.1",
@@ -1694,21 +1697,21 @@ def load_table(
             that is not part of the database
 
     Examples:
-        >>> df = load_table("emodb", "emotion", version="1.4.1", verbose=False)
+        >>> df = audb.load_table("emodb", "emotion", version="1.4.1", verbose=False)
         >>> df[:3]
                            emotion  emotion.confidence
         file
         wav/03a01Fa.wav  happiness                0.90
         wav/03a01Nc.wav    neutral                1.00
         wav/03a01Wa.wav      anger                0.95
-        >>> df = load_table("emodb", "files", version="1.4.1", verbose=False)
+        >>> df = audb.load_table("emodb", "files", version="1.4.1", verbose=False)
         >>> df[:3]
                                          duration speaker transcription
         file
         wav/03a01Fa.wav    0 days 00:00:01.898250       3           a01
         wav/03a01Nc.wav    0 days 00:00:01.611250       3           a01
         wav/03a01Wa.wav 0 days 00:00:01.877812500       3           a01
-        >>> df = load_table(
+        >>> df = audb.load_table(
         ...     "emodb",
         ...     "files",
         ...     version="1.4.1",

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1116,9 +1116,6 @@ def load(
             that don't contain audio,
             e.g. text files
 
-    ..
-        >>> import audb
-
     Examples:
         >>> db = audb.load(
         ...     "emodb",

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -146,9 +146,12 @@ class Repository:
                 that should be associated with ``backend_name``,
                 e.g. ``"audbackend.backend.Filesystem"``
 
+        ..
+            >>> import audb
+
         Examples:
             >>> import audbackend
-            >>> Repository.register("file-system", audbackend.backend.FileSystem)
+            >>> audb.Repository.register("file-system", audbackend.backend.FileSystem)
 
         """
         cls.backend_registry[backend_name] = backend_class

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -146,9 +146,6 @@ class Repository:
                 that should be associated with ``backend_name``,
                 e.g. ``"audbackend.backend.Filesystem"``
 
-        ..
-            >>> import audb
-
         Examples:
             >>> import audbackend
             >>> audb.Repository.register("file-system", audbackend.backend.FileSystem)

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -30,6 +30,9 @@ class DatabaseIterator(audformat.Database, metaclass=abc.ABCMeta):
     This class cannot be created directly,
     but only by calling :func:`audb.stream`.
 
+    ..
+        >>> import audb
+
     Examples:
         Create :class:`audb.DatabaseIterator` object.
 

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -30,9 +30,6 @@ class DatabaseIterator(audformat.Database, metaclass=abc.ABCMeta):
     This class cannot be created directly,
     but only by calling :func:`audb.stream`.
 
-    ..
-        >>> import audb
-
     Examples:
         Create :class:`audb.DatabaseIterator` object.
 

--- a/docs/api-src/audb.info.rst
+++ b/docs/api-src/audb.info.rst
@@ -1,8 +1,3 @@
-.. Pre-load data without being verbose
-..
-   >>> import audb
-
-
 audb.info
 ==========
 

--- a/docs/api-src/audb.info.rst
+++ b/docs/api-src/audb.info.rst
@@ -1,30 +1,7 @@
-.. Specify repository to overwrite local config files
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audb
-
-    audb.config.REPOSITORIES = [
-        audb.Repository(
-            name="data-public",
-            host="https://audeering.jfrog.io/artifactory",
-            backend="artifactory",
-        )
-    ]
-
 .. Pre-load data without being verbose
-.. jupyter-execute::
-    :stderr:
-    :hide-code:
-    :hide-output:
-
-    audb.load(
-        "emodb",
-        version="1.4.1",
-        only_metadata=True,
-        verbose=False,
-    )
+..
+   >>> import audb
+   >>> db = audb.load("emodb", version="1.4.1", only_metadata=True, verbose=False)
 
 
 audb.info
@@ -39,24 +16,59 @@ provide you direct access to this information.
 
 So instead of running:
 
-.. jupyter-execute::
+>>> db = audb.load("emodb", version="1.4.1", only_metadata=True, verbose=False)
+>>> db.tables
+emotion:
+  type: filewise
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.test.gold_standard:
+  type: filewise
+  split_id: test
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.train.gold_standard:
+  type: filewise
+  split_id: train
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+files:
+  type: filewise
+  columns:
+    duration: {scheme_id: duration}
+    speaker: {scheme_id: speaker}
+    transcription: {scheme_id: transcription}
 
-    db = audb.load(
-        "emodb",
-        version="1.4.1",
-        only_metadata=True,
-        verbose=False,
-    )
-    db.tables
 
 You can run:
 
-.. jupyter-execute::
-
-    audb.info.tables(
-        "emodb",
-        version="1.4.1",
-    )
+>>> audb.info.tables("emodb", version="1.4.1")
+emotion:
+  type: filewise
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.test.gold_standard:
+  type: filewise
+  split_id: test
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.train.gold_standard:
+  type: filewise
+  split_id: train
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+files:
+  type: filewise
+  columns:
+    duration: {scheme_id: duration}
+    speaker: {scheme_id: speaker}
+    transcription: {scheme_id: transcription}
 
 
 .. automodule:: audb.info

--- a/docs/api-src/audb.info.rst
+++ b/docs/api-src/audb.info.rst
@@ -1,7 +1,6 @@
 .. Pre-load data without being verbose
 ..
    >>> import audb
-   >>> db = audb.load("emodb", version="1.4.1", only_metadata=True, verbose=False)
 
 
 audb.info

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -91,4 +91,5 @@ Note,
 2. overwrites 3. and 4.,
 and so on.
 
+
 .. _adjust the rights: https://superuser.com/a/264406

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -1,6 +1,3 @@
-..
-    >>> import audb
-
 .. _caching:
 
 Caching

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -1,6 +1,6 @@
-.. _caching:
-
 .. skip: start
+
+.. _caching:
 
 Caching
 =======

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -1,12 +1,6 @@
-.. Import audb
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audb
-
-
 .. _caching:
+
+.. skip: start
 
 Caching
 =======
@@ -26,9 +20,8 @@ Shared cache
 
 By default the shared cache is located at
 
-.. jupyter-execute::
-
-    audb.default_cache_root(shared=True)
+>>> audb.default_cache_root(shared=True)
+'/data/audb'
 
 and is meant to be shared by several users.
 
@@ -52,9 +45,8 @@ The second cache folder should be
 accessible to you only.
 By default it points to
 
-.. jupyter-execute::
-
-    audb.default_cache_root(shared=False)
+>>> audb.default_cache_root(shared=False)
+'/home/.../audb'
 
 When you request a database with :meth:`audb.load`,
 :mod:`audb` first looks for it in the shared cache folder
@@ -68,9 +60,7 @@ There are four ways to change the default locations:
 
 1. By setting the argument ``cache_root`` during a function call, e.g.
 
-.. code-block:: python
-
-    audb.load("emodb", ..., cache_root="/cache/root/audb")
+>>> db = audb.load("emodb", ..., cache_root="/cache/root/audb")
 
 2. System-wide by setting the following system variables
 
@@ -81,15 +71,13 @@ There are four ways to change the default locations:
 
 3. Program-wide by overwriting the default values in :class:`audb.config`
 
-.. jupyter-execute::
+>>> audb.config.SHARED_CACHE_ROOT = "/new/shared/cache/audb"
+>>> audb.default_cache_root(shared=True)
+'/new/shared/cache/audb'
 
-    audb.config.SHARED_CACHE_ROOT = "/new/shared/cache/audb"
-    audb.default_cache_root(shared=True)
-
-.. jupyter-execute::
-
-    audb.config.CACHE_ROOT = "/new/local/cache/audb"
-    audb.default_cache_root(shared=False)
+>>> audb.config.CACHE_ROOT = "/new/local/cache/audb"
+>>> audb.default_cache_root(shared=False)
+'/new/local/cache/audb'
 
 4. System wide by
    using the :ref:`configuration file <configuration>`
@@ -100,5 +88,6 @@ Note,
 2. overwrites 3. and 4.,
 and so on.
 
+.. skip: end
 
 .. _adjust the rights: https://superuser.com/a/264406

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -1,4 +1,5 @@
-.. skip: start
+..
+    >>> import audb
 
 .. _caching:
 
@@ -60,6 +61,8 @@ There are four ways to change the default locations:
 
 1. By setting the argument ``cache_root`` during a function call, e.g.
 
+.. skip: next
+
 >>> db = audb.load("emodb", ..., cache_root="/cache/root/audb")
 
 2. System-wide by setting the following system variables
@@ -87,7 +90,5 @@ Note,
 1. overwrites all other methods,
 2. overwrites 3. and 4.,
 and so on.
-
-.. skip: end
 
 .. _adjust the rights: https://superuser.com/a/264406

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
-    "jupyter_sphinx",
     "sphinx_apipages",
 ]
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,4 +1,5 @@
-.. skip: start
+..
+    >>> import audb
 
 .. _configuration:
 
@@ -29,5 +30,5 @@ using :class:`audb.config`.
  Repository('data-local', '~/audb-host', 'file-system')]
 
 >>> audb.config.CACHE_ROOT = "/user/cache"
-
-.. skip: end
+>>> audb.config.CACHE_ROOT
+'/user/cache'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,6 @@
-.. _configuration:
-
 .. skip: start
+
+.. _configuration:
 
 Configuration
 -------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,12 +1,6 @@
-.. Import audb
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audb
-
-
 .. _configuration:
+
+.. skip: start
 
 Configuration
 -------------
@@ -24,19 +18,16 @@ they can be accessed
 or changed
 using :class:`audb.config`.
 
-.. jupyter-execute::
+>>> audb.config.CACHE_ROOT
+'~/audb'
 
-    audb.config.CACHE_ROOT
+>>> audb.config.SHARED_CACHE_ROOT
+'/data/audb'
 
-.. jupyter-execute::
+>>> audb.config.REPOSITORIES
+[Repository('data-public', 'https://audeering.jfrog.io/artifactory', 'artifactory'),
+ Repository('data-local', '~/audb-host', 'file-system')]
 
-    audb.config.SHARED_CACHE_ROOT
+>>> audb.config.CACHE_ROOT = "/user/cache"
 
-.. jupyter-execute::
-
-    audb.config.REPOSITORIES
-
-.. jupyter-execute::
-
-    audb.config.CACHE_ROOT = "/user/cache"
-    audb.config.CACHE_ROOT
+.. skip: end

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,3 @@
-..
-    >>> import audb
-
 .. _configuration:
 
 Configuration

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,10 +1,3 @@
-.. Specify pandas format output in cells
-.. invisible-code-block: python
-
-    import pandas as pd
-
-    # pd.set_option("display.max_columns", 7)
-
 ..
     >>> import audb
 
@@ -88,6 +81,7 @@ of the first ten files in the *emotion* table
 of the emodb database.
 
 >>> import numpy as np
+>>> import pandas as pd
 >>> df = audb.load_table("emodb", "emotion", version="1.4.1", verbose=False)
 >>> files = df.index[:10]
 >>> duration_in_sec = np.sum([deps.duration(f) for f in files])

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,27 +1,12 @@
-.. Specify repository to overwrite local config files
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audb
-
-    audb.config.REPOSITORIES = [
-        audb.Repository(
-            name="data-public",
-            host="https://audeering.jfrog.io/artifactory",
-            backend="artifactory",
-        )
-    ]
-
 .. Specify pandas format output in cells
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
+.. invisible-code-block: python
 
     import pandas as pd
 
-    pd.set_option("display.max_columns", 7)
+    # pd.set_option("display.max_columns", 7)
 
+..
+    >>> import audb
 
 .. _database-dependencies:
 
@@ -43,22 +28,25 @@ for every version of a database.
 You request a :class:`audb.Dependencies` object with
 :func:`audb.dependencies`.
 
-.. jupyter-execute::
-
-    deps = audb.dependencies("emodb", version="1.4.1")
+>>> deps = audb.dependencies("emodb", version="1.4.1")
 
 You can see all entries by calling the returned object.
 
-.. jupyter-execute::
-
-    df = deps()
-    df.head()
+>>> df = deps()
+>>> df.head()
+                                              archive  bit_depth  ...  type version
+db.emotion.csv                                emotion          0  ...     0   1.1.0
+db.files.csv                                    files          0  ...     0   1.1.0
+wav/03a01Fa.wav  c1f5cc6f-6d00-348a-ba3b-4adaa2436aad         16  ...     1   1.1.0
+wav/03a01Nc.wav  d40b53dd-8f0d-d5d3-42e7-8ad7ea6a05a6         16  ...     1   1.1.0
+wav/03a01Wa.wav  9b62bc9b-a68e-7e38-6ed1-f4a16ac18511         16  ...     1   1.1.0
+<BLANKLINE>
+[5 rows x 10 columns]
 
 You can also use it to request certain aspects, e.g.
 
-.. jupyter-execute::
-
-    deps.duration("wav/03a01Fa.wav")
+>>> deps.duration("wav/03a01Fa.wav")
+1.89825
 
 See :class:`audb.Dependencies` for all available methods.
 
@@ -70,18 +58,26 @@ If your database contains only WAV or FLAC files,
 we store the duration in seconds of every file
 in the database dependency table.
 
-.. jupyter-execute::
-
-    deps = audb.dependencies("emodb", version="1.4.1")
-    df = deps()
-    df.duration[:10]
+>>> deps = audb.dependencies("emodb", version="1.4.1")
+>>> df = deps()
+>>> df.duration[:10]
+db.emotion.csv          0.0
+db.files.csv            0.0
+wav/03a01Fa.wav     1.89825
+wav/03a01Nc.wav     1.61125
+wav/03a01Wa.wav    1.877813
+wav/03a02Fc.wav     2.00625
+wav/03a02Nc.wav    1.439812
+wav/03a02Ta.wav    1.735688
+wav/03a02Wb.wav    2.123625
+wav/03a02Wc.wav    1.498063
+Name: duration, dtype: double[pyarrow]
 
 For those databases
 you can get their overall duration with:
 
-.. jupyter-execute::
-
-    audb.info.duration("emodb", version="1.4.1")
+>>> audb.info.duration("emodb", version="1.4.1")
+Timedelta('0 days 00:24:47.092187500')
 
 The duration of parts of a database
 can be calculated
@@ -91,14 +87,12 @@ The following calculates the duration
 of the first ten files in the *emotion* table
 of the emodb database.
 
-.. jupyter-execute::
-
-    import numpy as np
-
-    df = audb.load_table("emodb", "emotion", version="1.4.1", verbose=False)
-    files = df.index[:10]
-    duration_in_sec = np.sum([deps.duration(f) for f in files])
-    pd.to_timedelta(duration_in_sec, unit="s")
+>>> import numpy as np
+>>> df = audb.load_table("emodb", "emotion", version="1.4.1", verbose=False)
+>>> files = df.index[:10]
+>>> duration_in_sec = np.sum([deps.duration(f) for f in files])
+>>> pd.to_timedelta(duration_in_sec, unit="s")
+Timedelta('0 days 00:00:17.392437500')
 
 If your table is a segmented table,
 and you would like to get the duration
@@ -108,17 +102,16 @@ you can use :func:`audformat.utils.duration`,
 which calculates the duration
 from the ``start`` and ``end`` entries.
 
-.. code-block:: python
-
-    df = audb.load_table("database-with-segmented-tables", "segmented-table")
-    audformat.utils.duration(df.dropna())
+>>> import audformat
+>>> df = audb.load_table("vadtoolkit", "segments", version="1.1.0", verbose=False)
+>>> audformat.utils.duration(df.dropna())
+Timedelta('0 days 00:37:17.037467')
 
 Or you can count the duration of all segments within your database.
 
-.. code-block:: python
-
-    db = audb.load("database-with-segmented-tables", only_metadata=True)
-    audformat.utils.duration(db.segments)
+>>> db = audb.load("vadtoolkit", version="1.1.0", only_metadata=True, verbose=False)
+>>> audformat.utils.duration(db.segments)
+Timedelta('0 days 00:37:17.037467')
 
 If your database contains files
 for which no duration information is stored
@@ -128,7 +121,9 @@ you have to download the database first
 and use :func:`audformat.utils.duration`
 to calculate the duration on the fly.
 
-.. code-block:: python
+.. skip: start
 
-    db = audb.load("database-with-videos")
-    audformat.utils.duration(db.files, num_workers=4)
+>>> db = audb.load("database-with-videos")
+>>> audformat.utils.duration(db.files, num_workers=4)
+
+.. skip: end

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,6 +1,3 @@
-..
-    >>> import audb
-
 .. _database-dependencies:
 
 Database dependencies

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -1,40 +1,5 @@
-.. Specify repository to overwrite local config files
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audb
-
-    audb.config.REPOSITORIES = [
-        audb.Repository(
-            name="data-public",
-            host="https://audeering.jfrog.io/artifactory",
-            backend="artifactory",
-        )
-    ]
-
-.. Specify pandas format output in cells
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import pandas as pd
-
-
-    def series_to_html(self):
-        df = self.to_frame()
-        df.columns = [""]
-        return df._repr_html_()
-
-
-    def index_to_html(self):
-        return self.to_frame(index=False)._repr_html_()
-
-
-    setattr(pd.Series, "_repr_html_", series_to_html)
-    setattr(pd.Index, "_repr_html_", index_to_html)
-    pd.set_option("display.max_rows", 6)
-
+..
+    >>> import audb
 
 .. _load:
 
@@ -51,23 +16,20 @@ but it will ensure your code returns the same data,
 even if a new version of the database is published.
 
 .. Prefetch data with only_metadata=True
-.. jupyter-execute::
-    :hide-code:
+.. invisible-code-block: python
 
     db = audb.load(
         "emodb",
         version="1.4.1",
         only_metadata=True,
+        full_path=False,
         verbose=False,
     )
 
-.. code-block:: python
+.. skip: next
 
-    db = audb.load(
-        "emodb",
-        version="1.4.1",
-        verbose=False,
-    )
+>>> db = audb.load("emodb", version="1.4.1", full_path=False, verbose=False)
+
 
 :func:`audb.load` will download the data,
 store them in a cache folder,
@@ -75,22 +37,67 @@ and return the database as an :class:`audformat.Database` object.
 The most important content of that object
 are the database tables.
 
-.. jupyter-execute::
-
-    db.tables
+>>> db.tables
+emotion:
+  type: filewise
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.test.gold_standard:
+  type: filewise
+  split_id: test
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.train.gold_standard:
+  type: filewise
+  split_id: train
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+files:
+  type: filewise
+  columns:
+    duration: {scheme_id: duration}
+    speaker: {scheme_id: speaker}
+    transcription: {scheme_id: transcription}
 
 They contain the annotations of the database,
 and can be requested as a :class:`pandas.DataFrame`.
 
-.. jupyter-execute::
-
-    db["emotion"].get()
+>>> db["emotion"].get()
+                   emotion  emotion.confidence
+file
+wav/03a01Fa.wav  happiness                0.90
+wav/03a01Nc.wav    neutral                1.00
+wav/03a01Wa.wav      anger                0.95
+wav/03a02Fc.wav  happiness                0.85
+wav/03a02Nc.wav    neutral                1.00
+...                    ...                 ...
+wav/16b10Lb.wav    boredom                1.00
+wav/16b10Tb.wav    sadness                0.90
+wav/16b10Td.wav    sadness                0.95
+wav/16b10Wa.wav      anger                1.00
+wav/16b10Wb.wav      anger                1.00
+<BLANKLINE>
+[535 rows x 2 columns]
 
 Or you can directly request single columns as :class:`pandas.Series`.
 
-.. jupyter-execute::
-
-    db["files"]["duration"].get()
+>>> db["files"]["duration"].get()
+file
+wav/03a01Fa.wav      0 days 00:00:01.898250
+wav/03a01Nc.wav      0 days 00:00:01.611250
+wav/03a01Wa.wav   0 days 00:00:01.877812500
+wav/03a02Fc.wav      0 days 00:00:02.006250
+wav/03a02Nc.wav   0 days 00:00:01.439812500
+                            ...
+wav/16b10Lb.wav   0 days 00:00:03.442687500
+wav/16b10Tb.wav      0 days 00:00:03.500625
+wav/16b10Td.wav   0 days 00:00:03.934187500
+wav/16b10Wa.wav      0 days 00:00:02.414125
+wav/16b10Wb.wav   0 days 00:00:02.522499999
+Name: duration, Length: 535, dtype: timedelta64[ns]
 
 As you can see the index of the returned object
 holds the path to the corresponding media files.
@@ -150,8 +157,7 @@ For each flavor a sub-folder will be created
 inside the :ref:`cache <caching>`.
 
 .. Prefetch data with only_metadata=True
-.. jupyter-execute::
-    :hide-code:
+.. invisible-code-block: python
 
     db = audb.load(
         "emodb",
@@ -161,6 +167,8 @@ inside the :ref:`cache <caching>`.
         only_metadata=True,
         verbose=False,
     )
+
+.. skip: start
 
 .. code-block:: python
 
@@ -172,19 +180,26 @@ inside the :ref:`cache <caching>`.
         verbose=False,
     )
 
+.. skip: end
+
 The flavor information of a database is stored
 inside the ``db.meta["audb"]`` dictionary.
 
-.. jupyter-execute::
-
-    db.meta["audb"]["flavor"]
+>>> db.meta["audb"]["flavor"]
+{'bit_depth': None,
+ 'channels': None,
+ 'format': 'flac',
+ 'mixdown': False,
+ 'sampling_rate': 44100}
 
 You can list all available flavors and their locations in the cache with:
 
-.. jupyter-execute::
-
-    df = audb.cached()
-    df[["name", "version", "complete", "format", "sampling_rate"]]
+>>> df = audb.cached()
+>>> df.reset_index()[["name", "version", "complete", "format", "sampling_rate"]]
+         name version  complete format sampling_rate
+0       emodb   1.4.1     False   flac         44100
+1       emodb   1.4.1     False   None          None
+2  vadtoolkit   1.1.0     False   None          None
 
 The entry ``"complete"`` tells you if a database flavor is completely cached,
 or if some table or media files are still missing.
@@ -201,14 +216,7 @@ of a database.
 In that case media files are not loaded,
 but all the tables and the header.
 
-.. jupyter-execute::
-
-    db = audb.load(
-        "emodb",
-        version="1.4.1",
-        only_metadata=True,
-        verbose=False,
-    )
+>>> db = audb.load("emodb", version="1.4.1", only_metadata=True, verbose=False)
 
 For databases with many annotations,
 this can still take some time.
@@ -219,21 +227,35 @@ in parts of the header,
 have a look at the :mod:`audb.info` module.
 It can list all table definitions.
 
-.. jupyter-execute::
-
-    audb.info.tables(
-        "emodb",
-        version="1.4.1",
-    )
+>>> audb.info.tables("emodb", version="1.4.1")
+emotion:
+  type: filewise
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.test.gold_standard:
+  type: filewise
+  split_id: test
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.train.gold_standard:
+  type: filewise
+  split_id: train
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+files:
+  type: filewise
+  columns:
+    duration: {scheme_id: duration}
+    speaker: {scheme_id: speaker}
+    transcription: {scheme_id: transcription}
 
 Or get the total duration of all media files.
 
-.. jupyter-execute::
-
-    audb.info.duration(
-        "emodb",
-        version="1.4.1",
-    )
+>>> audb.info.duration("emodb", version="1.4.1")
+Timedelta('0 days 00:24:47.092187500')
 
 See :mod:`audb.info` for a list of all available options.
 
@@ -258,7 +280,7 @@ we can do the following.
 First, we download the table with information
 about the speakers (here ``db["files"]``):
 
-.. jupyter-execute::
+.. code-block:: python
 
     db = audb.load(
         "emodb",
@@ -268,7 +290,14 @@ about the speakers (here ``db["files"]``):
         full_path=False,
         verbose=False,
     )
-    db.tables
+
+>>> db.tables
+files:
+  type: filewise
+  columns:
+    duration: {scheme_id: duration}
+    speaker: {scheme_id: speaker}
+    transcription: {scheme_id: transcription}
 
 Note,
 that we set ``only_metadata=True``
@@ -278,27 +307,55 @@ we further ensure that the paths
 in the table index are relative
 and therefore match the paths on the backend.
 
-.. jupyter-execute::
-
-    speaker = db["files"]["speaker"].get()
-    speaker
+>>> speaker = db["files"]["speaker"].get()
+>>> speaker
+file
+wav/03a01Fa.wav     3
+wav/03a01Nc.wav     3
+wav/03a01Wa.wav     3
+wav/03a02Fc.wav     3
+wav/03a02Nc.wav     3
+                   ..
+wav/16b10Lb.wav    16
+wav/16b10Tb.wav    16
+wav/16b10Td.wav    16
+wav/16b10Wa.wav    16
+wav/16b10Wb.wav    16
+Name: speaker, Length: 535, dtype: category
+Categories (10, int64): [3, 8, 9, 10, ..., 13, 14, 15, 16]
 
 Now, we use the column with speaker IDs
 to get a list of media files
 that belong to speaker 3.
 
-.. jupyter-execute::
 
-    media = db["files"].files[speaker == 3]
-    media
+>>> media = db["files"].files[speaker == 3]
+>>> media
+Index(['wav/03a01Fa.wav', 'wav/03a01Nc.wav', 'wav/03a01Wa.wav',
+       'wav/03a02Fc.wav', 'wav/03a02Nc.wav', 'wav/03a02Ta.wav',
+       'wav/03a02Wb.wav', 'wav/03a02Wc.wav', 'wav/03a04Ad.wav',
+       'wav/03a04Fd.wav', 'wav/03a04Lc.wav', 'wav/03a04Nc.wav',
+       'wav/03a04Ta.wav', 'wav/03a04Wc.wav', 'wav/03a05Aa.wav',
+       'wav/03a05Fc.wav', 'wav/03a05Nd.wav', 'wav/03a05Tc.wav',
+       'wav/03a05Wa.wav', 'wav/03a05Wb.wav', 'wav/03a07Fa.wav',
+       'wav/03a07Fb.wav', 'wav/03a07La.wav', 'wav/03a07Nc.wav',
+       'wav/03a07Wc.wav', 'wav/03b01Fa.wav', 'wav/03b01Lb.wav',
+       'wav/03b01Nb.wav', 'wav/03b01Td.wav', 'wav/03b01Wa.wav',
+       'wav/03b01Wc.wav', 'wav/03b02Aa.wav', 'wav/03b02La.wav',
+       'wav/03b02Na.wav', 'wav/03b02Tb.wav', 'wav/03b02Wb.wav',
+       'wav/03b03Nb.wav', 'wav/03b03Tc.wav', 'wav/03b03Wc.wav',
+       'wav/03b09La.wav', 'wav/03b09Nc.wav', 'wav/03b09Tc.wav',
+       'wav/03b09Wa.wav', 'wav/03b10Ab.wav', 'wav/03b10Ec.wav',
+       'wav/03b10Na.wav', 'wav/03b10Nc.wav', 'wav/03b10Wb.wav',
+       'wav/03b10Wc.wav'],
+      dtype='string', name='file')
 
 Finally, we load the database again
 and use the list to request
 only the data of this speaker.
 
 .. Prefetch data with only_metadata=True
-.. jupyter-execute::
-    :hide-code:
+.. invisible-code-block: python
 
     db = audb.load(
         "emodb",
@@ -308,6 +365,8 @@ only the data of this speaker.
         only_metadata=True,
         verbose=False,
     )
+
+.. skip: start
 
 .. code-block:: python
 
@@ -319,13 +378,20 @@ only the data of this speaker.
         verbose=False,
     )
 
+.. skip: end
+
 This will also remove
 entries of other speakers
 from the tables.
 
-.. jupyter-execute::
-
-    db["emotion"].get()
+>>> db["emotion"].get().head()
+                   emotion  emotion.confidence
+file
+wav/03a01Fa.wav  happiness                0.90
+wav/03a01Nc.wav    neutral                1.00
+wav/03a01Wa.wav      anger                0.95
+wav/03a02Fc.wav  happiness                0.85
+wav/03a02Nc.wav    neutral                1.00
 
 
 .. _streaming:
@@ -343,8 +409,7 @@ The table and media files
 are still stored in the cache.
 
 .. Prefetch data with only_metadata=True
-.. jupyter-execute::
-    :hide-code:
+.. invisible-code-block: python
 
     db = audb.stream(
         "emodb",
@@ -355,6 +420,8 @@ are still stored in the cache.
         full_path=False,
         verbose=False,
     )
+
+.. skip: start
 
 .. code-block:: python
 
@@ -367,14 +434,20 @@ are still stored in the cache.
         verbose=False,
     )
 
+.. skip: end
+
 It returns an :class:`audb.DatabaseIterator` object,
 which behaves as :class:`audformat.Database`,
 but provides the ability
 to iterate over the database:
 
-.. jupyter-execute::
-
-    next(db)
+>>> next(db)
+                   emotion  emotion.confidence
+file
+wav/03a01Fa.wav  happiness                0.90
+wav/03a01Nc.wav    neutral                1.00
+wav/03a01Wa.wav      anger                0.95
+wav/03a02Fc.wav  happiness                0.85
 
 With ``shuffle=True``,
 a user can request
@@ -382,7 +455,7 @@ that the data is returned in a random order.
 :func:`audb.stream` will then load ``buffer_size`` of rows
 into an buffer and selected randomly from those.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import numpy as np
     np.random.seed(1)
@@ -397,7 +470,14 @@ into an buffer and selected randomly from those.
         full_path=False,
         verbose=False,
     )
-    next(db)
+
+>>> next(db)
+                   emotion  emotion.confidence
+file
+wav/14a05Fb.wav  happiness                 1.0
+wav/15a05Eb.wav    disgust                 1.0
+wav/12a05Nd.wav    neutral                 0.9
+wav/13a07Na.wav    neutral                 0.9
 
 
 .. _corresponding audformat documentation: https://audeering.github.io/audformat/accessing-data.html

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -199,7 +199,6 @@ You can list all available flavors and their locations in the cache with:
          name version  complete format sampling_rate
 0       emodb   1.4.1     False   flac         44100
 1       emodb   1.4.1     False   None          None
-2  vadtoolkit   1.1.0     False   None          None
 
 The entry ``"complete"`` tells you if a database flavor is completely cached,
 or if some table or media files are still missing.

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -1,6 +1,3 @@
-..
-    >>> import audb
-
 .. _load:
 
 Load a database

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -46,12 +46,11 @@ to store all your data
 on your local disk under :file:`/data/data-local`
 you would use the following repository.
 
-.. jupyter-execute::
-    :hide-code:
+.. invisible-code-block: python
 
     import audb
 
-.. jupyter-execute::
+.. code-block:: python
 
     repository = audb.Repository(
         name="data-local",

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,3 +1,6 @@
+..
+    >>> import audb
+
 Overview
 ========
 
@@ -45,10 +48,6 @@ For example,
 to store all your data
 on your local disk under :file:`/data/data-local`
 you would use the following repository.
-
-.. invisible-code-block: python
-
-    import audb
 
 .. code-block:: python
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,6 +1,3 @@
-..
-    >>> import audb
-
 Overview
 ========
 

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -1,39 +1,5 @@
-.. Specify pandas format output in cells
-.. jupyter-execute::
-    :hide-code:
-
-    import pandas as pd
-
-    pd.set_option("display.max_columns", 7)
-
-.. Make sure we have no left-overs
-.. jupyter-execute::
-    :hide-code:
-
-    import os
-    import tempfile
-
-    import audb
-    import audeer
-
-
-    _cwd_root = os.getcwd()
-    _tmp_root = tempfile.mkdtemp()
-    os.chdir(_tmp_root)
-
-    folders = [
-        "./age-test-1.0.0",
-        "./age-test-1.1.0",
-        "./data/data-local",
-        "./cache",
-    ]
-    for folder in folders:
-        audeer.rmdir(folder)
-        audeer.mkdir(folder)
-
-    audb.config.CACHE_ROOT = "./cache"
-    audb.config.SHARED_CACHE_ROOT = "./cache"
-
+..
+    >>> import audb
 
 .. _publish:
 
@@ -54,11 +20,15 @@ Create a database
 We can create an example database
 with the :mod:`audformat.testing` module.
 
-.. jupyter-execute::
+.. code-block:: python
 
+    import random
+
+    import audeer
     import audformat.testing
 
-    build_dir = "./age-test-1.0.0"
+    random.seed(1)
+    build_dir = audeer.mkdir("./age-test-1.0.0")
 
     db = audformat.testing.create_db(minimal=True)
     db.name = "age-test"
@@ -77,15 +47,28 @@ with the :mod:`audformat.testing` module.
 This results in the following database,
 stored under :file:`build_dir`.
 
-.. jupyter-execute::
-
-    db
+>>> db
+name: age-test
+source: internal
+usage: unrestricted
+languages: [deu, eng]
+license: CC0-1.0
+schemes:
+  age: {dtype: int, minimum: 20, maximum: 90}
+tables:
+  age:
+    type: filewise
+    columns:
+      age: {scheme_id: age}
 
 Containing a few random annotations.
 
-.. jupyter-execute::
-
-    db["age"].get()
+>>> db["age"].get()
+               age
+file
+audio/001.wav   37
+audio/002.wav   28
+audio/003.wav   52
 
 
 Publish the first version
@@ -94,10 +77,9 @@ Publish the first version
 We define a repository on the local file system
 to publish the database to.
 
-.. jupyter-execute::
+.. code-block:: python
 
-    import audb
-
+    audeer.mkdir("./data", "data-local")
     repository = audb.Repository(
         name="data-local",
         host="./data",
@@ -108,7 +90,7 @@ Then we select the folder,
 where the database is stored,
 and pick a version for publishing it.
 
-.. jupyter-execute::
+.. code-block:: python
 
     deps = audb.publish(build_dir, "1.0.0", repository, verbose=False)
 
@@ -118,13 +100,18 @@ which files are part of the database
 in which archives they are stored,
 and information about audio metadata.
 
-.. jupyter-execute::
-
-    deps()
+>>> deps()
+											 archive  bit_depth  ...  type version
+db.age.parquet                                                0  ...     0   1.0.0
+audio/001.wav   436c65ec-1e42-f9de-2708-ecafe07e827e         16  ...     1   1.0.0
+audio/002.wav   fda7e4d6-f2b2-4cff-cab5-906ef5d57607         16  ...     1   1.0.0
+audio/003.wav   e26ef45d-bdc1-6153-bdc4-852d83806e4a         16  ...     1   1.0.0
+<BLANKLINE>
+[4 rows x 10 columns]
 
 We can compare this with the files stored in the repository.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import os
 
@@ -137,7 +124,21 @@ We can compare this with the files stored in the repository.
             for f in files:
                 print(f"{subindent}{f}")
 
-    list_files(repository.host)
+>>> list_files(repository.host)
+data/
+  data-local/
+    age-test/
+      1.0.0/
+        db.parquet
+        db.yaml
+      meta/
+        1.0.0/
+          age.parquet
+      media/
+        1.0.0/
+          e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
+          436c65ec-1e42-f9de-2708-ecafe07e827e.zip
+          fda7e4d6-f2b2-4cff-cab5-906ef5d57607.zip
 
 As you can see all media files are stored
 inside the ``media/`` folder,
@@ -157,10 +158,11 @@ or see which databases are available in your repository,
 we need to tell :mod:`audb` that it should use our repository
 instead of its default ones.
 
-.. jupyter-execute::
-
-    audb.config.REPOSITORIES = [repository]
-    audb.available()
+>>> audb.config.REPOSITORIES = [repository]
+>>> audb.available()
+              backend    host  repository version
+name
+age-test  file-system  ./data  data-local   1.0.0
 
 
 Update a database
@@ -174,9 +176,9 @@ previous version
 of the database
 to a new folder.
 
-.. jupyter-execute::
+.. code-block:: python
 
-    build_dir = "./age-test-1.1.0"
+    build_dir = audeer.mkdir("./age-test-1.1.0")
     db = audb.load_to(
         build_dir,
         "age-test",
@@ -188,19 +190,25 @@ to a new folder.
 Then we extend the age table by another file (:file:`audio/004.wav`)
 and add the age annotation of 22 to it.
 
-.. jupyter-execute::
+.. code-block:: python
 
     index = audformat.filewise_index(["audio/004.wav"])
     db["age"].extend_index(index, inplace=True)
     db["age"]["age"].set([22], index=index)
 
-    db["age"].get()
+>>> db["age"].get()
+               age
+file
+audio/001.wav   37
+audio/002.wav   28
+audio/003.wav   52
+audio/004.wav   22
 
 We save it to the database build folder,
 overwrite the old table,
 and add a new audio file.
 
-.. jupyter-execute::
+.. code-block:: python
 
     db.save(build_dir)
     audformat.testing.create_audio_files(db)
@@ -211,7 +219,7 @@ but this time we have to specify a version where our update should be based on.
 which files have changed
 and will only publish those.
 
-.. jupyter-execute::
+.. code-block:: python
 
     deps = audb.publish(
         build_dir,
@@ -220,7 +228,16 @@ and will only publish those.
         previous_version="1.0.0",
         verbose=False,
     )
-    deps()
+
+>>> deps()
+                                             archive  bit_depth  ...  type version
+db.age.parquet                                                0  ...     0   1.1.0
+audio/001.wav   436c65ec-1e42-f9de-2708-ecafe07e827e         16  ...     1   1.0.0
+audio/002.wav   fda7e4d6-f2b2-4cff-cab5-906ef5d57607         16  ...     1   1.0.0
+audio/003.wav   e26ef45d-bdc1-6153-bdc4-852d83806e4a         16  ...     1   1.0.0
+audio/004.wav   ef4d1e81-6488-95cf-a165-604d1e47d575         16  ...     1   1.1.0
+<BLANKLINE>
+[5 rows x 10 columns]
 
 It has just uploaded a new version of the table,
 and the new media files.
@@ -228,15 +245,37 @@ For the other media files,
 it just :ref:`depends on the previous published version <database-dependencies>`.
 We can again inspect the repository.
 
-.. jupyter-execute::
-
-    list_files(repository.host)
+>>> list_files(repository.host)
+data/
+  data-local/
+    age-test/
+      1.1.0/
+        db.parquet
+        db.yaml
+      1.0.0/
+        db.parquet
+        db.yaml
+      meta/
+        1.1.0/
+          age.parquet
+        1.0.0/
+          age.parquet
+      media/
+        1.1.0/
+          ef4d1e81-6488-95cf-a165-604d1e47d575.zip
+        1.0.0/
+          e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
+          436c65ec-1e42-f9de-2708-ecafe07e827e.zip
+          fda7e4d6-f2b2-4cff-cab5-906ef5d57607.zip
 
 And check which databases are available.
 
-.. jupyter-execute::
+>>> audb.available()
+              backend    host  repository version
+name
+age-test  file-system  ./data  data-local   1.0.0
+age-test  file-system  ./data  data-local   1.1.0
 
-    audb.available()
 
 As you can even `update one database by another one`_,
 you could automate the update step
@@ -257,11 +296,3 @@ to see how to load and use a database.
 
 .. _update one database by another one: https://audeering.github.io/audformat/update-database.html
 .. _emodb: http://emodb.bilderbar.info/start.html
-
-
-.. Clean up
-.. jupyter-execute::
-    :hide-code:
-
-    os.chdir(_cwd_root)
-    audeer.rmdir(_tmp_root)

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -1,6 +1,3 @@
-..
-    >>> import audb
-
 .. _publish:
 
 Publish a database

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -101,7 +101,7 @@ in which archives they are stored,
 and information about audio metadata.
 
 >>> deps()
-											 archive  bit_depth  ...  type version
+                                             archive  bit_depth  ...  type version
 db.age.parquet                                                0  ...     0   1.0.0
 audio/001.wav   436c65ec-1e42-f9de-2708-ecafe07e827e         16  ...     1   1.0.0
 audio/002.wav   fda7e4d6-f2b2-4cff-cab5-906ef5d57607         16  ...     1   1.0.0

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,18 +1,3 @@
-.. Specify repository to overwrite local config files
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import audb
-
-    audb.config.REPOSITORIES = [
-        audb.Repository(
-            name="data-public",
-            host="https://audeering.jfrog.io/artifactory",
-            backend="artifactory",
-        )
-    ]
-
 .. _quickstart:
 
 Quickstart
@@ -24,29 +9,31 @@ with :func:`audb.load`.
 Let's first see which databases are available
 on our `public Artifactory server`_.
 
-
-.. jupyter-execute::
-
-    import audb
-
-    audb.available(only_latest=True)
+>>> import audb
+>>> df = audb.available(only_latest=True)
+>>> df.loc["emodb"]
+backend                                  artifactory
+host          https://audeering.jfrog.io/artifactory
+repository                               data-public
+version                                        1.4.1
+Name: emodb, dtype: object
 
 Let's load version 1.4.1 of the emodb_ database.
 
 .. Load with only_metadata=True in the background
-.. jupyter-execute::
-    :hide-code:
+.. invisible-code-block: python
 
     db = audb.load(
         "emodb",
         version="1.4.1",
         only_metadata=True,
+        full_path=False,
         verbose=False,
     )
 
-.. code-block:: python
+.. skip: next
 
-    db = audb.load("emodb", version="1.4.1", verbose=False)
+>>> db = audb.load("emodb", version="1.4.1", full_path=False, verbose=False)
 
 This downloads the database header,
 all the media files,
@@ -59,16 +46,36 @@ Each database comes with a description,
 which is a good starting point
 to learn what the database is all about.
 
-.. jupyter-execute::
-
-    db.description
+>>> db.description[:78]
+'Berlin Database of Emotional Speech. A German database of emotional utterances'
 
 The annotations of a database are stored in
 tables represented by :class:`audformat.Table`.
 
-.. jupyter-execute::
-
-    db.tables
+>>> db.tables
+emotion:
+  type: filewise
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.test.gold_standard:
+  type: filewise
+  split_id: test
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+emotion.categories.train.gold_standard:
+  type: filewise
+  split_id: train
+  columns:
+    emotion: {scheme_id: emotion, rater_id: gold}
+    emotion.confidence: {scheme_id: confidence, rater_id: gold}
+files:
+  type: filewise
+  columns:
+    duration: {scheme_id: duration}
+    speaker: {scheme_id: speaker}
+    transcription: {scheme_id: transcription}
 
 Each table contains columns (:class:`audformat.Column`)
 that have corresponding schemes (:class:`audformat.Scheme`)
@@ -78,17 +85,21 @@ to get an idea about the emotion annotations
 stored in the ``emotion`` column,
 we can inspect the corresponding scheme.
 
-.. jupyter-execute::
-
-    db.schemes["emotion"]
+>>> db.schemes["emotion"]
+description: Six basic emotions and neutral.
+dtype: str
+labels: [anger, boredom, disgust, fear, happiness, sadness, neutral]
 
 Finally, we get the actual annotations
 as a :class:`pandas.DataFrame`.
 
-.. jupyter-execute::
-
-    df = db["emotion"].get()  # get table
-    df[:3]  # show first three entries
+>>> df = db["emotion"].get()  # get table
+>>> df[:3]  # show first three entries
+                   emotion  emotion.confidence
+file
+wav/03a01Fa.wav  happiness                0.90
+wav/03a01Nc.wav    neutral                1.00
+wav/03a01Wa.wav      anger                0.95
 
 
 .. _emodb: https://github.com/audeering/emodb

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -6,22 +6,23 @@ Quickstart
 The most common task is to load a database
 with :func:`audb.load`.
 
-Let's first see which databases are available
-on our `public Artifactory server`_.
+You can browse `available datasets`_
+or check them in your Python console:
 
 >>> import audb
->>> df = audb.available(only_latest=True)
->>> df.loc["emodb"]
-backend                                  artifactory
-host          https://audeering.jfrog.io/artifactory
-repository                               data-public
-version                                        1.4.1
-Name: emodb, dtype: object
+>>> audb.available(only_latest=True)
+                         backend  ... version
+name                              ...
+...
+emodb                artifactory  ...   1.4.1
+...
 
 Let's load version 1.4.1 of the emodb_ database.
 
 .. Load with only_metadata=True in the background
 .. invisible-code-block: python
+
+    import audformat as _audformat
 
     db = audb.load(
         "emodb",
@@ -30,10 +31,16 @@ Let's load version 1.4.1 of the emodb_ database.
         full_path=False,
         verbose=False,
     )
+    # Add flavor path, to mimic `full_path=True`
+    for table in list(db.tables):
+        db[table]._df.index = _audformat.utils.expand_file_path(
+            db[table]._df.index,
+            f'...{audb.flavor_path("emodb", "1.4.1")}',
+        )
 
 .. skip: next
 
->>> db = audb.load("emodb", version="1.4.1", full_path=False, verbose=False)
+>>> db = audb.load("emodb", version="1.4.1", verbose=False)
 
 This downloads the database header,
 all the media files,
@@ -95,12 +102,12 @@ as a :class:`pandas.DataFrame`.
 
 >>> df = db["emotion"].get()  # get table
 >>> df[:3]  # show first three entries
-                   emotion  emotion.confidence
+                                           emotion  emotion.confidence
 file
-wav/03a01Fa.wav  happiness                0.90
-wav/03a01Nc.wav    neutral                1.00
-wav/03a01Wa.wav      anger                0.95
+...emodb/1.4.1/d3b62a9b/wav/03a01Fa.wav  happiness                0.90
+...emodb/1.4.1/d3b62a9b/wav/03a01Nc.wav    neutral                1.00
+...emodb/1.4.1/d3b62a9b/wav/03a01Wa.wav      anger                0.95
 
 
 .. _emodb: https://github.com/audeering/emodb
-.. _public Artifactory server: https://audeering.jfrog.io/artifactory
+.. _available datasets: https://audeering.github.io/datasets/datasets.html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,4 @@
 docutils
-ipykernel
-jupyter-sphinx
-pyarrow
 sphinx >=3.5.4
 sphinx-apipages >=0.1.2
 sphinx-audeering-theme >=1.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,12 +78,11 @@ uri-ignore-words-list = 'ist'
 cache_dir = '.cache/pytest'
 xfail_strict = true
 addopts = '''
-    --doctest-plus
+    -p no:doctest
     --cov=audb
     --cov-fail-under=100
     --cov-report term-missing
     --cov-report xml
-    --ignore=docs/
     --ignore=benchmarks/
 '''
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,4 @@ audiofile >=1.1.0
 pytest
 pytest-cov
 pytest-console-scripts
-pytest-doctestplus
+sybil


### PR DESCRIPTION
Similar to audeering/audinterface#178 we switch to use sybil for doctests.

This has several motivations:
* separate testing and building the documentation
* remove dependency on `jupyter-sphinx` (large dependencies, not well maintained)
* remove dependency on `pytest-doctestplus` (slow in adopting to newer pytest versions)
* write expected results of code blocks as part of the usage documentation
* allow to use pytest fixtures inside doctests

Other changes:
* in docstrings, I have unified how we write examples by ensuring we always start with `audb` in front of a function, e.g. using `df = audb.available()` instead of `df = available()`

## Summary by Sourcery

Switch to using Sybil for doctests, updating the test configuration and dependencies accordingly.

Enhancements:
- Switch to using Sybil for doctests, replacing the previous doctest setup.

Build:
- Remove unnecessary dependencies from docs/requirements.txt and update pyproject.toml to disable doctest-plus.

Tests:
- Integrate Sybil for collecting and running doctests, replacing pytest-doctestplus.

## Summary by Sourcery

Switch to Sybil for doctests, update test configuration and dependencies, and unify example usage in docstrings.

Enhancements:
- Switch to using Sybil for doctests, replacing the previous doctest setup.

Build:
- Remove unnecessary dependencies from docs/requirements.txt and update pyproject.toml to disable doctest-plus.

Tests:
- Integrate Sybil for collecting and running doctests, replacing pytest-doctestplus.