### PR TITLE
Remove Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
             python-version: '3.10'
           # Other Python versions
           - os: ubuntu-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,13 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] >=2.2.2',
     'audeer >=2.2.0',


### PR DESCRIPTION
Removes support for Python 3.9

## Summary by Sourcery

Remove support for Python 3.9 by bumping the minimum required Python version to 3.10 and updating project metadata and CI workflows accordingly.

Build:
- Update requires-python to ">=3.10"
- Remove Python 3.9 classifier from project metadata

CI:
- Remove Python 3.9 test job from the CI workflow