### PR TITLE
Speedup _add_meta(), _add_attachment()

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -432,7 +432,7 @@ class Dependencies:
         archive: str,
         checksum: str,
     ):
-        r"""Add or update attachment.
+        r"""Add attachment.
 
         Args:
             file: relative path of attachment
@@ -493,7 +493,7 @@ class Dependencies:
         version: str,
         checksum: str,
     ):
-        r"""Add or update table file.
+        r"""Add table file.
 
         Args:
             file: relative file path
@@ -674,6 +674,36 @@ class Dependencies:
         df.index = df.index.astype(define.DEPENDENCY_INDEX_DTYPE)
         return df
 
+    def _update_attachment(
+        self,
+        file: str,
+        version: str,
+        archive: str,
+        checksum: str,
+    ):
+        r"""Update attachment.
+
+        Args:
+            file: relative path of attachment
+            version: version string
+            archive: archive name without extension
+            checksum: checksum of file
+
+        """
+        format = audeer.file_extension(file).lower()
+        self._df.loc[file] = [
+            archive,  # archive
+            0,  # bit_depth
+            0,  # channels
+            checksum,  # checksum
+            0.0,  # duration
+            format,  # format
+            0,  # removed
+            0,  # sampling_rate
+            define.DEPENDENCY_TYPE["attachment"],  # type
+            version,  # version
+        ]
+
     def _update_media(
         self,
         values: Sequence[
@@ -719,6 +749,39 @@ class Dependencies:
 
         """
         self._df.loc[files, "version"] = version
+
+    def _update_meta(
+        self,
+        file: str,
+        version: str,
+        checksum: str,
+    ):
+        r"""Update table file.
+
+        Args:
+            file: relative file path
+            checksum: checksum of file
+            version: version string
+
+        """
+        format = audeer.file_extension(file).lower()
+        if format == "parquet":
+            archive = ""
+        else:
+            archive = os.path.splitext(file[3:])[0]
+
+        self._df.loc[file] = [
+            archive,  # archive
+            0,  # bit_depth
+            0,  # channels
+            checksum,  # checksum
+            0.0,  # duration
+            format,  # format
+            0,  # removed
+            0,  # sampling_rate
+            define.DEPENDENCY_TYPE["meta"],  # type
+            version,  # version
+        ]
 
 
 def error_message_missing_object(

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -150,8 +150,16 @@ def _find_attachments(
                 db.attachments[attachment_id].files
         else:
             checksum = utils.md5(audeer.path(db_root, path))
-            if path not in deps or checksum != deps.checksum(path):
+            if path not in deps:
                 deps._add_attachment(
+                    file=path,
+                    version=version,
+                    archive=attachment_id,
+                    checksum=checksum,
+                )
+                attachment_ids.append(attachment_id)
+            elif checksum != deps.checksum(path):
+                deps._update_attachment(
                     file=path,
                     version=version,
                     archive=attachment_id,
@@ -302,8 +310,11 @@ def _find_tables(
         disable=not verbose,
     ):
         checksum = utils.md5(os.path.join(db_root, file))
-        if file not in deps or checksum != deps.checksum(file):
+        if file not in deps:
             deps._add_meta(file, version, checksum)
+            tables.append(table)
+        elif checksum != deps.checksum(file):
+            deps._update_meta(file, version, checksum)
             tables.append(table)
 
     return tables


### PR DESCRIPTION
Speedup `audb.Dependencies._add_meta()` and `audb.Dependencies._add_attachment()` by treating them in the same way as `audb.Dependencies._add_media()`.

Currently, this fails as it would require that the meta or attachment to be added is not already stored in the dependency table. It seems our implementation makes use of the fact that we can overwrite the row for meta and attachment.

## Summary by Sourcery

Unify how dependency rows are added for media, meta, and attachments by introducing a shared row insertion helper.

Enhancements:
- Introduce a generic _add_rows() helper for inserting dependency table rows.
- Update _add_meta() and _add_attachment() to use the same bulk row insertion logic as _add_media() for consistency and potential performance improvements.