### PR TITLE
Raise custom ValueError for non supported backends

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -653,6 +653,8 @@ def publish(
         ValueError: if ``version`` or ``previous_version``
             cannot be parsed by :class:`audeer.StrictVersion`
         ValueError: if ``previous_version`` >= ``version``
+        ValueError: if ``repository`` has artifactory as backend in Python>=3.12
+        ValueError: if ``repository`` has a non-supported backend
 
     """
     # Enforce error if version cannot be converted to audeer.StrictVersion

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -1,3 +1,5 @@
+import sys
+
 import audbackend
 
 
@@ -117,7 +119,15 @@ class Repository:
         Returns:
             interface to repository
 
+        Raises:
+            ValueError: if an artifactory backend is requested in Python>=3.12
+            ValueError: if a non-supported backend is requested
+
         """
+        if sys.version_info >= (3, 12) and self.backend == "artifactory":
+            raise ValueError("The 'artifactory' backend is not support in Python>=3.12")
+        if self.backend not in self.backend_registry:
+            raise ValueError(f"'{self.backend}' is not a registered backend")
         backend_class = self.backend_registry[self.backend]
         backend = backend_class(self.host, self.name)
         if self.backend == "artifactory":

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -125,7 +125,9 @@ class Repository:
 
         """
         if sys.version_info >= (3, 12) and self.backend == "artifactory":
-            raise ValueError("The 'artifactory' backend is not support in Python>=3.12")
+            raise ValueError(
+                "The 'artifactory' backend is not supported in Python>=3.12"
+            )
         if self.backend not in self.backend_registry:
             raise ValueError(f"'{self.backend}' is not a registered backend")
         backend_class = self.backend_registry[self.backend]

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -125,7 +125,7 @@ class Repository:
 
         """
         if sys.version_info >= (3, 12) and self.backend == "artifactory":
-            raise ValueError(
+            raise ValueError(  # pragma: no cover
                 "The 'artifactory' backend is not supported in Python>=3.12"
             )
         if self.backend not in self.backend_registry:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -129,7 +129,7 @@ def test_repository_create_backend_interface(
             "artifactory",
             "host",
             "repo",
-            "The 'artifactory' backend is not support in Python>=3.12",
+            "The 'artifactory' backend is not supported in Python>=3.12",
             ValueError,
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 12),

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -119,18 +119,22 @@ def test_repository_create_backend_interface(
     "backend, host, repo, expected_error_msg, expected_error",
     [
         (
-            "artifactory",
-            "host",
-            "repo",
-            "The 'artifactory' backend is not support in Python>=3.12",
-            ValueError,
-        ),
-        (
             "custom",
             "host",
             "repo",
             "'custom' is not a registered backend",
             ValueError,
+        ),
+        pytest.param(
+            "artifactory",
+            "host",
+            "repo",
+            "The 'artifactory' backend is not support in Python>=3.12",
+            ValueError,
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 12),
+                reason="Should only fail for Python>=3.12",
+            ),
         ),
     ],
 )

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -113,3 +113,34 @@ def test_repository_create_backend_interface(
     assert isinstance(backend_interface, expected_interface)
     assert isinstance(backend_interface.backend, expected_backend)
     assert not backend_interface.backend.opened
+
+
+@pytest.mark.parametrize(
+    "backend, host, repo, expected_error_msg, expected_error",
+    [
+        (
+            "artifactory",
+            "host",
+            "repo",
+            "The 'artifactory' backend is not support in Python>=3.12",
+            ValueError,
+        ),
+        (
+            "custom",
+            "host",
+            "repo",
+            "'custom' is not a registered backend",
+            ValueError,
+        ),
+    ],
+)
+def test_repository_create_backend_interface_errors(
+    backend,
+    host,
+    repo,
+    expected_error_msg,
+    expected_error,
+):
+    repository = audb.Repository(repo, host, backend)
+    with pytest.raises(expected_error, match=expected_error_msg):
+        repository.create_backend_interface()


### PR DESCRIPTION
This extends `audb.Repository.create_backend_interface()` to raise a custom `ValueError` if an artiactory backend is requested for Python>=3.12 and a custom `ValueError` if a non registered backend is requested.

![image](https://github.com/user-attachments/assets/82ffc62d-14e3-4cb6-9177-9c2a64892366)

We also add corresponding error to the docstring of `audb.publish()`, which calls `audb.Repository.create_backend_interface()`.

![image](https://github.com/user-attachments/assets/0f5131c1-73b6-48e2-b3d3-2285d96081bb)

## Summary by Sourcery

Enhance the audb.Repository.create_backend_interface() method to raise specific ValueErrors when an unsupported backend is requested, particularly for the 'artifactory' backend in Python>=3.12 and for any non-registered backends. Add corresponding tests to ensure these errors are raised correctly.

Enhancements:
- Extend error handling in audb.Repository.create_backend_interface() to raise specific ValueErrors for unsupported backends.

Tests:
- Add tests to verify that audb.Repository.create_backend_interface() raises appropriate ValueErrors for unsupported backends.