### PR TITLE
Release 1.11.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Version 1.11.0 (2024-12-06)
   (without Artifactory backend)
 * Added: support for Python 3.12
   (without Artifactory backend)
-* Changed: switched default repository
+* Changed: switch default repository
   to ``audb-public``,
   hosted on S3
 * Changed: ``audb.Repository.create_backend_interface()``
@@ -24,11 +24,10 @@ Version 1.11.0 (2024-12-06)
   now raise a ``ValueError``
   for a repository with non-registered backends,
   or an Artifactory backend under Python>=3.12
-* Changed: all functions
-  with read-only access to repositories
-  now skip non-registered backends
+* Changed: skip non-registered backends
   without raising an error
-* Changed: simplified quickstart section
+  in all functions with read-only access to repositories
+* Changed: simplify quickstart section
   of the documentation
 * Changed: depend on ``audbackend>=2.2.1``
 * Changed: depend on ``audeer>=2.2.0``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Version 1.11.0 (2024-12-06)
 * Changed: ``audb.Repository.create_backend_interface()``
   and ``audb.publish()``
   now raise a ``ValueError``
-  for an repository with non-registered backend,
+  for a repository with non-registered backends,
   or an Artifactory backend under Python>=3.12
 * Changed: all functions
   with read-only access to repositories

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,9 +32,8 @@ Version 1.11.0 (2024-12-06)
   of the documentation
 * Changed: depend on ``audbackend>=2.2.1``
 * Changed: depend on ``audeer>=2.2.0``
-* Deprecated: a sampling rate of 22500 Hz
-  as possible flavor
-* Removed: file system repository from default configuration
+* Deprecated: a sampling rate of 22500 Hz as flavor
+* Removed: file-system repository from default configuration
 * Fixed: handle an empty configuration file
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,37 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.11.0 (2024-12-06)
+---------------------------
+
+* Added: a sampling rate of 24000 Hz as flavor
+* Added: a sampling rate of 22050 Hz as flavor
+* Added: support for Python 3.13
+  (without Artifactory backend)
+* Added: support for Python 3.12
+  (without Artifactory backend)
+* Changed: switched default repository
+  to ``audb-public``,
+  hosted on S3
+* Changed: ``audb.Repository.create_backend_interface()``
+  and ``audb.publish()``
+  now raise a ``ValueError``
+  for an repository with non-registered backend,
+  or an Artifactory backend under Python>=3.12
+* Changed: all functions
+  with read-only access to repositories
+  now skip non-registered backends
+  without raising an error
+* Changed: simplified quickstart section
+  of the documentation
+* Changed: depend on ``audbackend>=2.2.1``
+* Changed: depend on ``audeer>=2.2.0``
+* Deprecated: a sampling rate of 22500 Hz
+  as possible flavor
+* Removed: file system repository from default configuration
+* Fixed: handle an empty configuration file
+
+
 Version 1.10.2 (2024-11-18)
 ---------------------------
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/74761157-635f-4dd0-90cd-a2a2d09fee89)


## Summary by Sourcery

Documentation:
- Update the CHANGELOG.rst file to include details for the 1.11.0 release.