### PR TITLE
Depend on dev audbackend version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audbackend[all] >=2.2.2',
+    'audbackend[all] @ git+https://github.com/audeering/audbackend.git@python3.13',
     'audeer >=2.2.0',
     'audformat >=1.2.0',
     'audiofile >=1.0.0',


### PR DESCRIPTION
Test Artifactory with Python 3.13.

## Summary by Sourcery

Update project dependency to use a specific Git branch of audbackend for Python 3.13 compatibility

Enhancements:
- Replace fixed version of audbackend with a direct Git reference to support Python 3.13 testing

Chores:
- Modify dependency specification to use a development branch of audbackend