### PR TITLE
Handle empty config file

### DIFF
--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -26,11 +26,13 @@ def load_configuration_file(config_file: str):
             ``backend``, or ``name`` key
 
     """
-    if os.path.exists(config_file):
-        with open(config_file) as cf:
-            config = yaml.load(cf, Loader=yaml.BaseLoader)
-    else:
-        config = {}
+    if not os.path.exists(config_file):
+        return {}
+
+    with open(config_file) as cf:
+        config = yaml.load(cf, Loader=yaml.BaseLoader)
+        if config is None:
+            return {}
 
     # Check that we have provided a valid repositories configuration
     if "repositories" in config:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,3 +84,11 @@ def test_config_file(tmpdir):
             },
         ]
     }
+
+
+def test_empty_config_file(tmp_path):
+    """Test loading an empty config file."""
+    empty_config = tmp_path / "empty.yaml"
+    empty_config.write_text("")
+    config = audb.core.config.load_configuration_file(empty_config)
+    assert config == {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import pytest
+import yaml
 
 import audeer
 
@@ -92,3 +93,10 @@ def test_empty_config_file(tmp_path):
     empty_config.write_text("")
     config = audb.core.config.load_configuration_file(empty_config)
     assert config == {}
+
+
+def test_invalid_config_file(tmp_path):
+    invalid_config = tmp_path / "invalid.yaml"
+    invalid_config.write_text("{invalid: yaml: content}")
+    with pytest.raises(yaml.YAMLError):
+        audb.core.config.load_configuration_file(invalid_config)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,6 +96,7 @@ def test_empty_config_file(tmp_path):
 
 
 def test_invalid_config_file(tmp_path):
+    """Test loading a broken config file."""
     invalid_config = tmp_path / "invalid.yaml"
     invalid_config.write_text("{invalid: yaml: content}")
     with pytest.raises(yaml.YAMLError):


### PR DESCRIPTION
If the user stored an empty config file before, `import audb` would fail with an error. This pull request adds a test for the case and a fix for it. In addition, it adds a test for a config file with broken syntax, which should raise a corresponding YAML error.

## Summary by Sourcery

Fix handling of empty configuration files by returning an empty dictionary and add tests for empty and invalid configuration files.

Bug Fixes:
- Fix error when loading an empty configuration file by returning an empty dictionary.

Tests:
- Add a test to ensure that loading an empty configuration file returns an empty dictionary.
- Add a test to verify that a configuration file with invalid YAML syntax raises a YAML error.