### PR TITLE
Add 22050 Hz as flavor, deprecate 22500 Hz

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -332,7 +332,7 @@ def exists(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22050``, ``24000``, ``44100``, ``48000``
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
 
@@ -416,7 +416,7 @@ def flavor_path(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22050``, ``24000``, ``44100``, ``48000``
 
     Returns:
         flavor path relative to cache folder

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -91,7 +91,7 @@ class Format:
 
 FORMATS = [Format.WAV, Format.FLAC]
 BIT_DEPTHS = [16, 24, 32]
-SAMPLING_RATES = [8000, 16000, 22500, 24000, 44100, 48000]
+SAMPLING_RATES = [8000, 16000, 22050, 24000, 44100, 48000]
 
 # Progress bar
 MAXIMUM_REFRESH_TIME = 1  # force progress bar to update every second

--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -41,7 +41,7 @@ class Flavor(audobject.Object):
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down on selection
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22050``, ``24000``, ``44100``, ``48000``
 
     Raises:
         ValueError: if a non-supported ``bit_depth``,

--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 import os
 import shutil
+import warnings
 
 import numpy as np
 
@@ -81,7 +82,14 @@ class Flavor(audobject.Object):
 
         if sampling_rate is not None:
             sampling_rate = int(sampling_rate)
-            if sampling_rate not in define.SAMPLING_RATES:
+            if sampling_rate == 22500:
+                message = (
+                    "A sampling rate of 22500 Hz is deprecated "
+                    "and will be removed with version 1.13.0 of audb. "
+                    "Use 22050 Hz instead."
+                )
+                warnings.warn(message, category=UserWarning, stacklevel=2)
+            elif sampling_rate not in define.SAMPLING_RATES:
                 raise ValueError(
                     f"Sampling_rate has to be one of "
                     f"{define.SAMPLING_RATES}, not {sampling_rate}."

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1057,7 +1057,7 @@ def load(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22050``, ``24000``, ``44100``, ``48000``
         attachments: load only attachment files
             for the attachments
             matching the regular expression
@@ -1521,7 +1521,7 @@ def load_media(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22050``, ``24000``, ``44100``, ``48000``
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used
         num_workers: number of parallel jobs or 1 for sequential

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -481,7 +481,7 @@ def stream(
         format: file format, one of ``'flac'``, ``'wav'``
         mixdown: apply mono mix-down
         sampling_rate: sampling rate in Hz, one of
-            ``8000``, ``16000``, ``22500``, ``24000``, ``44100``, ``48000``
+            ``8000``, ``16000``, ``22050``, ``24000``, ``44100``, ``48000``
         full_path: replace relative with absolute file paths
         cache_root: cache folder where databases are stored.
             If not set :meth:`audb.default_cache_root` is used

--- a/docs/load.rst
+++ b/docs/load.rst
@@ -143,7 +143,7 @@ The following properties can be changed.
     sampling_rate:
       - 8000
       - 16000
-      - 22500
+      - 22050
       - 24000
       - 44100
       - 48000

--- a/tests/test_flavor.py
+++ b/tests/test_flavor.py
@@ -73,6 +73,13 @@ def test_init(bit_depth, channels, format, mixdown, sampling_rate):
     assert flavor.id == flavor_2.id
 
 
+def test_deprecated_sampling_rate():
+    """Test a sampling rate of 22500 Hz raises user warning."""
+    message = "removed with version 1.13.0"
+    with pytest.warns(UserWarning, match=message):
+        audb.Flavor(sampling_rate=22500)
+
+
 @pytest.mark.parametrize(
     "format",
     [


### PR DESCRIPTION
closes #468

## Summary by Sourcery

Change the supported sampling rate from 22500 Hz to 22050 Hz in the codebase and update the documentation accordingly.

Enhancements:
- Update the sampling rate from 22500 Hz to 22050 Hz across multiple files for consistency.

Documentation:
- Update documentation to reflect the change in supported sampling rates from 22500 Hz to 22050 Hz.