### PR TITLE
TST: allow newer pytest versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ documentation = 'https://audeering.github.io/audb/'
 dev = [
     'audiofile >=1.1.0',
     'docutils',
-    'pytest <8.4.0',
+    'pytest',
     'pytest-cov',
     'sphinx >=3.5.4',
     'sphinx-apipages >=0.1.2',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,9 +9,8 @@ import audb
 class TestAvailable:
     r"""Test collecting available datasets."""
 
-    @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup(cls, tmpdir_factory):
+    def setup(self, tmpdir_factory):
         r"""Prepare repositories and datasets.
 
         Create two repositories

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -53,9 +53,8 @@ class TestStreaming:
     seed = 2
     """Seed for random operations."""
 
-    @classmethod
     @pytest.fixture(scope="class", autouse=True, params=["parquet", "csv"])
-    def setup(cls, request, tmpdir_factory, persistent_repository):
+    def setup(self, request, tmpdir_factory, persistent_repository):
         r"""Publish a database.
 
         This creates a database,
@@ -77,7 +76,7 @@ class TestStreaming:
 
         db_root = tmpdir_factory.mktemp("build")
 
-        db = audformat.Database(cls.name)
+        db = audformat.Database(self.name)
 
         # Misc table for scheme labels
         db.schemes["year-of-birth"] = audformat.Scheme("date")
@@ -125,7 +124,7 @@ class TestStreaming:
         audeer.rmdir(persistent_repository.host)
         audeer.mkdir(persistent_repository.host, persistent_repository.name)
 
-        audb.publish(db_root, cls.version, persistent_repository)
+        audb.publish(db_root, self.version, persistent_repository)
 
         yield
 


### PR DESCRIPTION
Closes https://github.com/audeering/audb/issues/509

For me the tests now also work with `pytest` 8.4.0 and 8.4.1. I guess a newer version of another pytest plugin fixed this. But I would not try to dig into it, but simply remove the restriction we have on `pytest`.

---

The problem was our use of `classmethod` in a fixture, which is officially not supported and stopped working in Python 3.13 with newer versions of `pytest`. We remove the `classmethod` here from the fixture.