### PR TITLE
Update dependency benchmark script

### DIFF
--- a/benchmarks/benchmark-dependencies-methods.py
+++ b/benchmarks/benchmark-dependencies-methods.py
@@ -69,7 +69,6 @@ if not os.path.exists(data_cache):
 deps = audb.Dependencies()
 deps.load(data_cache)
 deps_file = audeer.path(cache, audb.core.define.DEPENDENCY_FILE)
-file = "file-10.wav"
 n_files = 10000
 _files = deps.files[:n_files]
 results = pd.DataFrame(columns=["result"])
@@ -97,17 +96,19 @@ results.at[method, "result"] = t
 
 # Access the index one time.
 # Further calls will be faster
-file in deps
+"file-10.wav" in deps
 
 method = rf"Dependencies.\_\_contains\_\_({n_files} files)"
 t0 = time.time()
-[file in deps for file in _files]
+for file in _files:
+    _ = file in deps
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = rf"Dependencies.\_\_get_item\_\_({n_files} files)"
 t0 = time.time()
-[deps[file] for file in _files]
+for file in _files:
+    _ = deps[file]
 t = time.time() - t0
 results.at[method, "result"] = t
 
@@ -173,61 +174,71 @@ results.at[method, "result"] = t
 
 method = f"Dependencies.archive({n_files} files)"
 t0 = time.time()
-[deps.archive(file) for file in _files]
+for file in _files:
+    _ = deps.archive(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.bit_depth({n_files} files)"
 t0 = time.time()
-[deps.bit_depth(file) for file in _files]
+for file in _files:
+    _ = deps.bit_depth(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.channels({n_files} files)"
 t0 = time.time()
-[deps.channels(file) for file in _files]
+for file in _files:
+    _ = deps.channels(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.checksum({n_files} files)"
 t0 = time.time()
-[deps.checksum(file) for file in _files]
+for file in _files:
+    _ = deps.checksum(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.duration({n_files} files)"
 t0 = time.time()
-[deps.duration(file) for file in _files]
+for file in _files:
+    _ = deps.duration(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.format({n_files} files)"
 t0 = time.time()
-[deps.format(file) for file in _files]
+for file in _files:
+    _ = deps.format(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.removed({n_files} files)"
 t0 = time.time()
-[deps.removed(file) for file in _files]
+for file in _files:
+    _ = deps.removed(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.sampling_rate({n_files} files)"
 t0 = time.time()
-[deps.sampling_rate(file) for file in _files]
+for file in _files:
+    _ = deps.sampling_rate(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.type({n_files} files)"
 t0 = time.time()
-[deps.type(file) for file in _files]
+for file in _files:
+    _ = deps.type(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
 method = f"Dependencies.version({n_files} files)"
 t0 = time.time()
-[deps.version(file) for file in _files]
+for file in _files:
+    _ = deps.version(file)
 t = time.time() - t0
 results.at[method, "result"] = t
 
@@ -274,7 +285,7 @@ results.at[method, "result"] = t
 
 method = "Dependencies._remove()"
 t0 = time.time()
-deps._remove(file)
+deps._remove("file-10.wav")
 t = time.time() - t0
 results.at[method, "result"] = t
 


### PR DESCRIPTION
Updates dependency benchmark script:

* work with current `main`
* do not separate between dtypes
* add test for `load()` and `save()`
* don't create unused lists
* make it future proof for working on #517 

Results

| method                                          |   result |
|-------------------------------------------------|----------|
| Dependencies.save()                             |    0.314 |
| Dependencies.load()                             |    0.177 |
| Dependencies.\_\_call\_\_()                     |    0.000 |
| Dependencies.\_\_contains\_\_(10000 files)      |    0.005 |
| Dependencies.\_\_get_item\_\_(10000 files)      |    0.829 |
| Dependencies.\_\_len\_\_()                      |    0.000 |
| Dependencies.\_\_str\_\_()                      |    0.018 |
| Dependencies.archives                           |    0.140 |
| Dependencies.attachments                        |    0.028 |
| Dependencies.attachment_ids                     |    0.028 |
| Dependencies.files                              |    0.011 |
| Dependencies.media                              |    0.069 |
| Dependencies.removed_media                      |    0.062 |
| Dependencies.table_ids                          |    0.080 |
| Dependencies.tables                             |    0.026 |
| Dependencies.archive(10000 files)               |    0.063 |
| Dependencies.bit_depth(10000 files)             |    0.046 |
| Dependencies.channels(10000 files)              |    0.047 |
| Dependencies.checksum(10000 files)              |    0.047 |
| Dependencies.duration(10000 files)              |    0.046 |
| Dependencies.format(10000 files)                |    0.048 |
| Dependencies.removed(10000 files)               |    0.046 |
| Dependencies.sampling_rate(10000 files)         |    0.046 |
| Dependencies.type(10000 files)                  |    0.046 |
| Dependencies.version(10000 files)               |    0.048 |
| Dependencies._add_attachment()                  |    0.187 |
| Dependencies._add_media(10000 files)            |    0.076 |
| Dependencies._add_meta()                        |    0.129 |
| Dependencies._drop()                            |    0.115 |
| Dependencies._remove()                          |    0.076 |
| Dependencies._update_media()                    |    0.121 |
| Dependencies._update_media_version(10000 files) |    0.021 |
