### PR TITLE
publish: improve error message for missing files

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -61,8 +61,8 @@ def _check_for_missing_media(
         error_msg = (
             f"The following "
             f"{len(missing_files)} "
-            f"files are referenced in tables "
-            f"that cannot be found on disk "
+            f"files are referenced in tables, "
+            f"but cannot be found on disk "
             f"and are not yet part of the database: "
             f"{missing_files[:number_of_presented_files]}"
         )

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -744,8 +744,8 @@ def test_publish_changed_db(
             None,
             RuntimeError,
             (
-                "The following 5 files are referenced in tables "
-                "that cannot be found on disk "
+                "The following 5 files are referenced in tables, "
+                "but cannot be found on disk "
                 "and are not yet part of the database: "
                 "['audio/002.wav', 'audio/003.wav', "
                 "'audio/004.wav', 'audio/005.wav', "
@@ -757,8 +757,8 @@ def test_publish_changed_db(
             None,
             RuntimeError,
             (
-                "The following 25 files are referenced in tables "
-                "that cannot be found on disk "
+                "The following 25 files are referenced in tables, "
+                "but cannot be found on disk "
                 "and are not yet part of the database: "
                 "['audio/002.wav', 'audio/003.wav', "
                 "'audio/004.wav', 'audio/005.wav', "
@@ -774,8 +774,8 @@ def test_publish_changed_db(
             "1.0.0",
             RuntimeError,
             (
-                "The following 21 files are referenced in tables "
-                "that cannot be found on disk "
+                "The following 21 files are referenced in tables, "
+                "but cannot be found on disk "
                 "and are not yet part of the database: "
                 f"['{LONG_PATH}', "
                 "'file0.wav', 'file1.wav', 'file10.wav', 'file11.wav', "


### PR DESCRIPTION
Changes the error message in `audb.publish()` for missing media files from 

```
The following {n} files are referenced in tables that cannot be found on disk and are not yet part of the database
```

to

```
The following {n} files are referenced in tables, but cannot be found on disk and are not yet part of the database
```

## Summary by Sourcery

Tests:
- Adjust publish-related tests to assert the revised missing media files error message.