### PR TITLE
TST: enable tests for documentation files

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -1,5 +1,12 @@
 .. _caching:
 
+.. As the test outputs are mainly paths,
+.. we skip the tests under Windows
+..
+   >>> import platform
+
+.. skip: start if(platform.system() == "Windows")
+
 Caching
 =======
 
@@ -44,7 +51,7 @@ accessible to you only.
 By default it points to
 
 >>> audb.default_cache_root(shared=False)
-'/home/.../audb'
+'.../audb'
 
 When you request a database with :meth:`audb.load`,
 :mod:`audb` first looks for it in the shared cache folder
@@ -88,5 +95,6 @@ Note,
 2. overwrites 3. and 4.,
 and so on.
 
+.. skip: end
 
 .. _adjust the rights: https://superuser.com/a/264406

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -65,6 +65,9 @@ There are four ways to change the default locations:
 
 1. By setting the argument ``cache_root`` during a function call, e.g.
 
+.. skip: end
+.. skip: next
+
 >>> db = audb.load("emodb", ..., cache_root="/cache/root/audb")
 
 2. System-wide by setting the following system variables
@@ -75,6 +78,8 @@ There are four ways to change the default locations:
     export AUDB_SHARED_CACHE_ROOT=/new/shared/cache/audb
 
 3. Program-wide by overwriting the default values in :class:`audb.config`
+
+.. skip: start if(platform.system() == "Windows")
 
 >>> audb.config.SHARED_CACHE_ROOT = "/new/shared/cache/audb"
 >>> audb.default_cache_root(shared=True)

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -65,8 +65,6 @@ There are four ways to change the default locations:
 
 1. By setting the argument ``cache_root`` during a function call, e.g.
 
-.. skip: next
-
 >>> db = audb.load("emodb", ..., cache_root="/cache/root/audb")
 
 2. System-wide by setting the following system variables

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -45,6 +45,13 @@ class DefaultConfiguration:
 
 
 @pytest.fixture(scope="module")
+def default_configuration():
+    """Set config values to default values."""
+    with DefaultConfiguration():
+        yield
+
+
+@pytest.fixture(scope="module")
 def run_in_tmpdir(tmpdir_factory):
     """Move to a persistent tmpdir for execution of a whole file."""
     tmpdir = tmpdir_factory.mktemp("tmp")
@@ -54,13 +61,6 @@ def run_in_tmpdir(tmpdir_factory):
     yield
 
     os.chdir(current_dir)
-
-
-@pytest.fixture(scope="module")
-def default_configuration():
-    """Set config values to default values."""
-    with DefaultConfiguration():
-        yield
 
 
 # Collect doctests

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,98 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
+import os
+
+import pytest
+import sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+from sybil.parsers.rest import SkipParser
+
+import audb
+from audb.core.conftest import cache  # noqa: F401
+from audb.core.conftest import imports
+from audb.core.conftest import public_repository  # noqa: F401
+
+
+@pytest.fixture(scope="module")
+def run_in_tmpdir(tmpdir_factory):
+    """Move to a persistent tmpdir for execution of a whole file."""
+    tmpdir = tmpdir_factory.mktemp("tmp")
+    current_dir = os.getcwd()
+    os.chdir(tmpdir)
+
+    yield
+
+    os.chdir(current_dir)
+
+
+@pytest.fixture(scope="module")
+def default_configuration():
+    """Set config values to default values from global config file."""
+    # Read global config file
+    global_config = audb.core.config.load_configuration_file(
+        audb.core.config.global_config_file
+    )
+    # Store current user settings
+    current_cache_root = audb.config.CACHE_ROOT
+    current_shared_cache_root = audb.config.SHARED_CACHE_ROOT
+    current_repositories = audb.config.REPOSITORIES
+    # Enforce default values
+    audb.config.CACHE_ROOT = global_config["cache_root"]
+    audb.config.SHARED_CACHE_ROOT = global_config["shared_cache_root"]
+    audb.config.REPOSITORIES = [
+        audb.Repository(r["name"], r["host"], r["backend"])
+        for r in global_config["repositories"]
+    ]
+
+    yield audb
+
+    # Restore user settings
+    audb.config.CACHE_ROOT = current_cache_root
+    audb.config.SHARED_CACHE_ROOT = current_shared_cache_root
+    audb.config.REPOSITORIES = current_repositories
+
+
+# Collect doctests
+#
+# We use several `sybil.Sybil` instances
+# to pass different fixtures for different files
+#
+parsers = [
+    DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE),
+    PythonCodeBlockParser(),
+    SkipParser(),
+]
+pytest_collect_file = sybil.sybil.SybilCollection(
+    (
+        sybil.Sybil(
+            parsers=parsers,
+            filenames=[
+                "authentication.rst",
+                "overview.rst",
+                "quickstart.rst",
+                "dependencies.rst",
+                "load.rst",
+                "audb.info.rst",
+            ],
+            fixtures=[
+                "cache",
+                "run_in_tmpdir",
+                "public_repository",
+            ],
+            setup=imports,
+        ),
+        sybil.Sybil(
+            parsers=parsers,
+            filenames=["publish.rst"],
+            fixtures=["cache", "run_in_tmpdir"],
+            setup=imports,
+        ),
+        sybil.Sybil(
+            parsers=parsers,
+            filenames=["configuration.rst", "caching.rst"],
+            fixtures=["default_configuration"],
+            setup=imports,
+        ),
+    )
+).pytest()

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -48,6 +48,11 @@ If your database contains only WAV or FLAC files,
 we store the duration in seconds of every file
 in the database dependency table.
 
+..
+    >>> import pandas as pd
+
+.. skip: start if(pd.version == "2.1.4", reason="formats output differently")
+
 >>> deps = audb.dependencies("emodb", version="1.4.1")
 >>> df = deps()
 >>> df.duration[:10]
@@ -62,6 +67,8 @@ wav/03a02Ta.wav    1.735688
 wav/03a02Wb.wav    2.123625
 wav/03a02Wc.wav    1.498063
 Name: duration, dtype: double[pyarrow]
+
+.. skip: end
 
 For those databases
 you can get their overall duration with:

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -51,7 +51,7 @@ in the database dependency table.
 ..
     >>> import pandas as pd
 
-.. skip: start if(pd.version == "2.1.4", reason="formats output differently")
+.. skip: start if(pd.__version__ == "2.1.4", reason="formats output differently")
 
 >>> deps = audb.dependencies("emodb", version="1.4.1")
 >>> df = deps()

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -118,7 +118,7 @@ We can compare this with the files stored in the repository.
             indent = " " * 2 * (level)
             print(f"{indent}{os.path.basename(root)}/")
             subindent = " " * 2 * (level + 1)
-            for f in files:
+            for f in sorted(files):
                 print(f"{subindent}{f}")
 
 >>> list_files(repository.host)
@@ -133,8 +133,8 @@ data/
           age.parquet
       media/
         1.0.0/
-          e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
           436c65ec-1e42-f9de-2708-ecafe07e827e.zip
+          e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
           fda7e4d6-f2b2-4cff-cab5-906ef5d57607.zip
 
 As you can see all media files are stored
@@ -261,8 +261,8 @@ data/
         1.1.0/
           ef4d1e81-6488-95cf-a165-604d1e47d575.zip
         1.0.0/
-          e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
           436c65ec-1e42-f9de-2708-ecafe07e827e.zip
+          e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
           fda7e4d6-f2b2-4cff-cab5-906ef5d57607.zip
 
 And check which databases are available.

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -113,7 +113,7 @@ We can compare this with the files stored in the repository.
     import os
 
     def list_files(path):
-        for root, dirs, files in os.walk(path):
+        for root, _, files in sorted(os.walk(path)):
             level = root.replace(path, "").count(os.sep)
             indent = " " * 2 * (level)
             print(f"{indent}{os.path.basename(root)}/")
@@ -128,14 +128,14 @@ data/
       1.0.0/
         db.parquet
         db.yaml
-      meta/
-        1.0.0/
-          age.parquet
       media/
         1.0.0/
           436c65ec-1e42-f9de-2708-ecafe07e827e.zip
           e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
           fda7e4d6-f2b2-4cff-cab5-906ef5d57607.zip
+      meta/
+        1.0.0/
+          age.parquet
 
 As you can see all media files are stored
 inside the ``media/`` folder,
@@ -246,24 +246,24 @@ We can again inspect the repository.
 data/
   data-local/
     age-test/
-      1.1.0/
-        db.parquet
-        db.yaml
       1.0.0/
         db.parquet
         db.yaml
-      meta/
-        1.1.0/
-          age.parquet
-        1.0.0/
-          age.parquet
+      1.1.0/
+        db.parquet
+        db.yaml
       media/
-        1.1.0/
-          ef4d1e81-6488-95cf-a165-604d1e47d575.zip
         1.0.0/
           436c65ec-1e42-f9de-2708-ecafe07e827e.zip
           e26ef45d-bdc1-6153-bdc4-852d83806e4a.zip
           fda7e4d6-f2b2-4cff-cab5-906ef5d57607.zip
+        1.1.0/
+          ef4d1e81-6488-95cf-a165-604d1e47d575.zip
+      meta/
+        1.0.0/
+          age.parquet
+        1.1.0/
+          age.parquet
 
 And check which databases are available.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -22,8 +22,6 @@ Let's load version 1.4.1 of the emodb_ database.
 .. Load with only_metadata=True in the background
 .. invisible-code-block: python
 
-    import audformat as _audformat
-
     db = audb.load(
         "emodb",
         version="1.4.1",

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -32,11 +32,9 @@ Let's load version 1.4.1 of the emodb_ database.
         verbose=False,
     )
     # Add flavor path, to mimic `full_path=True`
+    flavor_path = audb.flavor_path("emodb", "1.4.1").replace("\\", "/")
     for table in list(db.tables):
-        db[table]._df.index = _audformat.utils.expand_file_path(
-            db[table]._df.index,
-            f'...{audb.flavor_path("emodb", "1.4.1")}',
-        )
+        db[table]._df.index = f"...{flavor_path}/" + db[table]._df.index
 
 .. skip: next
 


### PR DESCRIPTION
In https://github.com/audeering/audb/pull/469 we switched to use `sybil` for doctests, but we forgot to push `docs/conftest.py` to include the documentation files as well. This is fixed by this pull request.

## Summary by Sourcery

Tests:
- Enable testing of documentation files using sybil by adding a conftest.py file in the docs directory.