### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.13'
+          - os: ubuntu-latest
+            python-version: '3.14'
           # Other pandas versions
           - os: ubuntu-latest
             python-version: '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.10'

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -44,6 +44,37 @@ class CrashFileSystem(audbackend.backend.FileSystem):
 audb.Repository.register("crash-file-system", CrashFileSystem)
 
 
+def _get_config():
+    """Return current audb config for passing to child processes.
+
+    With ``"spawn"`` or ``"forkserver"`` start methods,
+    child processes don't inherit the parent's memory.
+    This captures the current config so it can be passed as arguments.
+
+    """
+    repo = audb.config.REPOSITORIES[0]
+    return {
+        "cache_root": str(audb.config.CACHE_ROOT),
+        "shared_cache_root": str(audb.config.SHARED_CACHE_ROOT),
+        "repo_name": repo.name,
+        "repo_host": str(repo.host),
+        "repo_backend": repo.backend,
+    }
+
+
+def _apply_config(config):
+    """Apply audb config in a child process."""
+    audb.config.CACHE_ROOT = config["cache_root"]
+    audb.config.SHARED_CACHE_ROOT = config["shared_cache_root"]
+    audb.config.REPOSITORIES = [
+        audb.Repository(
+            name=config["repo_name"],
+            host=config["repo_host"],
+            backend=config["repo_backend"],
+        )
+    ]
+
+
 def lock_paths(cache):
     r"""Return list of lock file locations."""
     paths = []
@@ -164,7 +195,8 @@ def dbs(tmpdir_factory, persistent_repository):
     )
 
 
-def load_deps():
+def load_deps(config):
+    _apply_config(config)
     return audb.dependencies(
         DB_NAME,
         version="1.0.0",
@@ -200,9 +232,10 @@ def test_lock_dependencies(
     if multiprocessing and sys.platform in ["win32", "darwin"]:
         return
 
+    config = _get_config()
     result = audeer.run_tasks(
         load_deps,
-        [([], {})] * num_workers,
+        [([config], {})] * num_workers,
         num_workers=num_workers,
         multiprocessing=multiprocessing,
     )
@@ -210,7 +243,8 @@ def test_lock_dependencies(
     assert len(result) == num_workers
 
 
-def load_header():
+def load_header(config):
+    _apply_config(config)
     return audb.info.header(
         DB_NAME,
         version="1.0.0",
@@ -242,9 +276,10 @@ def test_lock_header(set_repositories, multiprocessing, num_workers):
     if multiprocessing and sys.platform in ["win32", "darwin"]:
         return
 
+    config = _get_config()
     result = audeer.run_tasks(
         load_header,
-        [([], {})] * num_workers,
+        [([config], {})] * num_workers,
         num_workers=num_workers,
         multiprocessing=multiprocessing,
     )
@@ -252,7 +287,8 @@ def test_lock_header(set_repositories, multiprocessing, num_workers):
     assert len(result) == num_workers
 
 
-def load_db(timeout):
+def load_db(config, timeout):
+    _apply_config(config)
     return audb.load(
         DB_NAME,
         version="1.0.0",
@@ -294,7 +330,8 @@ def test_lock_load(
         return
 
     warns = not multiprocessing and num_workers != expected
-    params = [([timeout], {})] * num_workers
+    config = _get_config()
+    params = [([config, timeout], {})] * num_workers
     if warns:
         with pytest.warns(
             UserWarning,
@@ -325,7 +362,7 @@ def test_lock_load(
 )
 def test_lock_load_crash(set_repositories):
     with pytest.raises(audbackend.BackendError):
-        load_db(-1)
+        load_db(_get_config(), -1)
 
 
 @pytest.mark.parametrize(
@@ -346,7 +383,8 @@ def test_lock_load_deprecated_timeout(
     expected,
 ):
     """Test timeout <0 argument."""
-    params = [([timeout], {})] * num_workers
+    config = _get_config()
+    params = [([config, timeout], {})] * num_workers
     msg = (
         "'timeout' values <0 are no longer supported. "
         f"Changing your provided value of {timeout} to {audb.core.define.TIMEOUT}"
@@ -450,7 +488,8 @@ def test_lock_load_from_cached_versions(
     audb.core.define.CACHED_VERSIONS_TIMEOUT = cached_version_timeout
 
 
-def load_attachment():
+def load_attachment(config):
+    _apply_config(config)
     return audb.load_attachment(
         DB_NAME,
         "folder",
@@ -488,9 +527,10 @@ def test_lock_load_attachment(
     if multiprocessing and sys.platform in ["win32", "darwin"]:
         return
 
+    config = _get_config()
     result = audeer.run_tasks(
         load_attachment,
-        [([], {})] * num_workers,
+        [([config], {})] * num_workers,
         num_workers=num_workers,
         multiprocessing=multiprocessing,
     )
@@ -498,7 +538,8 @@ def test_lock_load_attachment(
     assert len(result) == num_workers
 
 
-def load_media(timeout):
+def load_media(config, timeout):
+    _apply_config(config)
     return audb.load_media(
         DB_NAME,
         "audio/001.wav",
@@ -541,7 +582,8 @@ def test_lock_load_media(
         return
 
     warns = not multiprocessing and num_workers != expected
-    params = [([timeout], {})] * num_workers
+    config = _get_config()
+    params = [([config, timeout], {})] * num_workers
     if warns:
         with pytest.warns(
             UserWarning,
@@ -565,7 +607,8 @@ def test_lock_load_media(
     assert len(result) == expected
 
 
-def load_table():
+def load_table(config):
+    _apply_config(config)
     return audb.load_table(
         DB_NAME,
         "table",
@@ -599,9 +642,10 @@ def test_lock_load_table(set_repositories, multiprocessing, num_workers):
     if multiprocessing and sys.platform in ["win32", "darwin"]:
         return
 
+    config = _get_config()
     result = audeer.run_tasks(
         load_table,
-        [([], {})] * num_workers,
+        [([config], {})] * num_workers,
         num_workers=num_workers,
         multiprocessing=multiprocessing,
     )

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -52,6 +52,9 @@ def _get_config():
     This captures the current config so it can be passed as arguments.
 
     """
+    assert audb.config.REPOSITORIES, (
+        "audb.config.REPOSITORIES must contain at least one repository"
+    )
     repo = audb.config.REPOSITORIES[0]
     return {
         "cache_root": str(audb.config.CACHE_ROOT),

--- a/tests/test_lock_db.py
+++ b/tests/test_lock_db.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import sys
 import time
@@ -65,8 +66,20 @@ def _get_config():
     }
 
 
-def _apply_config(config):
-    """Apply audb config in a child process."""
+@contextlib.contextmanager
+def _applied_config(config):
+    """Apply audb config and restore previous values on exit.
+
+    When workers run in threads (``multiprocessing=False``),
+    ``_apply_config()`` mutates the parent process' global state.
+    This context manager restores the previous config on exit
+    to avoid cross-test interference.
+
+    """
+    previous_cache_root = audb.config.CACHE_ROOT
+    previous_shared_cache_root = audb.config.SHARED_CACHE_ROOT
+    previous_repositories = audb.config.REPOSITORIES
+
     audb.config.CACHE_ROOT = config["cache_root"]
     audb.config.SHARED_CACHE_ROOT = config["shared_cache_root"]
     audb.config.REPOSITORIES = [
@@ -76,6 +89,12 @@ def _apply_config(config):
             backend=config["repo_backend"],
         )
     ]
+    try:
+        yield
+    finally:
+        audb.config.CACHE_ROOT = previous_cache_root
+        audb.config.SHARED_CACHE_ROOT = previous_shared_cache_root
+        audb.config.REPOSITORIES = previous_repositories
 
 
 def lock_paths(cache):
@@ -199,11 +218,11 @@ def dbs(tmpdir_factory, persistent_repository):
 
 
 def load_deps(config):
-    _apply_config(config)
-    return audb.dependencies(
-        DB_NAME,
-        version="1.0.0",
-    )
+    with _applied_config(config):
+        return audb.dependencies(
+            DB_NAME,
+            version="1.0.0",
+        )
 
 
 @pytest.mark.parametrize(
@@ -247,11 +266,11 @@ def test_lock_dependencies(
 
 
 def load_header(config):
-    _apply_config(config)
-    return audb.info.header(
-        DB_NAME,
-        version="1.0.0",
-    )
+    with _applied_config(config):
+        return audb.info.header(
+            DB_NAME,
+            version="1.0.0",
+        )
 
 
 @pytest.mark.parametrize(
@@ -291,13 +310,13 @@ def test_lock_header(set_repositories, multiprocessing, num_workers):
 
 
 def load_db(config, timeout):
-    _apply_config(config)
-    return audb.load(
-        DB_NAME,
-        version="1.0.0",
-        timeout=timeout,
-        verbose=False,
-    )
+    with _applied_config(config):
+        return audb.load(
+            DB_NAME,
+            version="1.0.0",
+            timeout=timeout,
+            verbose=False,
+        )
 
 
 @pytest.mark.parametrize(
@@ -492,13 +511,13 @@ def test_lock_load_from_cached_versions(
 
 
 def load_attachment(config):
-    _apply_config(config)
-    return audb.load_attachment(
-        DB_NAME,
-        "folder",
-        version="1.0.0",
-        verbose=False,
-    )
+    with _applied_config(config):
+        return audb.load_attachment(
+            DB_NAME,
+            "folder",
+            version="1.0.0",
+            verbose=False,
+        )
 
 
 @pytest.mark.parametrize(
@@ -542,14 +561,14 @@ def test_lock_load_attachment(
 
 
 def load_media(config, timeout):
-    _apply_config(config)
-    return audb.load_media(
-        DB_NAME,
-        "audio/001.wav",
-        version="1.0.0",
-        timeout=timeout,
-        verbose=False,
-    )
+    with _applied_config(config):
+        return audb.load_media(
+            DB_NAME,
+            "audio/001.wav",
+            version="1.0.0",
+            timeout=timeout,
+            verbose=False,
+        )
 
 
 @pytest.mark.parametrize(
@@ -611,13 +630,13 @@ def test_lock_load_media(
 
 
 def load_table(config):
-    _apply_config(config)
-    return audb.load_table(
-        DB_NAME,
-        "table",
-        version="1.0.0",
-        verbose=False,
-    )
+    with _applied_config(config):
+        return audb.load_table(
+            DB_NAME,
+            "table",
+            version="1.0.0",
+            verbose=False,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add support and tests for Python 3.14

## Summary by Sourcery

Add Python 3.14 support and ensure concurrent database locking tests work with modern multiprocessing start methods.

Enhancements:
- Ensure multiprocessing-based database locking helpers apply the current audb configuration explicitly in child processes to be compatible with non-fork start methods.

Build:
- Declare support for Python 3.14 in project metadata classifiers.

CI:
- Extend the test workflow matrix to run on Python 3.14.

Tests:
- Update lock-related database, header, media, table, and attachment tests to pass configuration explicitly to worker processes in multiprocessing runs.