### PR TITLE
DOC: fix doctests to for new public repo

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -23,8 +23,7 @@ using :class:`audb.config`.
 '/data/audb'
 
 >>> audb.config.REPOSITORIES
-[Repository('data-public', 'https://audeering.jfrog.io/artifactory', 'artifactory'),
- Repository('data-local', '~/audb-host', 'file-system')]
+[Repository('audb-public', 's3.dualstack.eu-north-1.amazonaws.com', 's3'), Repository('data-local', '~/audb-host', 'file-system')]
 
 >>> audb.config.CACHE_ROOT = "/user/cache"
 >>> audb.config.CACHE_ROOT

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,10 +11,10 @@ or check them in your Python console:
 
 >>> import audb
 >>> audb.available(only_latest=True)
-                         backend  ... version
-name                              ...
+                      backend  ... version
+name                           ...
 ...
-emodb                artifactory  ...   1.4.1
+emodb                      s3  ...   1.4.1
 ...
 
 Let's load version 1.4.1 of the emodb_ database.


### PR DESCRIPTION
In https://github.com/audeering/audb/pull/450 we switched to a new default public repo on S3, but we haven't updated the doctests accordingly.

## Summary by Sourcery

Documentation:
- Update doctests in the documentation to reflect the new default public repository on S3.