### PR TITLE
DOC: hide audb.config.__eq__() docstring

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,19 @@
+{{ objname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+{% block methods %}
+{%- for item in (all_methods + attributes)|sort %}
+    {%- if not item.startswith('_') or item in hidden_methods %}
+        {%- if item in all_methods and objname != 'config' %}
+{{ (item + '()') | escape | underline(line='-') }}
+.. automethod:: {{ name }}.{{ item }}
+        {%- elif item in attributes %}
+{{ item | escape | underline(line='-') }}
+.. autoattribute:: {{ name }}.{{ item }}
+        {%- endif %}
+    {% endif %}
+{%- endfor %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,7 @@ title = "Documentation"
 # General -----------------------------------------------------------------
 master_doc = "index"
 source_suffix = ".rst"
+templates_path = ["_templates"]
 exclude_patterns = [
     "api-src",
     "build",


### PR DESCRIPTION
Hide `audb.config.__eq__()` from the API documentation.

This is achieved by customizing the [`class.rst` template from sphinx-apipages](https://audeering.github.io/sphinx-apipages/usage.html#custom-templates) to skip methods for a class named `config`.

## Summary by Sourcery

Documentation:
- Hide the audb.config.__eq__() method from the API documentation by customizing the class.rst template.