### PR TITLE
TST: use Python 3.12 as default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,16 @@ jobs:
         include:
           # Different platforms
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.12'
           - os: macOS-latest
-            python-version: '3.10'
+            python-version: '3.12'
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.12'
           # Other Python versions
           - os: ubuntu-latest
-            python-version: '3.11'
+            python-version: '3.10'
           - os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.13'
           # Other pandas versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 #
 #
 default_language_version:
-  python: python3.10
+  python: python3.12
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Use Python 3.12 as default in tests

## Summary by Sourcery

Update CI workflows and pre-commit configuration to use Python 3.12 as the default version and adjust the test matrix accordingly.

Enhancements:
- Bump default Python version to 3.12 in test, linter, documentation, and publish workflows
- Reorder the test matrix to include Python 3.10, 3.11, 3.12, and 3.13 with 3.12 as the default
- Update pre-commit default_language_version to python3.12