### PR TITLE
Depend on audbackend>=2.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[all] >=2.2.0',
+    'audbackend[all] >=2.2.1',
     'audeer >=2.1.0',
     'audformat >=1.2.0',
     'audiofile >=1.0.0',


### PR DESCRIPTION
Require newest version of `audbackend`, which contains a critical bug fix for publishing on Artifactory.

## Summary by Sourcery

Build:
- Update dependency on audbackend to version 2.2.1.