### PR TITLE
Ensure audb.Repository is hashable

### DIFF
--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -71,6 +71,15 @@ class Repository:
         """
         return str(self) == str(other)
 
+    def __hash__(self):
+        """Hash of repository.
+
+        Returns:
+            hash of repository
+
+        """
+        return hash(str(self))
+
     def __repr__(self):  # noqa: D105
         return (
             f"Repository("

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -71,7 +71,7 @@ class Repository:
         """
         return str(self) == str(other)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash of repository.
 
         Returns:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -44,6 +44,17 @@ def test_repository_eq(repository1, repository2, expected):
 
 
 @pytest.mark.parametrize(
+    "repository",
+    [audb.Repository("repo", "host", "file-system")],
+)
+def test_repository_hash(repository):
+    """Test Repository object is hashable."""
+    assert isinstance(hash(repository), int)
+    # set needs `__hash__` to exist to work
+    assert set([repository]) == set([str(repository)])
+
+
+@pytest.mark.parametrize(
     "backend, host, repo, expected",
     [
         (

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -44,14 +44,56 @@ def test_repository_eq(repository1, repository2, expected):
 
 
 @pytest.mark.parametrize(
-    "repository",
-    [audb.Repository("repo", "host", "file-system")],
+    "repo1, repo2, should_have_same_hash",
+    [
+        # Same repositories should have same hash
+        (
+            audb.Repository("repo", "host", "file-system"),
+            audb.Repository("repo", "host", "file-system"),
+            True,
+        ),
+        # Different attributes should have different hashes
+        (
+            audb.Repository("repo1", "host", "file-system"),
+            audb.Repository("repo2", "host", "file-system"),
+            False,
+        ),
+        (
+            audb.Repository("repo", "host1", "file-system"),
+            audb.Repository("repo", "host2", "file-system"),
+            False,
+        ),
+        (
+            audb.Repository("repo", "host", "file-system"),
+            audb.Repository("repo", "host", "s3"),
+            False,
+        ),
+    ],
 )
-def test_repository_hash(repository):
-    """Test Repository object is hashable."""
-    assert isinstance(hash(repository), int)
-    # set needs `__hash__` to exist to work
-    assert set([repository]) == set([str(repository)])
+def test_repository_hash(repo1, repo2, should_have_same_hash):
+    """Test Repository object hash behavior.
+
+    Tests that:
+    - Repository objects are hashable
+    - Equal repositories have same hash
+    - Different repositories have different hashes
+    """
+    # Verify objects are hashable
+    assert isinstance(hash(repo1), int)
+    assert isinstance(hash(repo2), int)
+
+    # Test hash equality matches object equality
+    if should_have_same_hash:
+        assert hash(repo1) == hash(repo2)
+        assert repo1 == repo2
+    else:
+        assert hash(repo1) != hash(repo2)
+        assert repo1 != repo2
+
+    # Verify can be used in sets
+    test_set = {repo1, repo2}
+    expected_len = 1 if should_have_same_hash else 2
+    assert len(test_set) == expected_len
 
 
 @pytest.mark.parametrize(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -77,6 +77,14 @@ def test_repository_hash(repo1, repo2, should_have_same_hash):
     - Repository objects are hashable
     - Equal repositories have same hash
     - Different repositories have different hashes
+
+    Args:
+        repo1: repository object
+        repo2: repository object
+        should_have_same_hash: if ``True``,
+            expects ``repo1`` and ``repo2``
+            to be the same object
+
     """
     # Verify objects are hashable
     assert isinstance(hash(repo1), int)


### PR DESCRIPTION
As `audb.config.REPOSITORIES` is given as a list of repositories, one would expect `set(audb.config.REPOSITORIES)` to work as well, which is not the case at the moment. It is solved in this pull request by adding a `__hash__()` method to `audb.Repository`.

## Summary by Sourcery

Make audb.Repository hashable by implementing the __hash__ method and add a test to ensure its hashability.

Enhancements:
- Add __hash__ method to audb.Repository to make it hashable.

Tests:
- Add test to verify that audb.Repository objects are hashable.