### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.12'
           # Other pandas versions
           - os: ubuntu-latest
             python-version: '3.10'

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -32,7 +32,7 @@ class Repository:
     }
 
     if hasattr(audbackend.backend, "Artifactory"):
-        _backends["artifactory"] = audbackend.backend.Artifactory
+        _backends["artifactory"] = audbackend.backend.Artifactory  # pragma: no cover
 
     backend_registry = _backends
     r"""Backend registry.
@@ -121,7 +121,7 @@ class Repository:
         backend_class = self.backend_registry[self.backend]
         backend = backend_class(self.host, self.name)
         if self.backend == "artifactory":
-            interface = audbackend.interface.Maven(backend)
+            interface = audbackend.interface.Maven(backend)  # pragma: no cover
         else:
             interface = audbackend.interface.Versioned(backend)
         return interface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import platform
+import sys
 
 import pytest
 
@@ -208,12 +209,15 @@ def private_and_public_repository():
     public_artifactory_host = "https://audeering.jfrog.io/artifactory"
     public_s3_host = "s3.dualstack.eu-north-1.amazonaws.com"
     audb.config.REPOSITORIES = [
-        audb.Repository("data-private", public_artifactory_host, "artifactory"),
         audb.Repository("audb-private", public_s3_host, "s3"),
-        audb.Repository("data-public", public_artifactory_host, "artifactory"),
         audb.Repository("audb-public", public_s3_host, "s3"),
-        audb.Repository("data-public2", public_artifactory_host, "artifactory"),
     ]
+    if sys.version_info < (3, 12):
+        audb.config.REPOSITORIES += [
+            audb.Repository("data-private", public_artifactory_host, "artifactory"),
+            audb.Repository("data-public", public_artifactory_host, "artifactory"),
+            audb.Repository("data-public2", public_artifactory_host, "artifactory"),
+        ]
 
     yield repository
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -7,6 +7,12 @@ import audbackend
 import audb
 
 
+if hasattr(audbackend.backend, "Artifactory"):
+    artifactory_backend = audbackend.backend.Artifactory
+else:
+    artifactory_backend = None
+
+
 @pytest.mark.parametrize(
     "repository1, repository2, expected",
     [
@@ -76,7 +82,7 @@ def test_repository_repr(backend, host, repo, expected):
             "artifactory",
             "host",
             "repo",
-            audbackend.backend.Artifactory,
+            artifactory_backend,
             audbackend.interface.Maven,
             marks=pytest.mark.skipif(
                 sys.version_info >= (3, 12),

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 import audbackend
@@ -70,12 +72,16 @@ def test_repository_repr(backend, host, repo, expected):
             audbackend.backend.FileSystem,
             audbackend.interface.Versioned,
         ),
-        (
+        pytest.param(
             "artifactory",
             "host",
             "repo",
             audbackend.backend.Artifactory,
             audbackend.interface.Maven,
+            marks=pytest.mark.skipif(
+                sys.version_info >= (3, 12),
+                reason="No artifactory backend support in Python>=3.12",
+            ),
         ),
     ],
 )

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -424,10 +424,7 @@ def test_database_iterator_error():
     db = audformat.Database("db")
     db["some"] = audformat.Table()
     table = "some"
-    error_msg = (
-        "Can't instantiate abstract class DatabaseIterator "
-        "with abstract method _initialize_stream"
-    )
+    error_msg = "Can't instantiate abstract class DatabaseIterator"
     with pytest.raises(TypeError, match=error_msg):
         audb.DatabaseIterator(
             db,


### PR DESCRIPTION
Adds Python 3.12 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.12 and update CI to test against it.

New Features:
- Add support for Python 3.12 in the project.

CI:
- Enable testing for Python 3.12 on Ubuntu runners in the CI workflow.