### PR TITLE
TST: require pytest<8.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ documentation = 'https://audeering.github.io/audb/'
 dev = [
     'audiofile >=1.1.0',
     'docutils',
-    'pytest',
+    'pytest <8.4.0',
     'pytest-cov',
     'sphinx >=3.5.4',
     'sphinx-apipages >=0.1.2',


### PR DESCRIPTION
We see failing tests with `pytest>=8.4.0` for `tests/test_api.py` and `tests/test_stream.py`. Until those are fixed, we require `pytest <8.4.0` for the tests.

## Summary by Sourcery

Chores:
- Restrict pytest in dev dependencies to version <8.4.0 to avoid test failures with pytest>=8.4.0