### PR TITLE
TST: ensure default config values for cache

### DIFF
--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -7,6 +7,8 @@ import sybil
 from sybil.parsers.rest import DocTestParser
 
 import audb
+from audb.core.config import global_config_file
+from audb.core.config import load_configuration_file
 
 
 def imports(namespace):
@@ -22,8 +24,10 @@ def cache(tmpdir_factory):
     it makes sense to cache it
     across all docstring tests.
 
-    We use a environment variable,
-    and set ``audb.config.CACHE_ROOT`` to its default value.
+    We use a environment variables,
+    and set ``audb.config.CACHE_ROOT``
+    and ``audb.config.SHARED_CACHE_ROOT``
+    to its default values.
 
     """
     cache = tmpdir_factory.mktemp("cache")
@@ -35,9 +39,7 @@ def cache(tmpdir_factory):
     # Assign values for test
     os.environ["AUDB_CACHE_ROOT"] = str(cache)
     os.environ["AUDB_SHARED_CACHE_ROOT"] = str(cache)
-    default_config = audb.core.config.load_configuration_file(
-        audb.core.config.global_config_file
-    )
+    default_config = load_configuration_file(global_config_file)
     audb.config.CACHE_ROOT = default_config["cache_root"]
     audb.config.SHARED_CACHE_ROOT = default_config["shared_cache_root"]
 


### PR DESCRIPTION
Ensures we set the expected default values to `audb.config.CACHE_ROOT` and `audb.config.SHARED_CACHE_ROOT` when running the docstring tests, to avoid the error reported at https://github.com/audeering/audb/pull/501#discussion_r2104233237

## Summary by Sourcery

Ensure docstring tests use the expected default cache configuration by setting and restoring both environment variables and `audb.config` values in the cache fixture.

Bug Fixes:
- Prevent doctest failures by explicitly setting default `audb.config.CACHE_ROOT` and `audb.config.SHARED_CACHE_ROOT` in the cache fixture

Tests:
- Capture and restore original cache config values and environment variables in the `cache` fixture