### PR TITLE
Skip non-media files when loading flavor

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -470,15 +470,15 @@ def _get_media_from_backend(
             version,
             tmp_root=db_root_tmp,
         )
+        # media files that can be changed to a requested flavor
+        flavor_files = deps._df[deps._df.sampling_rate != 0].index
         for file in files:
             if os.name == "nt":  # pragma: no cover
                 file = file.replace(os.sep, "/")
-            if flavor is not None:
-                # Skip non-media files
-                if (sampling_rate := deps.sampling_rate(file)) == 0:
-                    continue
+            if flavor is not None and file in flavor_files:
                 bit_depth = deps.bit_depth(file)
                 channels = deps.channels(file)
+                sampling_rate = deps.sampling_rate(file)
                 src_path = os.path.join(db_root_tmp, file)
                 file = flavor.destination(file)
                 dst_path = os.path.join(db_root_tmp, file)

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -482,18 +482,13 @@ def _get_media_from_backend(
                 src_path = os.path.join(db_root_tmp, file)
                 file = flavor.destination(file)
                 dst_path = os.path.join(db_root_tmp, file)
-                try:
-                    flavor(
-                        src_path,
-                        dst_path,
-                        src_bit_depth=bit_depth,
-                        src_channels=channels,
-                        src_sampling_rate=sampling_rate,
-                    )
-                except RuntimeError:
-                    raise RuntimeError(
-                        f"Media file '{file}' does not support requesting a flavor."
-                    )
+                flavor(
+                    src_path,
+                    dst_path,
+                    src_bit_depth=bit_depth,
+                    src_channels=channels,
+                    src_sampling_rate=sampling_rate,
+                )
                 if src_path != dst_path:
                     os.remove(src_path)
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -474,9 +474,11 @@ def _get_media_from_backend(
             if os.name == "nt":  # pragma: no cover
                 file = file.replace(os.sep, "/")
             if flavor is not None:
+                # Skip non-media files
+                if (sampling_rate := deps.sampling_rate(file)) == 0:
+                    continue
                 bit_depth = deps.bit_depth(file)
                 channels = deps.channels(file)
-                sampling_rate = deps.sampling_rate(file)
                 src_path = os.path.join(db_root_tmp, file)
                 file = flavor.destination(file)
                 dst_path = os.path.join(db_root_tmp, file)

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1167,9 +1167,10 @@ def test_publish_text_media_files(tmpdir, dbs, repository, storage_format):
     assert list(db) == ["files"]
     assert os.path.exists(audeer.path(db.root, file))
 
-    error_msg = f"Media file '{file}' does not support requesting a flavor."
-    with pytest.raises(RuntimeError, match=error_msg):
-        db = audb.load(name, version=version, channels=[0], verbose=False)
+    # Test requestng a flavor
+    db = audb.load(name, version=version, channels=[0], verbose=False)
+    assert db.files == [file]
+    assert os.path.exists(audeer.path(db.root, file))
 
     # Publish database, containing text and media files
     audeer.rmdir(build_dir)
@@ -1206,9 +1207,10 @@ def test_publish_text_media_files(tmpdir, dbs, repository, storage_format):
     assert list(db) == tables
     assert os.path.exists(audeer.path(db.root, file))
 
-    error_msg = f"Media file '{file}' does not support requesting a flavor."
-    with pytest.raises(RuntimeError, match=error_msg):
-        db = audb.load(name, version=version, channels=[0], verbose=False)
+    # Test requesting a flavor
+    db = audb.load(name, version=version, channels=[0], verbose=False)
+    assert db.files == files + [file]
+    assert os.path.exists(audeer.path(db.root, file))
 
 
 def test_update_database(dbs, persistent_repository):

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1167,7 +1167,7 @@ def test_publish_text_media_files(tmpdir, dbs, repository, storage_format):
     assert list(db) == ["files"]
     assert os.path.exists(audeer.path(db.root, file))
 
-    # Test requestng a flavor
+    # Test requesting a flavor
     db = audb.load(name, version=version, channels=[0], verbose=False)
     assert db.files == [file]
     assert os.path.exists(audeer.path(db.root, file))


### PR DESCRIPTION
Closes #510

When loading a database with `audb.load()` that contains audio files and files without any audio, e.g. json files, we had forbidden to request a specific flavor and raised an error, compare https://github.com/audeering/audb/pull/392.

This was not necessary as we have the information for any file in the dependency table if it contains audio or not as all non-audio files have a sampling rate of 0. This pull request fixes it and allows now to request flavor for mixed databases as well. In that case only the files containing audio (sampling rate > 0) are converted to the requested flavor.

## Summary by Sourcery

Allow requesting audio flavor on databases containing both media and non-media files by filtering out non-audio files (sampling_rate=0) before conversion

Bug Fixes:
- Skip files with a sampling rate of zero during flavor conversion to prevent errors on non-media files

Tests:
- Update tests to assert successful flavor loading on mixed audio and non-audio databases instead of expecting errors