### PR TITLE
DOC: fix default value for config.REPOSITORIES

### DIFF
--- a/audb/core/config.py
+++ b/audb/core/config.py
@@ -115,10 +115,10 @@ class config:
     A repository is defined by the object :class:`audb.Repository`,
     containing the following attributes:
 
-    * :attr:`audb.Repository.name`: repository name, e.g. ``'data-local'``
-    * :attr:`audb.Repository.backend`: backend name, e.g. ``'artifactory'``
+    * :attr:`audb.Repository.name`: repository name, e.g. ``"audb-public"``
+    * :attr:`audb.Repository.backend`: backend name, e.g. ``"s3"``
     * :attr:`audb.Repository.host`: host name,
-      e.g. ``'https://artifactory.audeering.com/artifactory'``
+      e.g. ``"s3.dualstack.eu-north-1.amazonaws.com"``
 
     """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,12 +94,12 @@ html_title = title
 
 
 # Cache databases to avoid progress bar in code examples ------------------
+_config = audb.core.config.load_configuration_file(
+    audb.core.config.global_config_file,
+)
 audb.config.REPOSITORIES = [
-    audb.Repository(
-        name="audb-public",
-        host="s3.dualstack.eu-north-1.amazonaws.com",
-        backend="s3",
-    )
+    audb.Repository(repo["name"], repo["host"], repo["backend"])
+    for repo in _config["repositories"]
 ]
 database_name = "emodb"
 database_version = "1.4.1"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,9 +96,9 @@ html_title = title
 # Cache databases to avoid progress bar in code examples ------------------
 audb.config.REPOSITORIES = [
     audb.Repository(
-        name="data-public",
-        host="https://audeering.jfrog.io/artifactory",
-        backend="artifactory",
+        name="audb-public",
+        host="s3.dualstack.eu-north-1.amazonaws.com",
+        backend="s3",
     )
 ]
 database_name = "emodb"


### PR DESCRIPTION
Ensures the correct value is shown for `audb.config.REPOSITORIES` in the documentation.
This is ensured by reading the default config file inside `docs/conf.py` and extract the value for `REPOSITORIES` from there.

![image](https://github.com/user-attachments/assets/e3ec47dd-c844-4ce8-bf24-66f5c82e2669)

## Summary by Sourcery

Documentation:
- Correct the default value for `audb.config.REPOSITORIES` in the documentation by dynamically loading it from the default configuration file.