### PR TITLE
Fix finding cached files for flavor in load()

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -742,6 +742,9 @@ def _load_files(
         flavor,
         verbose,
     )
+    print(f"{flavor=}")
+    print(f"{files[:3]=}")
+    print(f"{missing_files[:3]=}")
     if missing_files:
         if cached_versions is None:
             cached_versions = _cached_versions(
@@ -861,6 +864,12 @@ def _missing_files(
 
     """
     missing_files = []
+
+    # Adjust expected file extensions,
+    # if a specific file format is requested.
+    # See https://github.com/audeering/audb/issues/324
+    if files_type == "media" and flavor.format is not None:
+        files = audformat.utils.replace_file_extension(files, flavor.format)
 
     for file in audeer.progress_bar(
         files,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -409,7 +409,7 @@ def test_load_from_cache(dbs):
     db = audb.load(
         DB_NAME,
         version="1.0.0",
-        format=format,
+        format="flac",
         full_path=False,
         num_workers=pytest.NUM_WORKERS,
         verbose=False,
@@ -430,8 +430,8 @@ def test_load_from_cache(dbs):
     for file in db.files:
         assert os.path.exists(os.path.join(db_root, file))
 
-    # Ensure no media files are marked as missing files,
-    # when requested in format different from original
+    # Ensure no media files in flavor cache are marked as missing files,
+    # when flavor format is different from original format
     # (https://github.com/audeering/audb/issues/324)
     original_files = audformat.utils.replace_file_extension(db.files, "wav")
     assert (
@@ -439,7 +439,7 @@ def test_load_from_cache(dbs):
             original_files,
             "media",
             db_root,
-            audb.Flavor(format=format),
+            audb.Flavor(format="flac"),
             False,
         )
         == []
@@ -449,7 +449,7 @@ def test_load_from_cache(dbs):
     db = audb.load(
         DB_NAME,
         version="2.0.0",
-        format=format,
+        format="flac",
         full_path=False,
         num_workers=pytest.NUM_WORKERS,
         verbose=False,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -409,7 +409,7 @@ def test_load_from_cache(dbs):
     db = audb.load(
         DB_NAME,
         version="1.0.0",
-        format="flac",
+        format=format,
         full_path=False,
         num_workers=pytest.NUM_WORKERS,
         verbose=False,
@@ -430,11 +430,26 @@ def test_load_from_cache(dbs):
     for file in db.files:
         assert os.path.exists(os.path.join(db_root, file))
 
+    # Ensure no media files are marked as missing files,
+    # when requested in format different from original
+    # (https://github.com/audeering/audb/issues/324)
+    original_files = audformat.utils.replace_file_extension(db.files, "wav")
+    assert (
+        audb.core.load._missing_files(
+            original_files,
+            "media",
+            db_root,
+            audb.Flavor(format=format),
+            False,
+        )
+        == []
+    )
+
     version = "2.0.0"
     db = audb.load(
         DB_NAME,
         version="2.0.0",
-        format="flac",
+        format=format,
         full_path=False,
         num_workers=pytest.NUM_WORKERS,
         verbose=False,


### PR DESCRIPTION
Closes #324 

Ensures that media files are found in cache when using `audb.load(..., format=format)` and `format` is different from the original format of the media files. This is achieved by replacing the file extension of the original file (original file names are given by dependency table) by the given `format` when checking if the file exists in the cache. The pull request also adds a test for the expected behavior, which is failing for the current `main` branch.

/cc @ureichel 