### PR TITLE
DOC: simplify quickstart section

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -75,7 +75,7 @@ or from the files index ``db.files``.
 .. skip: start
 
 >>> import audiofile
->>> signal, sampling_rate = audiofile.read(db.files[0], always_2d=True)
+>>> signal, sampling_rate = audiofile.read(db.files[0])
 
 Listen to the signal.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -68,6 +68,22 @@ file
 .../wav/12a02Ac.wav       fear                0.90
 ...                        ...                 ...
 
+Load a media file,
+selected from the index of the dataframe
+or from the files index ``db.files``.
+
+>>> import audiofile
+>>> signal, sampling_rate = audiofile.read(db.files[0], always_2d=True)
+
+Listen to the signal.
+
+.. skip: start
+
+>>> import sounddevice
+>>> sounddevice.play(signal.T, sampling_rate)
+
+.. skip: end
+
 
 .. _emodb: https://github.com/audeering/emodb
 .. _available datasets: https://audeering.github.io/datasets/datasets.html

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -72,12 +72,12 @@ Load a media file,
 selected from the index of the dataframe
 or from the files index ``db.files``.
 
+.. skip: start
+
 >>> import audiofile
 >>> signal, sampling_rate = audiofile.read(db.files[0], always_2d=True)
 
 Listen to the signal.
-
-.. skip: start
 
 >>> import sounddevice
 >>> sounddevice.play(signal.T, sampling_rate)

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,21 +3,10 @@
 Quickstart
 ==========
 
-The most common task is to load a database
-with :func:`audb.load`.
-
-You can browse `available datasets`_
-or check them in your Python console:
-
->>> import audb
->>> audb.available(only_latest=True)
-                      backend  ... version
-name                           ...
-...
-emodb                      s3  ...   1.4.1
-...
-
-Let's load version 1.4.1 of the emodb_ database.
+Browse `available datasets`_ and select one.
+We load emodb_,
+which is returned
+as an :class:`audformat.Database`.
 
 .. Load with only_metadata=True in the background
 .. invisible-code-block: python
@@ -36,73 +25,48 @@ Let's load version 1.4.1 of the emodb_ database.
 
 .. skip: next
 
->>> db = audb.load("emodb", version="1.4.1", verbose=False)
+>>> db = audb.load("emodb", version="1.4.1")
 
-This downloads the database header,
-all the media files,
-and tables with annotations
-to a caching folder on your machine.
-The database is then returned
-as an :class:`audformat.Database` object.
+Inspect label schemes,
+and request emotion labels for the test split.
 
-Each database comes with a description,
-which is a good starting point
-to learn what the database is all about.
-
->>> db.description[:78]
-'Berlin Database of Emotional Speech. A German database of emotional utterances'
-
-The annotations of a database are stored in
-tables represented by :class:`audformat.Table`.
-
->>> db.tables
-emotion:
-  type: filewise
-  columns:
-    emotion: {scheme_id: emotion, rater_id: gold}
-    emotion.confidence: {scheme_id: confidence, rater_id: gold}
-emotion.categories.test.gold_standard:
-  type: filewise
-  split_id: test
-  columns:
-    emotion: {scheme_id: emotion, rater_id: gold}
-    emotion.confidence: {scheme_id: confidence, rater_id: gold}
-emotion.categories.train.gold_standard:
-  type: filewise
-  split_id: train
-  columns:
-    emotion: {scheme_id: emotion, rater_id: gold}
-    emotion.confidence: {scheme_id: confidence, rater_id: gold}
-files:
-  type: filewise
-  columns:
-    duration: {scheme_id: duration}
-    speaker: {scheme_id: speaker}
-    transcription: {scheme_id: transcription}
-
-Each table contains columns (:class:`audformat.Column`)
-that have corresponding schemes (:class:`audformat.Scheme`)
-describing its content.
-For example,
-to get an idea about the emotion annotations
-stored in the ``emotion`` column,
-we can inspect the corresponding scheme.
-
->>> db.schemes["emotion"]
-description: Six basic emotions and neutral.
-dtype: str
-labels: [anger, boredom, disgust, fear, happiness, sadness, neutral]
-
-Finally, we get the actual annotations
-as a :class:`pandas.DataFrame`.
-
->>> df = db["emotion"].get()  # get table
->>> df[:3]  # show first three entries
-                                           emotion  emotion.confidence
+>>> list(db.schemes)
+['age',
+ 'confidence',
+ 'duration',
+ 'emotion',
+ 'gender',
+ 'language',
+ 'speaker',
+ 'transcription']
+>>> db.get("emotion", splits="test")  # returns dataframe
+                       emotion
 file
-...emodb/1.4.1/d3b62a9b/wav/03a01Fa.wav  happiness                0.90
-...emodb/1.4.1/d3b62a9b/wav/03a01Nc.wav    neutral                1.00
-...emodb/1.4.1/d3b62a9b/wav/03a01Wa.wav      anger                0.95
+.../wav/12a01Fb.wav  happiness
+.../wav/12a01Lb.wav    boredom
+.../wav/12a01Nb.wav    neutral
+.../wav/12a01Wc.wav      anger
+.../wav/12a02Ac.wav       fear
+...                        ...
+
+Or inspect tables,
+and request labels from a table.
+
+>>> list(db)
+['emotion',
+ 'emotion.categories.test.gold_standard',
+ 'emotion.categories.train.gold_standard',
+ 'files',
+ 'speaker']
+>>> db["emotion.categories.test.gold_standard"].get()  # returns dataframe
+                       emotion  emotion.confidence
+file
+.../wav/12a01Fb.wav  happiness                0.95
+.../wav/12a01Lb.wav    boredom                0.90
+.../wav/12a01Nb.wav    neutral                0.95
+.../wav/12a01Wc.wav      anger                0.95
+.../wav/12a02Ac.wav       fear                0.90
+...                        ...                 ...
 
 
 .. _emodb: https://github.com/audeering/emodb


### PR DESCRIPTION
This simplifies the [quickstart section](https://audeering.github.io/audb/quickstart.html) by focusing on how to load a dataset and get the corresponding labels.
It shortens the section by removing:
* Discussion of `audb.avilable()`, instead we only link to https://audeering.github.io/datasets/datasets.html
* Don't show `db.descriptions` and other YAML representations of the header
* Strip down the amount of written text

And adds a small signal, how to load and listen to an audio file.

The updated quickstart documentation now fits on a single screen page and looks like this:

![image](https://github.com/user-attachments/assets/de6ab973-75d9-4e61-bed7-dedbecda49c4)


## Summary by Sourcery

Documentation:
- Simplify the quickstart section by focusing on loading datasets and obtaining labels, removing discussions on `audb.available()`, YAML representations, and reducing text.