### PR TITLE
Fix audb.stream() for pyarrow>=21.0.0

### DIFF
--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 from collections.abc import Iterable
+from collections.abc import Iterator
 from collections.abc import Sequence
 import os
 
@@ -397,13 +398,12 @@ class DatabaseIteratorCsv(DatabaseIterator):
 
 
 class DatabaseIteratorParquet(DatabaseIterator):
-    def _initialize_stream(self) -> pa.RecordBatch:
+    def _initialize_stream(self) -> Iterator[pa.RecordBatch]:
         if self._samples == 0:
             # pyarrow >=21.0.0 does not support batch_size=0
-            return pa.RecordBatch.from_arrays([])
-        else:
-            file = os.path.join(self.root, f"db.{self._table}.parquet")
-            return parquet.ParquetFile(file).iter_batches(batch_size=self._samples)
+            return []
+        file = os.path.join(self.root, f"db.{self._table}.parquet")
+        return parquet.ParquetFile(file).iter_batches(batch_size=self._samples)
 
     def _postprocess_batch(self, batch: pa.RecordBatch) -> pd.DataFrame:
         df = batch.to_pandas(

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -398,8 +398,12 @@ class DatabaseIteratorCsv(DatabaseIterator):
 
 class DatabaseIteratorParquet(DatabaseIterator):
     def _initialize_stream(self) -> pa.RecordBatch:
-        file = os.path.join(self.root, f"db.{self._table}.parquet")
-        return parquet.ParquetFile(file).iter_batches(batch_size=self._samples)
+        if self._samples == 0:
+            # pyarrow >=21.0.0 does not support batch_size=0
+            return pa.RecordBatch.from_arrays([])
+        else:
+            file = os.path.join(self.root, f"db.{self._table}.parquet")
+            return parquet.ParquetFile(file).iter_batches(batch_size=self._samples)
 
     def _postprocess_batch(self, batch: pa.RecordBatch) -> pd.DataFrame:
         df = batch.to_pandas(


### PR DESCRIPTION
Closes #512 

Handles the case of a batch size of 0 manually now for parquet files inside `audb.stream()` as since `pyarrow>=21.0.0` it does no longer support this directly in `parquet.ParquetFile.iter_batches()`.

## Summary by Sourcery

Bug Fixes:
- Handle zero batch size manually in DatabaseIteratorParquet to support pyarrow>=21.0.0