### PR TITLE
Raise deprecation warning for 22500 Hz

### DIFF
--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 import os
 import shutil
+import warnings
 
 import numpy as np
 
@@ -81,7 +82,14 @@ class Flavor(audobject.Object):
 
         if sampling_rate is not None:
             sampling_rate = int(sampling_rate)
-            if sampling_rate not in define.SAMPLING_RATES:
+            if sampling_rate == 22500:
+                message = (
+                    "A sampling rate of 22500 Hz is deprecated "
+                    "and will be removed with version 1.13.0 of audb. "
+                    "Use 22050 Hz instead."
+                )
+                warnings.warn(message, category=UserWarning, stacklevel=2)
+            elif sampling_rate not in define.SAMPLING_RATES:
                 raise ValueError(
                     f"Sampling_rate has to be one of "
                     f"{define.SAMPLING_RATES}, not {sampling_rate}."

--- a/tests/test_flavor.py
+++ b/tests/test_flavor.py
@@ -73,6 +73,13 @@ def test_init(bit_depth, channels, format, mixdown, sampling_rate):
     assert flavor.id == flavor_2.id
 
 
+def test_deprecated_sampling_rate():
+    """Test a sampling rate of 22500 Hz raises user warning."""
+    message = "removed with version 1.13.0"
+    with pytest.warns(UserWarning, match=message):
+        audb.Flavor(sampling_rate=22500)
+
+
 @pytest.mark.parametrize(
     "format",
     [


### PR DESCRIPTION
This raises a deprecation warning for a sampling rate of 22500 Hz and marks it to be removed in version 1.13.0 of `audb`.

## Summary by Sourcery

Tests:
- Add a test to ensure a deprecation warning is raised for a sampling rate of 22500 Hz.