### PR TITLE
Remove filesystem backend from default repos

### DIFF
--- a/audb/core/etc/audb.yaml
+++ b/audb/core/etc/audb.yaml
@@ -4,6 +4,3 @@ repositories:
   - name: audb-public
     backend: s3
     host: s3.dualstack.eu-north-1.amazonaws.com
-  - name: data-local
-    backend: file-system
-    host: ~/audb-host

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -23,7 +23,7 @@ using :class:`audb.config`.
 '/data/audb'
 
 >>> audb.config.REPOSITORIES
-[Repository('audb-public', 's3.dualstack.eu-north-1.amazonaws.com', 's3'), Repository('data-local', '~/audb-host', 'file-system')]
+[Repository('audb-public', 's3.dualstack.eu-north-1.amazonaws.com', 's3')]
 
 >>> audb.config.CACHE_ROOT = "/user/cache"
 >>> audb.config.CACHE_ROOT


### PR DESCRIPTION
We have `~/audb-host` as a repository on the local filesystem in the default repositories, but we do not use it.
To not confuse anyone with this repo, and avoid possible failing code if the folder does not exists, we remove it from the default config.

## Summary by Sourcery

Chores:
- Remove unused local filesystem repository from default configuration.