### PR TITLE
Be more explicit on creating tmp/cache folders

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -293,6 +293,7 @@ def dependencies(
         version,
         cache_root=cache_root,
     )
+    audeer.mkdir(db_root)
     cached_deps_file = os.path.join(db_root, define.CACHED_DEPENDENCY_FILE)
 
     with FolderLock(db_root):

--- a/audb/core/cache.py
+++ b/audb/core/cache.py
@@ -12,7 +12,7 @@ def database_cache_root(
     cache_root: str = None,
     flavor: Flavor = None,
 ) -> str:
-    r"""Create and return database cache folder.
+    r"""Database cache folder.
 
     Args:
         name: name of database
@@ -39,16 +39,15 @@ def database_cache_root(
         if os.path.exists(db_root):
             break
 
-    audeer.mkdir(db_root)
     return db_root
 
 
 def database_tmp_root(
     db_root: str,
 ) -> str:
-    r"""Create and return temporary database cache folder.
+    r"""Temporary database cache folder.
 
-    The temporary cache folder is created under ``db_root + '~'``.
+    The temporary cache folder is ``db_root + '~'``.
 
     Args:
         db_root: path to database cache folder
@@ -57,9 +56,7 @@ def database_tmp_root(
         path to temporary cache folder
 
     """
-    tmp_root = db_root + "~"
-    tmp_root = audeer.mkdir(tmp_root)
-    return tmp_root
+    return db_root + "~"
 
 
 def default_cache_root(

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -275,6 +275,7 @@ def _get_attachments_from_cache(
         )
         missing_attachments = [deps.archive(path) for path in missing_paths]
         db_root_tmp = database_tmp_root(db_root)
+        audeer.mkdir(db_root_tmp)
 
         def job(cache_root: str, file: str):
             _copy_path(file, cache_root, db_root_tmp, db_root)
@@ -343,6 +344,7 @@ def _get_files_from_cache(
                 verbose,
             )
             db_root_tmp = database_tmp_root(db_root)
+            audeer.mkdir(db_root_tmp)
 
             # Tables are stored as CSV or PARQUET files,
             # and are also cached as PKL files
@@ -387,6 +389,7 @@ def _get_attachments_from_backend(
 ):
     r"""Load attachments from backend."""
     db_root_tmp = database_tmp_root(db_root)
+    audeer.mkdir(db_root_tmp)
 
     paths = [db.attachments[attachment].path for attachment in attachments]
 
@@ -541,6 +544,7 @@ def _get_tables_from_backend(
 
     """
     db_root_tmp = database_tmp_root(db_root)
+    audeer.mkdir(db_root_tmp)
 
     def job(table: str):
         csv_file = f"db.{table}.csv"
@@ -1136,6 +1140,7 @@ def load(
         sampling_rate=sampling_rate,
     )
     db_root = database_cache_root(name, version, cache_root, flavor)
+    audeer.mkdir(db_root)
 
     if verbose:  # pragma: no cover
         print(f"Get:   {name} v{version}")
@@ -1336,6 +1341,7 @@ def load_attachment(
         version = latest_version(name)
 
     db_root = database_cache_root(name, version, cache_root)
+    audeer.mkdir(db_root)
 
     if verbose:  # pragma: no cover
         print(f"Get:   {name} v{version}")
@@ -1410,6 +1416,7 @@ def load_header(
         version = latest_version(name)
 
     db_root = database_cache_root(name, version, cache_root)
+    audeer.mkdir(db_root)
 
     with FolderLock(db_root):
         db, _ = load_header_to(db_root, name, version)
@@ -1455,6 +1462,7 @@ def load_header_to(
         remote_header = backend_interface.join("/", name, define.HEADER_FILE)
         if add_audb_meta:
             db_root_tmp = database_tmp_root(db_root)
+            audeer.mkdir(db_root_tmp)
             local_header = os.path.join(db_root_tmp, define.HEADER_FILE)
         backend_interface.get_file(remote_header, local_header, version)
         if add_audb_meta:
@@ -1565,6 +1573,7 @@ def load_media(
         sampling_rate=sampling_rate,
     )
     db_root = database_cache_root(name, version, cache_root, flavor)
+    audeer.mkdir(db_root)
 
     if verbose:  # pragma: no cover
         print(f"Get:   {name} v{version}")
@@ -1720,6 +1729,7 @@ def load_table(
         version = latest_version(name)
 
     db_root = database_cache_root(name, version, cache_root)
+    audeer.mkdir(db_root)
 
     if verbose:  # pragma: no cover
         print(f"Get:   {name} v{version}")

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -339,6 +339,7 @@ def load_to(
 
     db_root = audeer.path(root, follow_symlink=True)
     db_root_tmp = database_tmp_root(db_root)
+    audeer.mkdir(db_root_tmp)
 
     # remove files with a wrong checksum
     # to ensure we load correct version

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as parquet
 
+import audeer
 import audformat
 
 from audb.core import define
@@ -550,6 +551,7 @@ def stream(
         sampling_rate=sampling_rate,
     )
     db_root = database_cache_root(name, version, cache_root, flavor)
+    audeer.mkdir(db_root)
 
     deps = dependencies(
         name,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -610,7 +610,8 @@ def test_load_media(cache, version, media, format):
         cache,
         audb.Flavor(format=format),
     )
-    shutil.rmtree(cache_root)
+    if os.path.exists(cache_root):
+        shutil.rmtree(cache_root)
     paths2 = audb.load_media(
         DB_NAME,
         media,


### PR DESCRIPTION
This updates the private functions `audb.core.cache.database_tmp_root()` and `audb.core.cache.database_cache_root()` to not create the tmp/cache folder, but just return its path.

This pull request is only relevant if we decide to use it in https://github.com/audeering/audb/pull/538

## Summary by Sourcery

Make database cache and temporary cache directory creation explicit at call sites instead of being handled implicitly by cache helper functions.

Enhancements:
- Change database cache helper functions to only return cache and temporary cache paths without creating directories.
- Ensure all loading, streaming, and dependency-resolution paths explicitly create required cache and temporary directories before use.

Tests:
- Adjust media loading test teardown to safely remove cache directories only if they exist.