### PR TITLE
Speed up import by lazy importing

### DIFF
--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -5,11 +5,15 @@
 import importlib
 
 
-# Submodules that should be lazily imported
+# Single source of truth for all lazy-loaded names.
+# Submodules map to their fully-qualified module names.
+# Symbols map to the module that defines them.
 _LAZY_SUBMODULES = {"info", "core"}
 
-# Define what should be lazily imported and from where
-_LAZY_IMPORTS = {
+_LAZY_TARGETS = {
+    # Submodules
+    "info": "audb.info",
+    "core": "audb.core",
     # From audb.core.api
     "available": "audb.core.api",
     "cached": "audb.core.api",
@@ -44,32 +48,31 @@ _LAZY_IMPORTS = {
     "stream": "audb.core.stream",
 }
 
-# Cache for lazily loaded attributes
 _loaded = {}
 
 
 def __getattr__(name: str):
-    """Lazily import attributes on first access."""
-    # Handle submodules
+    """Lazily import attributes and submodules on first access."""
+    if name not in _LAZY_TARGETS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    if name in _loaded:
+        return _loaded[name]
+
+    module = importlib.import_module(_LAZY_TARGETS[name])
+    # For submodules, return the module itself
     if name in _LAZY_SUBMODULES:
-        if name not in _loaded:
-            _loaded[name] = importlib.import_module(f"audb.{name}")
-        return _loaded[name]
+        value = module
+    else:
+        value = getattr(module, name)
 
-    # Handle attributes from modules
-    if name in _LAZY_IMPORTS:
-        if name not in _loaded:
-            module_path = _LAZY_IMPORTS[name]
-            module = importlib.import_module(module_path)
-            _loaded[name] = getattr(module, name)
-        return _loaded[name]
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    _loaded[name] = value
+    return value
 
 
 def __dir__():
     """List available attributes for autocomplete."""
-    return list(_LAZY_SUBMODULES) + list(_LAZY_IMPORTS.keys()) + ["__version__"]
+    return list(_LAZY_TARGETS) + ["__version__"]
 
 
 __all__ = []

--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -72,7 +72,7 @@ def __dir__():
     return list(_LAZY_SUBMODULES) + list(_LAZY_IMPORTS.keys()) + ["__version__"]
 
 
-__all__ = list(_LAZY_SUBMODULES) + list(_LAZY_IMPORTS.keys())
+__all__ = []
 
 
 # Dynamically get the version of the installed module

--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -72,7 +72,9 @@ def __getattr__(name: str):
 
 def __dir__():
     """List available attributes for autocomplete."""
-    return list(_LAZY_TARGETS) + ["__version__"]
+    # Standard module attributes (exclude private implementation details)
+    standard = [k for k in globals().keys() if k.startswith("__")]
+    return standard + list(_LAZY_TARGETS)
 
 
 __all__ = []

--- a/audb/__init__.py
+++ b/audb/__init__.py
@@ -1,29 +1,78 @@
-from audb import info
-from audb.core.api import available
-from audb.core.api import cached
-from audb.core.api import dependencies
-from audb.core.api import exists
-from audb.core.api import flavor_path
-from audb.core.api import latest_version
-from audb.core.api import remove_media
-from audb.core.api import repository
-from audb.core.api import versions
-from audb.core.cache import default_cache_root
-from audb.core.config import config
-from audb.core.dependencies import Dependencies
-from audb.core.flavor import Flavor
-from audb.core.load import load
-from audb.core.load import load_attachment
-from audb.core.load import load_media
-from audb.core.load import load_table
-from audb.core.load_to import load_to
-from audb.core.publish import publish
-from audb.core.repository import Repository
-from audb.core.stream import DatabaseIterator
-from audb.core.stream import stream
+# Lazy imports for faster import time.
+# Heavy dependencies (pandas, audbackend, audformat, etc.) are only loaded
+# when the corresponding functions/classes are actually accessed.
+
+import importlib
 
 
-__all__ = []
+# Submodules that should be lazily imported
+_LAZY_SUBMODULES = {"info", "core"}
+
+# Define what should be lazily imported and from where
+_LAZY_IMPORTS = {
+    # From audb.core.api
+    "available": "audb.core.api",
+    "cached": "audb.core.api",
+    "dependencies": "audb.core.api",
+    "exists": "audb.core.api",
+    "flavor_path": "audb.core.api",
+    "latest_version": "audb.core.api",
+    "remove_media": "audb.core.api",
+    "repository": "audb.core.api",
+    "versions": "audb.core.api",
+    # From audb.core.cache
+    "default_cache_root": "audb.core.cache",
+    # From audb.core.config
+    "config": "audb.core.config",
+    # From audb.core.dependencies
+    "Dependencies": "audb.core.dependencies",
+    # From audb.core.flavor
+    "Flavor": "audb.core.flavor",
+    # From audb.core.load
+    "load": "audb.core.load",
+    "load_attachment": "audb.core.load",
+    "load_media": "audb.core.load",
+    "load_table": "audb.core.load",
+    # From audb.core.load_to
+    "load_to": "audb.core.load_to",
+    # From audb.core.publish
+    "publish": "audb.core.publish",
+    # From audb.core.repository
+    "Repository": "audb.core.repository",
+    # From audb.core.stream
+    "DatabaseIterator": "audb.core.stream",
+    "stream": "audb.core.stream",
+}
+
+# Cache for lazily loaded attributes
+_loaded = {}
+
+
+def __getattr__(name: str):
+    """Lazily import attributes on first access."""
+    # Handle submodules
+    if name in _LAZY_SUBMODULES:
+        if name not in _loaded:
+            _loaded[name] = importlib.import_module(f"audb.{name}")
+        return _loaded[name]
+
+    # Handle attributes from modules
+    if name in _LAZY_IMPORTS:
+        if name not in _loaded:
+            module_path = _LAZY_IMPORTS[name]
+            module = importlib.import_module(module_path)
+            _loaded[name] = getattr(module, name)
+        return _loaded[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    """List available attributes for autocomplete."""
+    return list(_LAZY_SUBMODULES) + list(_LAZY_IMPORTS.keys()) + ["__version__"]
+
+
+__all__ = list(_LAZY_SUBMODULES) + list(_LAZY_IMPORTS.keys())
 
 
 # Dynamically get the version of the installed module
@@ -32,6 +81,4 @@ try:
 
     __version__ = importlib.metadata.version(__name__)
 except Exception:  # pragma: no cover
-    importlib = None  # pragma: no cover
-finally:
-    del importlib
+    __version__ = "unknown"

--- a/audb/core/__init__.py
+++ b/audb/core/__init__.py
@@ -6,7 +6,6 @@ _SUBMODULES = {
     "api",
     "cache",
     "config",
-    "conftest",
     "define",
     "dependencies",
     "flavor",

--- a/audb/core/__init__.py
+++ b/audb/core/__init__.py
@@ -1,0 +1,36 @@
+# Lazy loading for audb.core submodules
+import importlib
+
+
+_SUBMODULES = {
+    "api",
+    "cache",
+    "config",
+    "conftest",
+    "define",
+    "dependencies",
+    "flavor",
+    "info",
+    "load",
+    "load_to",
+    "lock",
+    "publish",
+    "repository",
+    "stream",
+    "utils",
+}
+
+_loaded = {}
+
+
+def __getattr__(name: str):
+    """Lazily import submodules on first access."""
+    if name in _SUBMODULES:
+        if name not in _loaded:
+            _loaded[name] = importlib.import_module(f"audb.core.{name}")
+        return _loaded[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(_SUBMODULES)

--- a/audb/core/__init__.py
+++ b/audb/core/__init__.py
@@ -32,4 +32,6 @@ def __getattr__(name: str):
 
 
 def __dir__():
-    return list(_SUBMODULES)
+    # Standard module attributes + lazy-loaded submodules
+    standard = [k for k in globals().keys() if k.startswith("__")]
+    return standard + list(_SUBMODULES)

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -362,7 +362,6 @@ class DatabaseIteratorCsv(DatabaseIterator):
 
         # index
         columns_and_dtypes = self[self._table]._levels_and_dtypes.copy()
-        levels = list(columns_and_dtypes.keys())
         # add columns
         for column_id, column in self[self._table].columns.items():
             if column.scheme_id is not None:
@@ -393,22 +392,9 @@ class DatabaseIteratorCsv(DatabaseIterator):
                 chunksize=self._samples,
                 usecols=list(columns_and_dtypes.keys()),
                 dtype=dtypes_wo_converters,
-                index_col=levels,
                 converters=converters,
                 float_precision="round_trip",
             )
-
-    def _postprocess_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
-        r"""Post-process dataframe to have correct index and data types.
-
-        Args:
-            df: dataframe
-
-        Returns:
-            dataframe
-
-        """
-        return df
 
 
 class DatabaseIteratorParquet(DatabaseIterator):

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -362,6 +362,7 @@ class DatabaseIteratorCsv(DatabaseIterator):
 
         # index
         columns_and_dtypes = self[self._table]._levels_and_dtypes.copy()
+        levels = list(columns_and_dtypes.keys())
         # add columns
         for column_id, column in self[self._table].columns.items():
             if column.scheme_id is not None:
@@ -392,9 +393,22 @@ class DatabaseIteratorCsv(DatabaseIterator):
                 chunksize=self._samples,
                 usecols=list(columns_and_dtypes.keys()),
                 dtype=dtypes_wo_converters,
+                index_col=levels,
                 converters=converters,
                 float_precision="round_trip",
             )
+
+    def _postprocess_dataframe(self, df: pd.DataFrame) -> pd.DataFrame:
+        r"""Post-process dataframe to have correct index and data types.
+
+        Args:
+            df: dataframe
+
+        Returns:
+            dataframe
+
+        """
+        return df
 
 
 class DatabaseIteratorParquet(DatabaseIterator):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,9 @@ addopts = '''
     --cov-report xml
     --ignore=benchmarks/
 '''
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 
 # ----- ruff --------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -254,3 +254,24 @@ def test_dir():
     ]
     for attr in standard_attrs:
         assert attr in attrs, f"Missing standard attribute: {attr}"
+
+    # Test dir(audb.core) includes submodules
+    core_attrs = dir(audb.core)
+    core_submodules = [
+        "api",
+        "cache",
+        "config",
+        "define",
+        "dependencies",
+        "flavor",
+        "info",
+        "load",
+        "load_to",
+        "lock",
+        "publish",
+        "repository",
+        "stream",
+        "utils",
+    ]
+    for submodule in core_submodules:
+        assert submodule in core_attrs, f"Missing core submodule: {submodule}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -229,42 +229,36 @@ def test_versions(tmpdir, repository):
     assert audb.versions(name) == [version]
 
 
+@pytest.mark.slow
 def test_lazy_import():
     """Test that heavy dependencies are not imported with 'import audb'.
 
     With lazy loading, importing audb should not import pandas
     or other heavy dependencies until they are actually needed.
 
+    This test uses subprocess to ensure a clean Python state,
+    as modules remain in sys.modules once imported.
+
     """
     import subprocess
     import sys
 
-    # Test that pandas is NOT imported after 'import audb'
     code = """
 import sys
 import audb
-# Check that pandas is not yet imported
-if 'pandas' in sys.modules:
-    print('FAIL: pandas was imported')
-    sys.exit(1)
-print('PASS: pandas not imported')
-"""
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0, f"Lazy import failed: {result.stdout}{result.stderr}"
 
-    # Test that pandas IS imported after accessing audb.Dependencies
-    code = """
-import sys
-import audb
+# Check 1: pandas should NOT be imported after 'import audb'
+if 'pandas' in sys.modules:
+    print('FAIL: pandas was imported on import audb')
+    sys.exit(1)
+
+# Check 2: pandas SHOULD be imported after accessing Dependencies
 _ = audb.Dependencies
 if 'pandas' not in sys.modules:
     print('FAIL: pandas should be imported after accessing Dependencies')
     sys.exit(1)
-print('PASS: pandas imported after access')
+
+print('PASS')
 """
     result = subprocess.run(
         [sys.executable, "-c", code],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,14 +230,12 @@ def test_versions(tmpdir, repository):
 
 
 def test_dir():
-    """Test that dir(audb) includes standard module attributes.
+    """Test that dir() includes standard module attributes.
 
     With lazy loading, we need to ensure that standard module
-    attributes are still available in dir(audb).
+    attributes are still available in dir().
 
     """
-    attrs = dir(audb)
-
     # Standard module attributes
     standard_attrs = [
         "__all__",
@@ -253,25 +251,22 @@ def test_dir():
         "__version__",
     ]
     for attr in standard_attrs:
-        assert attr in attrs, f"Missing standard attribute: {attr}"
+        assert attr in dir(audb), f"Missing standard attribute '{attr}'"
 
-    # Test dir(audb.core) includes submodules
-    core_attrs = dir(audb.core)
-    core_submodules = [
-        "api",
-        "cache",
-        "config",
-        "define",
-        "dependencies",
-        "flavor",
-        "info",
-        "load",
-        "load_to",
-        "lock",
-        "publish",
-        "repository",
-        "stream",
-        "utils",
+    # Test dir(audb.core) includes standard attributes and submodules
+    submodule_standard_attrs = [
+        "__builtins__",
+        "__cached__",
+        "__doc__",
+        "__file__",
+        "__loader__",
+        "__name__",
+        "__package__",
+        "__path__",
+        "__spec__",
     ]
-    for submodule in core_submodules:
-        assert submodule in core_attrs, f"Missing core submodule: {submodule}"
+    submodules = [audb.core, audb.info]
+    for submodule in submodules:
+        for attr in submodule_standard_attrs:
+            err_msg = f"Missing standard attribute '{attr}' in submodule '{submodule}'"
+            assert attr in dir(submodule), err_msg

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -229,6 +229,51 @@ def test_versions(tmpdir, repository):
     assert audb.versions(name) == [version]
 
 
+def test_lazy_import():
+    """Test that heavy dependencies are not imported with 'import audb'.
+
+    With lazy loading, importing audb should not import pandas
+    or other heavy dependencies until they are actually needed.
+
+    """
+    import subprocess
+    import sys
+
+    # Test that pandas is NOT imported after 'import audb'
+    code = """
+import sys
+import audb
+# Check that pandas is not yet imported
+if 'pandas' in sys.modules:
+    print('FAIL: pandas was imported')
+    sys.exit(1)
+print('PASS: pandas not imported')
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Lazy import failed: {result.stdout}{result.stderr}"
+
+    # Test that pandas IS imported after accessing audb.Dependencies
+    code = """
+import sys
+import audb
+_ = audb.Dependencies
+if 'pandas' not in sys.modules:
+    print('FAIL: pandas should be imported after accessing Dependencies')
+    sys.exit(1)
+print('PASS: pandas imported after access')
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"Lazy import failed: {result.stdout}{result.stderr}"
+
+
 def test_dir():
     """Test that dir() includes standard module attributes.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -227,3 +227,30 @@ def test_versions(tmpdir, repository):
     audb.publish(build_dir, version, repository)
 
     assert audb.versions(name) == [version]
+
+
+def test_dir():
+    """Test that dir(audb) includes standard module attributes.
+
+    With lazy loading, we need to ensure that standard module
+    attributes are still available in dir(audb).
+
+    """
+    attrs = dir(audb)
+
+    # Standard module attributes
+    standard_attrs = [
+        "__all__",
+        "__builtins__",
+        "__cached__",
+        "__doc__",
+        "__file__",
+        "__loader__",
+        "__name__",
+        "__package__",
+        "__path__",
+        "__spec__",
+        "__version__",
+    ]
+    for attr in standard_attrs:
+        assert attr in attrs, f"Missing standard attribute: {attr}"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -309,3 +309,55 @@ def test_dir():
         for attr in submodule_standard_attrs:
             err_msg = f"Missing standard attribute '{attr}' in submodule '{submodule}'"
             assert attr in dir(submodule), err_msg
+
+
+def test_public_api_accessible():
+    """Test that all public API symbols are accessible via lazy loading."""
+    import types
+
+    # Functions from audb.core.api
+    api_functions = [
+        "available",
+        "cached",
+        "dependencies",
+        "exists",
+        "flavor_path",
+        "latest_version",
+        "remove_media",
+        "repository",
+        "versions",
+    ]
+    for name in api_functions:
+        attr = getattr(audb, name)
+        assert callable(attr), f"audb.{name} should be callable"
+
+    # Functions from other modules
+    other_functions = [
+        "default_cache_root",
+        "load",
+        "load_attachment",
+        "load_media",
+        "load_table",
+        "load_to",
+        "publish",
+        "stream",
+    ]
+    for name in other_functions:
+        attr = getattr(audb, name)
+        assert callable(attr), f"audb.{name} should be callable"
+
+    # Classes
+    classes = ["Dependencies", "Flavor", "Repository", "DatabaseIterator"]
+    for name in classes:
+        attr = getattr(audb, name)
+        assert isinstance(attr, type), f"audb.{name} should be a class"
+
+    # Config object
+    assert audb.config is not None
+
+    # Submodules
+    assert isinstance(audb.core, types.ModuleType)
+    assert isinstance(audb.info, types.ModuleType)
+
+    # Version
+    assert isinstance(audb.__version__, str)


### PR DESCRIPTION
As `audb` has now a few bigger dependencies, and importing `pandas` seems to be slow at the moment, I would propose to switch to lazy imports here. This means importing packages only when they are needed, e.g. loading `audformat` not when `import audb` is executed, but when `audb.load()` is executed.

This reduces import time of `audb` from ~0.440s to ~0.001s on my Laptop and from ~1.333s to ~0.007s on `iva-p4d`.

We also change the behavior if we cannot detect the version of `audb` and set `__version__ = "unknown"` which seems to be the most common practice in this case.