### PR TITLE
Skip non-registered or non-supported backends

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -101,7 +101,7 @@ def available(
                             name = path.split("/")[1]
                             add_database(name, version, repository)
 
-        except audbackend.BackendError:
+        except (audbackend.BackendError, ValueError):
             continue
 
     df = pd.DataFrame.from_records(
@@ -635,7 +635,7 @@ def versions(
                             suppress_backend_errors=True,
                         )
                     )
-        except audbackend.BackendError:
+        except (audbackend.BackendError, ValueError):
             # If the backend cannot be accessed,
             # e.g. host or repository do not exist,
             # we skip it

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -91,7 +91,7 @@ def _lookup(
         try:
             backend_interface = repository.create_backend_interface()
             backend_interface.backend.open()
-        except audbackend.BackendError:
+        except (audbackend.BackendError, ValueError):
             continue
 
         header = backend_interface.join("/", name, "db.yaml")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import audeer
 import audformat
@@ -22,14 +23,25 @@ def test_available(repository):
     # Non existing repo
     name = "non-existing-repo"
     audb.config.REPOSITORIES = [
-        audb.Repository(
-            name=name,
-            host=repository.host,
-            backend=repository.backend,
-        )
+        audb.Repository(name, repository.host, repository.backend)
     ]
     df = audb.available()
     assert len(df) == 0
+
+    # Non existing backend
+    audb.config.REPOSITORIES = [
+        audb.Repository(repository.name, repository.host, "custom")
+    ]
+    df = audb.available()
+    assert len(df) == 0
+
+    # artifactory backend and Python>=3.12
+    if sys.version_info >= (3, 12):
+        audb.config.REPOSITORIES = [
+            audb.Repository(repository.name, repository.host, "artifactory")
+        ]
+        df = audb.available()
+        assert len(df) == 0
 
 
 def test_available_broken_dataset(private_and_public_repository):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import audeer
 import audformat
@@ -35,13 +34,13 @@ def test_available(repository):
     df = audb.available()
     assert len(df) == 0
 
-    # artifactory backend and Python>=3.12
-    if sys.version_info >= (3, 12):
-        audb.config.REPOSITORIES = [
-            audb.Repository(repository.name, repository.host, "artifactory")
-        ]
-        df = audb.available()
-        assert len(df) == 0
+    # artifactory backend with non-existing host,
+    # and non-support under Python>=3.12
+    audb.config.REPOSITORIES = [
+        audb.Repository("repo", "https:artifactory.url.com", "artifactory")
+    ]
+    df = audb.available()
+    assert len(df) == 0
 
 
 def test_available_broken_dataset(private_and_public_repository):


### PR DESCRIPTION
In https://github.com/audeering/audb/pull/486 we introduced custom errors for non-registered backends or the artifactory backend with Python >=3.12 when instantiating a backend interface. Here we extend `audb.available()`, `audb.versions()`, and the helper function `audb.core.utils._lookup()` which all instantiate backend interfaces to skip any repository which raises an error.
This allows us to have a common configuration file when using `audb` with Python <3.12 or Python >=-3.12, as long as we want to support Artifactory backends in Python <3.12.

## Summary by Sourcery

Extend audb.available(), audb.versions(), and audb.core.utils._lookup() to skip repositories that raise errors due to non-existing backends or compatibility issues with Python >=3.12. Update test cases to cover these scenarios.

Bug Fixes:
- Skip repositories with non-existing backends or those that raise errors in audb.available(), audb.versions(), and audb.core.utils._lookup().

Tests:
- Add test cases to verify behavior when encountering non-existing repositories and backends, including Artifactory backend with Python >=3.12.