### PR TITLE
Add repositories argument to audb.available()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -38,6 +38,9 @@ def available(
         table with database name as index,
         and backend, host, repository, version as columns
 
+    Raises:
+        ValueError: if ``repositories`` is an empty when provided
+
     Examples:
         >>> df = audb.available(only_latest=True)
         >>> df.loc[["air", "emodb"]]
@@ -63,6 +66,8 @@ def available(
 
     if repositories is not None:
         repositories = audeer.to_list(repositories)
+        if not repositories:
+            raise ValueError("'repositories' argument must not be empty when provided")
     else:
         repositories = config.REPOSITORIES
 

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -26,11 +26,13 @@ from audb.core.repository import Repository
 def available(
     *,
     only_latest: bool = False,
+    repositories: Repository | Sequence[Repository] = None,
 ) -> pd.DataFrame:
     r"""List all databases that are available to the user.
 
     Args:
         only_latest: include only latest version of database
+        repositories: search only in the given repositories
 
     Returns:
         table with database name as index,
@@ -59,7 +61,12 @@ def available(
             ]
         )
 
-    for repository in config.REPOSITORIES:
+    if repositories is not None:
+        repositories = audeer.to_list(repositories)
+    else:
+        repositories = config.REPOSITORIES
+
+    for repository in repositories:
         try:
             backend_interface = repository.create_backend_interface()
             with backend_interface.backend as backend:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -38,9 +38,6 @@ def available(
         table with database name as index,
         and backend, host, repository, version as columns
 
-    Raises:
-        ValueError: if ``repositories`` is an empty when provided
-
     Examples:
         >>> df = audb.available(only_latest=True)
         >>> df.loc[["air", "emodb"]]
@@ -66,8 +63,6 @@ def available(
 
     if repositories is not None:
         repositories = audeer.to_list(repositories)
-        if not repositories:
-            raise ValueError("'repositories' argument must not be empty when provided")
     else:
         repositories = config.REPOSITORIES
 

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -32,7 +32,9 @@ def available(
 
     Args:
         only_latest: include only latest version of database
-        repositories: search only in the given repositories
+        repositories: search only in the given repositories.
+            If ``None``,
+            :attr:`audb.config.REPOSITORIES` is used
 
     Returns:
         table with database name as index,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,9 +141,8 @@ class TestAvailable:
     @pytest.mark.parametrize("repositories", [[], ()])
     def test_repositories_empty(self, repositories):
         """Tests empty repositories argument."""
-        expected_error_msg = "'repositories' argument must not be empty when provided"
-        with pytest.raises(ValueError, match=expected_error_msg):
-            audb.available(repositories=repositories)
+        df = audb.available(repositories=repositories)
+        assert len(df) == 0
 
     def test_broken_database(self, repository_with_broken_database):
         """Test having a database only given as a folder."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,6 +93,36 @@ class TestAvailable:
         assert "name0" in df.index
         assert "name1" in df.index
 
+    def test_repositories_all(self):
+        """Test repositories argument with all repositories."""
+        df = audb.available(repositories=self.repositories)
+        assert len(df) == 2
+
+    @pytest.mark.parametrize("repository_index", [0, 1])
+    @pytest.mark.parametrize("as_list", [False, True])
+    def test_repositories_single(self, repository_index, as_list):
+        """Test repositories argument with single repositories.
+
+        Args:
+            repository_index: select single repository
+                by the given index
+                from ``audb.config.REPOSITORIES``
+            as_list: if ``True``,
+                single repository is given as list
+                to ``repositories`` argument
+
+        """
+        repository = audb.config.REPOSITORIES[repository_index]
+        if as_list:
+            repositories = [repository]
+        else:
+            repositories = repository
+        df = audb.available(repositories=repositories)
+        assert len(df) == 1
+        assert df.host.iloc[0] == repository.host
+        assert df.repository.iloc[0] == repository.name
+        assert df.index[0] == f"name{repository_index}"
+
     def test_broken_database(self, repository_with_broken_database):
         """Test having a database only given as a folder."""
         df = audb.available()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,6 +138,13 @@ class TestAvailable:
         # Verify host
         assert df.host.iloc[0] == repository.host
 
+    @pytest.mark.parametrize("repositories", [[], ()])
+    def test_repositories_empty(self, repositories):
+        """Tests empty repositories argument."""
+        expected_error_msg = "'repositories' argument must not be empty when provided"
+        with pytest.raises(ValueError, match=expected_error_msg):
+            audb.available(repositories=repositories)
+
     def test_broken_database(self, repository_with_broken_database):
         """Test having a database only given as a folder."""
         df = audb.available()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,45 +95,48 @@ class TestAvailable:
 
     def test_repositories_all(self):
         """Test repositories argument with all repositories."""
-        df = audb.available(repositories=audb.config.REPOSITORIES)
+        repositories = audb.config.REPOSITORIES
+        df = audb.available(repositories=repositories)
         assert len(df) == 2
 
         # Verify repositories
-        expected_repos = set(audb.config.REPOSITORIES)
+        expected_repos = set([repo.name for repo in repositories])
         assert set(df.repository.unique()) == expected_repos
 
-        # Verify database names are present
+        # Verify database names
         assert "name0" in df.index
         assert "name1" in df.index
 
         # Verify hosts
-        assert df.loc["name0", "host"] == "host0"
-        assert df.loc["name1", "host"] == "host1"
+        assert df.loc["name0", "host"] == repositories[0].host
+        assert df.loc["name1", "host"] == repositories[1].host
 
     @pytest.mark.parametrize("repository_index", [0, 1])
-    @pytest.mark.parametrize("as_list", [False, True])
-    def test_repositories_single(self, repository_index, as_list):
+    @pytest.mark.parametrize("preprocess_repository", [lambda x: x, lambda x: [x]])
+    def test_repositories_single(self, repository_index, preprocess_repository):
         """Test repositories argument with single repositories.
 
         Args:
             repository_index: select single repository
                 by the given index
                 from ``audb.config.REPOSITORIES``
-            as_list: if ``True``,
-                single repository is given as list
-                to ``repositories`` argument
+            preprocess_repository: apply given function
+                to single repository
+                before using as ``repositories`` argument
 
         """
         repository = audb.config.REPOSITORIES[repository_index]
-        if as_list:
-            repositories = [repository]
-        else:
-            repositories = repository
-        df = audb.available(repositories=repositories)
+        df = audb.available(repositories=preprocess_repository(repository))
         assert len(df) == 1
-        assert df.host.iloc[0] == repository.host
+
+        # Verify repository
         assert df.repository.iloc[0] == repository.name
+
+        # Verify database name
         assert df.index[0] == f"name{repository_index}"
+
+        # Verify host
+        assert df.host.iloc[0] == repository.host
 
     def test_broken_database(self, repository_with_broken_database):
         """Test having a database only given as a folder."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,7 +95,7 @@ class TestAvailable:
 
     def test_repositories_all(self):
         """Test repositories argument with all repositories."""
-        df = audb.available(repositories=self.repositories)
+        df = audb.available(repositories=audb.config.REPOSITORIES)
         assert len(df) == 2
 
     @pytest.mark.parametrize("repository_index", [0, 1])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -98,6 +98,18 @@ class TestAvailable:
         df = audb.available(repositories=audb.config.REPOSITORIES)
         assert len(df) == 2
 
+        # Verify repositories
+        expected_repos = set(audb.config.REPOSITORIES)
+        assert set(df.repository.unique()) == expected_repos
+
+        # Verify database names are present
+        assert "name0" in df.index
+        assert "name1" in df.index
+
+        # Verify hosts
+        assert df.loc["name0", "host"] == "host0"
+        assert df.loc["name1", "host"] == "host1"
+
     @pytest.mark.parametrize("repository_index", [0, 1])
     @pytest.mark.parametrize("as_list", [False, True])
     def test_repositories_single(self, repository_index, as_list):


### PR DESCRIPTION
Add `repositories` argument to `audb.available()` to be able to limit the repositories, in which it should search. Before, a user needed to modify `audb.confg.REPOSITORIES` before calling `audb.available()` to limit its output to certain repositories.

![image](https://github.com/user-attachments/assets/bbd199bb-e6ea-4e50-84ad-f481dfb50a15)


## Summary by Sourcery

Add a 'repositories' argument to the audb.available() function to enable users to limit the search to specified repositories, enhancing the function's flexibility and usability.

New Features:
- Introduce a 'repositories' argument to the audb.available() function, allowing users to specify which repositories to search.

Tests:
- Add tests for the new 'repositories' argument in audb.available(), including scenarios for all repositories and single repository searches.