### PR TITLE
Prevent cross-repository publishing

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -762,16 +762,18 @@ def publish(
         if previous_repository != repository:
             print("repos different")
             raise RuntimeError(
-                f"Cannot publish version '{version}' to repository "
-                f"'{repository.name}' based on previous version "
-                f"'{previous_version}'. The previous version is stored "
-                f"in repository '{previous_repository.name}'. "
-                f"Publishing to a different repository would split "
-                f"the database across multiple repositories, which "
-                f"can create data privacy risks and is not supported. "
-                f"Use previous_version=None to start a new database "
-                f"in '{repository.name}' or publish to the same "
-                f"repository '{previous_repository.name}'."
+                f"Cannot publish version '{version}' "
+                f"to repository '{repository.name}' "
+                f"based on previous version '{previous_version}'. "
+                "The previous version is stored in repository "
+                f"'{previous_repository.name}'. "
+                "Publishing to a different repository would split the database "
+                "across multiple repositories, "
+                "which can create data privacy risks "
+                "and is not supported. "
+                "Use previous_version=None "
+                f"to start a new database in '{repository.name}' "
+                f"or publish to the same repository '{previous_repository.name}'."
             )
 
     # load database and dependencies

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -755,11 +755,7 @@ def publish(
     if previous_version == "latest":
         # Find latest version across all repositories (like audb.latest_version)
         all_versions = api_versions(db.name)
-        if len(all_versions) > 0:
-            previous_version = all_versions[-1]
-        else:
-            previous_version = None
-
+        previous_version = all_versions[-1] if len(all_versions) > 0 else None
     # Check repository consistency when previous_version is specified
     if previous_version is not None:
         try:

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -760,7 +760,6 @@ def publish(
     if previous_version is not None:
         previous_repository = utils._lookup(db.name, previous_version)[0]
         if previous_repository != repository:
-            print("repos different")
             raise RuntimeError(
                 f"Cannot publish version '{version}' "
                 f"to repository '{repository.name}' "

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -758,26 +758,21 @@ def publish(
         previous_version = all_versions[-1] if len(all_versions) > 0 else None
     # Check repository consistency when previous_version is specified
     if previous_version is not None:
-        try:
-            previous_repository = utils._lookup(db.name, previous_version)[0]
-            if previous_repository.name != repository.name:
-                raise RuntimeError(
-                    f"Cannot publish version '{version}' to repository "
-                    f"'{repository.name}' based on previous version "
-                    f"'{previous_version}'. The previous version is stored "
-                    f"in repository '{previous_repository.name}'. "
-                    f"Publishing to a different repository would split "
-                    f"the database across multiple repositories, which "
-                    f"can create data privacy risks and is not supported. "
-                    f"Use previous_version=None to start a new database "
-                    f"in '{repository.name}' or publish to the same "
-                    f"repository '{previous_repository.name}'."
-                )
-        except RuntimeError as e:
-            # If lookup fails because previous version doesn't exist,
-            # re-raise the original error
-            if "Cannot find version" in str(e):
-                raise
+        previous_repository = utils._lookup(db.name, previous_version)[0]
+        if previous_repository != repository:
+            print("repos different")
+            raise RuntimeError(
+                f"Cannot publish version '{version}' to repository "
+                f"'{repository.name}' based on previous version "
+                f"'{previous_version}'. The previous version is stored "
+                f"in repository '{previous_repository.name}'. "
+                f"Publishing to a different repository would split "
+                f"the database across multiple repositories, which "
+                f"can create data privacy risks and is not supported. "
+                f"Use previous_version=None to start a new database "
+                f"in '{repository.name}' or publish to the same "
+                f"repository '{previous_repository.name}'."
+            )
 
     # load database and dependencies
     deps = Dependencies()

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1082,11 +1082,12 @@ def test_publish_error_cross_repository(tmpdir):
     try:
         # Create simple database
         db_path = audeer.mkdir(tmpdir, "db")
+        name = "test_cross_repo"
         audio_file = audeer.path(db_path, "f1.wav")
         signal = np.zeros((2, 1000))
         sampling_rate = 8000
         audiofile.write(audio_file, signal, sampling_rate)
-        db = audformat.Database("test_cross_repo")
+        db = audformat.Database(name)
         index = audformat.filewise_index(os.path.basename(audio_file))
         db["table"] = audformat.Table(index)
         db["table"]["column"] = audformat.Column()
@@ -1099,7 +1100,7 @@ def test_publish_error_cross_repository(tmpdir):
         # Load the previous version to set up dependencies for next version
         # (this is the normal workflow)
         db_path_v2 = audeer.mkdir(tmpdir, "db_v2")
-        audb.load_to(db_path_v2, "test_cross_repo", version="1.0.0", verbose=False)
+        audb.load_to(db_path_v2, name, version="1.0.0", verbose=False)
 
         # Try to publish version 2.0.0 to repo2 with previous_version="latest"
         # This should fail because latest version is in repo1
@@ -1121,14 +1122,10 @@ def test_publish_error_cross_repository(tmpdir):
         audb.publish(db_path, "2.0.0", repo2, previous_version=None)
 
         # Assert that the new version appears in repo2
-        assert os.path.exists(
-            audeer.path(repo2.host, repo2.name, "test_cross_repo", "2.0.0")
-        )
+        assert os.path.exists(audeer.path(repo2.host, repo2.name, name, "2.0.0"))
 
         # Assert that the new version does NOT appear in repo1
-        assert not os.path.exists(
-            audeer.path(repo1.host, repo1.name, "test_cross_repo", "2.0.0")
-        )
+        assert not os.path.exists(audeer.path(repo1.host, repo1.name, name, "2.0.0"))
 
     finally:
         # Restore original repositories

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1117,7 +1117,18 @@ def test_publish_error_cross_repository(tmpdir):
             audb.publish(db_path_v2, "2.0.0", repo2, previous_version="1.0.0")
 
         # Publishing to repo2 with previous_version=None should work
+        os.remove(audeer.path(db_path, "db.parquet"))
         audb.publish(db_path, "2.0.0", repo2, previous_version=None)
+
+        # Assert that the new version appears in repo2
+        assert os.path.exists(
+            audeer.path(repo2.host, repo2.name, "test_cross_repo", "2.0.0")
+        )
+
+        # Assert that the new version does NOT appear in repo1
+        assert not os.path.exists(
+            audeer.path(repo1.host, repo1.name, "test_cross_repo", "2.0.0")
+        )
 
     finally:
         # Restore original repositories

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -994,6 +994,74 @@ def test_publish_error_changed_deps_file_type(tmpdir, repository):
     audeer.rmdir(db_path)
 
 
+def test_publish_error_cross_repository(tmpdir):
+    """Test that publishing to different repository fails with appropriate error."""
+    # Create two separate repositories
+    host = audeer.mkdir(tmpdir, "host")
+    repo1 = audb.Repository("repo1", host, "file-system")
+    repo2 = audb.Repository("repo2", host, "file-system")
+
+    # Create directory structure for repositories
+    audeer.mkdir(host, "repo1")
+    audeer.mkdir(host, "repo2")
+
+    # Save original config and set both repositories
+    original_repos = audb.config.REPOSITORIES
+    audb.config.REPOSITORIES = [repo1, repo2]
+
+    try:
+        # Create simple database
+        db_path = audeer.mkdir(tmpdir, "db")
+        name = "test_cross_repo"
+        audio_file = audeer.path(db_path, "f1.wav")
+        signal = np.zeros((2, 1000))
+        sampling_rate = 8000
+        audiofile.write(audio_file, signal, sampling_rate)
+        db = audformat.Database(name)
+        index = audformat.filewise_index(os.path.basename(audio_file))
+        db["table"] = audformat.Table(index)
+        db["table"]["column"] = audformat.Column()
+        db["table"]["column"].set(["label"])
+        db.save(db_path)
+
+        # Publish version 1.0.0 to repo1
+        audb.publish(db_path, "1.0.0", repo1, previous_version=None)
+
+        # Load the previous version to set up dependencies for next version
+        # (this is the normal workflow)
+        db_path_v2 = audeer.mkdir(tmpdir, "db_v2")
+        audb.load_to(db_path_v2, name, version="1.0.0", verbose=False)
+
+        # Try to publish version 2.0.0 to repo2 with previous_version="latest"
+        # This should fail because latest version is in repo1
+        error_msg = (
+            "Cannot publish version '2.0.0' to repository 'repo2' "
+            "based on previous version '1.0.0'. The previous version is stored "
+            "in repository 'repo1'. Publishing to a different repository would "
+            "split the database across multiple repositories"
+        )
+        with pytest.raises(RuntimeError, match=re.escape(error_msg)):
+            audb.publish(db_path_v2, "2.0.0", repo2, previous_version="latest")
+
+        # Try to publish version 2.0.0 to repo2 with explicit previous_version
+        with pytest.raises(RuntimeError, match=re.escape(error_msg)):
+            audb.publish(db_path_v2, "2.0.0", repo2, previous_version="1.0.0")
+
+        # Publishing to repo2 with previous_version=None should work
+        os.remove(audeer.path(db_path, "db.parquet"))
+        audb.publish(db_path, "2.0.0", repo2, previous_version=None)
+
+        # Assert that the new version appears in repo2
+        assert os.path.exists(audeer.path(repo2.host, repo2.name, name, "2.0.0"))
+
+        # Assert that the new version does NOT appear in repo1
+        assert not os.path.exists(audeer.path(repo1.host, repo1.name, name, "2.0.0"))
+
+    finally:
+        # Restore original repositories
+        audb.config.REPOSITORIES = original_repos
+
+
 def test_publish_error_repository_does_not_exist(tmpdir, repository):
     db = audformat.Database("test")
     db.save(tmpdir)
@@ -1062,74 +1130,6 @@ def test_publish_error_version(tmpdir, repository):
     error_msg = "invalid version number '1.0.0?'"
     with pytest.raises(ValueError, match=re.escape(error_msg)):
         audb.publish(db_path, "2.0.0", repository, previous_version="1.0.0?")
-
-
-def test_publish_error_cross_repository(tmpdir):
-    """Test that publishing to different repository fails with appropriate error."""
-    # Create two separate repositories
-    host = audeer.mkdir(tmpdir, "host")
-    repo1 = audb.Repository("repo1", host, "file-system")
-    repo2 = audb.Repository("repo2", host, "file-system")
-
-    # Create directory structure for repositories
-    audeer.mkdir(host, "repo1")
-    audeer.mkdir(host, "repo2")
-
-    # Save original config and set both repositories
-    original_repos = audb.config.REPOSITORIES
-    audb.config.REPOSITORIES = [repo1, repo2]
-
-    try:
-        # Create simple database
-        db_path = audeer.mkdir(tmpdir, "db")
-        name = "test_cross_repo"
-        audio_file = audeer.path(db_path, "f1.wav")
-        signal = np.zeros((2, 1000))
-        sampling_rate = 8000
-        audiofile.write(audio_file, signal, sampling_rate)
-        db = audformat.Database(name)
-        index = audformat.filewise_index(os.path.basename(audio_file))
-        db["table"] = audformat.Table(index)
-        db["table"]["column"] = audformat.Column()
-        db["table"]["column"].set(["label"])
-        db.save(db_path)
-
-        # Publish version 1.0.0 to repo1
-        audb.publish(db_path, "1.0.0", repo1, previous_version=None)
-
-        # Load the previous version to set up dependencies for next version
-        # (this is the normal workflow)
-        db_path_v2 = audeer.mkdir(tmpdir, "db_v2")
-        audb.load_to(db_path_v2, name, version="1.0.0", verbose=False)
-
-        # Try to publish version 2.0.0 to repo2 with previous_version="latest"
-        # This should fail because latest version is in repo1
-        error_msg = (
-            "Cannot publish version '2.0.0' to repository 'repo2' "
-            "based on previous version '1.0.0'. The previous version is stored "
-            "in repository 'repo1'. Publishing to a different repository would "
-            "split the database across multiple repositories"
-        )
-        with pytest.raises(RuntimeError, match=re.escape(error_msg)):
-            audb.publish(db_path_v2, "2.0.0", repo2, previous_version="latest")
-
-        # Try to publish version 2.0.0 to repo2 with explicit previous_version
-        with pytest.raises(RuntimeError, match=re.escape(error_msg)):
-            audb.publish(db_path_v2, "2.0.0", repo2, previous_version="1.0.0")
-
-        # Publishing to repo2 with previous_version=None should work
-        os.remove(audeer.path(db_path, "db.parquet"))
-        audb.publish(db_path, "2.0.0", repo2, previous_version=None)
-
-        # Assert that the new version appears in repo2
-        assert os.path.exists(audeer.path(repo2.host, repo2.name, name, "2.0.0"))
-
-        # Assert that the new version does NOT appear in repo1
-        assert not os.path.exists(audeer.path(repo1.host, repo1.name, name, "2.0.0"))
-
-    finally:
-        # Restore original repositories
-        audb.config.REPOSITORIES = original_repos
 
 
 def test_publish_text_media_files(tmpdir, dbs, repository, storage_format):


### PR DESCRIPTION
Add validation to `audb.publish()` that prevents publishing new versions to different repositories when `previous_version` is specified. This fixes issue #505 where using `previous_version="latest"` could inadvertently publish to a different repository, splitting databases across multiple backends and creating potential data privacy risks.

Changes:
- Update "latest" version resolution to search across all repositories
- Add repository consistency check when previous_version is specified
- Provide clear error messages suggesting alternatives
- Add comprehensive test coverage for cross-repository scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Prevent cross-repository publishing when a previous_version is specified, update latest version resolution to search all repositories, and add tests to validate cross-repository scenarios.

Bug Fixes:
- Prevent publishing a new version to a different repository when previous_version is specified to avoid splitting databases across multiple backends (fixes #505)

Enhancements:
- Resolve "latest" version by searching across all configured repositories
- Add a consistency check with clear error messages suggesting alternatives when the target repository differs from the previous one

Tests:
- Add tests to verify error handling and successful publishing in cross-repository publish scenarios with various previous_version settings