### PR TITLE
Release 1.11.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.11.2 (2025-02-03)
+---------------------------
+
+* Added: support for Artifactory backend under Python 3.12
+* Changed: depend on ``audbackend>=2.2.2``
+
+
 Version 1.11.1 (2025-01-06)
 ---------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ and this project adheres to `Semantic Versioning`_.
 Version 1.11.2 (2025-02-03)
 ---------------------------
 
-* Added: support for Artifactory backend under Python 3.12
+* Added: support for Artifactory backend in Python 3.12
 * Changed: depend on ``audbackend>=2.2.2``
 
 


### PR DESCRIPTION
This uses the changes introduced in https://github.com/audeering/audbackend/pull/261 and applied in https://github.com/audeering/audb/pull/495 to support Artifactory repositories under Python 3.12.

![image](https://github.com/user-attachments/assets/5e6de269-040b-4751-81de-65284ea53ec2)

