### PR TITLE
Support Artifactory backend with Python 3.12

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -715,7 +715,7 @@ def publish(
         ValueError: if ``version`` or ``previous_version``
             cannot be parsed by :class:`audeer.StrictVersion`
         ValueError: if ``previous_version`` >= ``version``
-        ValueError: if ``repository`` has artifactory as backend in Python>=3.12
+        ValueError: if ``repository`` has artifactory as backend in Python>=3.18
         ValueError: if ``repository`` has a non-supported backend
 
     """

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -715,7 +715,7 @@ def publish(
         ValueError: if ``version`` or ``previous_version``
             cannot be parsed by :class:`audeer.StrictVersion`
         ValueError: if ``previous_version`` >= ``version``
-        ValueError: if ``repository`` has artifactory as backend in Python>=3.18
+        ValueError: if ``repository`` has artifactory as backend in Python>=3.13
         ValueError: if ``repository`` has a non-supported backend
 
     """

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -129,13 +129,13 @@ class Repository:
             interface to repository
 
         Raises:
-            ValueError: if an artifactory backend is requested in Python>=3.12
+            ValueError: if an artifactory backend is requested in Python>=3.13
             ValueError: if a non-supported backend is requested
 
         """
-        if sys.version_info >= (3, 12) and self.backend == "artifactory":
+        if sys.version_info >= (3, 13) and self.backend == "artifactory":
             raise ValueError(  # pragma: no cover
-                "The 'artifactory' backend is not supported in Python>=3.12"
+                "The 'artifactory' backend is not supported in Python>=3.13"
             )
         if self.backend not in self.backend_registry:
             raise ValueError(f"'{self.backend}' is not a registered backend")

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -42,7 +42,7 @@ class Repository:
     Holds mapping between registered backend names,
     and their corresponding backend classes.
     The ``"artifactory"`` backend is currently not available
-    under Python >=3.12.
+    under Python >=3.13.
 
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[all] >=2.2.1',
+    'audbackend[all] >=2.2.2',
     'audeer >=2.2.0',
     'audformat >=1.2.0',
     'audiofile >=1.0.0',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,7 +212,7 @@ def private_and_public_repository():
         audb.Repository("audb-private", public_s3_host, "s3"),
         audb.Repository("audb-public", public_s3_host, "s3"),
     ]
-    if sys.version_info < (3, 12):
+    if sys.version_info < (3, 13):
         audb.config.REPOSITORIES += [
             audb.Repository("data-private", public_artifactory_host, "artifactory"),
             audb.Repository("data-public", public_artifactory_host, "artifactory"),

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -147,7 +147,7 @@ def test_repository_repr(backend, host, repo, expected):
             audbackend.interface.Maven,
             marks=pytest.mark.skipif(
                 sys.version_info >= (3, 13),
-                reason="No artifactory backend support in Python>=3.12",
+                reason="No artifactory backend support in Python>=3.13",
             ),
         ),
     ],

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -146,7 +146,7 @@ def test_repository_repr(backend, host, repo, expected):
             artifactory_backend,
             audbackend.interface.Maven,
             marks=pytest.mark.skipif(
-                sys.version_info >= (3, 12),
+                sys.version_info >= (3, 13),
                 reason="No artifactory backend support in Python>=3.12",
             ),
         ),
@@ -190,11 +190,11 @@ def test_repository_create_backend_interface(
             "artifactory",
             "host",
             "repo",
-            "The 'artifactory' backend is not supported in Python>=3.12",
+            "The 'artifactory' backend is not supported in Python>=3.13",
             ValueError,
             marks=pytest.mark.skipif(
-                sys.version_info < (3, 12),
-                reason="Should only fail for Python>=3.12",
+                sys.version_info < (3, 13),
+                reason="Should only fail for Python>=3.13",
             ),
         ),
     ],


### PR DESCRIPTION
Relying on the recent `audbackend` 2.2.2 release to add support for Artifactory backends in Python 3.12.

## Summary by Sourcery

Build:
- Update `audbackend` dependency to 2.2.2.