### PR TITLE
Use Scan as verbose message when parsing files

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -878,7 +878,7 @@ def _missing_files(
         else:
             return os.path.exists(os.path.join(db_root, file))
 
-    pbar = audeer.progress_bar(files, desc=f"Missing {files_type}", disable=not verbose)
+    pbar = audeer.progress_bar(files, desc=f"Scan {files_type}", disable=not verbose)
     return [file for file in pbar if not is_cached(file)]
 
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -879,7 +879,7 @@ def _missing_files(
         else:
             return os.path.exists(os.path.join(db_root, file))
 
-    pbar = audeer.progress_bar(files, desc=f"Missing {files_type}", disable=not verbose)
+    pbar = audeer.progress_bar(files, desc=f"Scan {files_type}", disable=not verbose)
     return [file for file in pbar if not is_cached(file)]
 
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -110,7 +110,7 @@ def _find_tables(
         params=[([table], {}) for table in list(db_header)],
         num_workers=num_workers,
         progress_bar=verbose,
-        task_description="Find tables",
+        task_description="Scan tables",
         maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -61,7 +61,7 @@ def _find_media(
         params=[([file], {}) for file in db.files],
         num_workers=num_workers,
         progress_bar=verbose,
-        task_description="Find media",
+        task_description="Scan media",
         maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -111,7 +111,7 @@ def _find_tables(
         params=[([table], {}) for table in list(db_header)],
         num_workers=num_workers,
         progress_bar=verbose,
-        task_description="Find tables",
+        task_description="Scan tables",
         maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -62,7 +62,7 @@ def _find_media(
         params=[([file], {}) for file in db.files],
         num_workers=num_workers,
         progress_bar=verbose,
-        task_description="Find media",
+        task_description="Scan media",
         maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -134,7 +134,7 @@ def _find_attachments(
     attachment_ids = []
     for attachment_id in audeer.progress_bar(
         list(db.attachments),
-        desc="Find attachments",
+        desc="Scan attachments",
         disable=not verbose,
     ):
         # use one archive per attachment ID
@@ -254,7 +254,7 @@ def _find_media(
         params=[([file], {}) for file in db_media_in_root],
         num_workers=num_workers,
         progress_bar=verbose,
-        task_description="Find media",
+        task_description="Scan media",
         maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
@@ -298,7 +298,7 @@ def _find_tables(
     tables = []
     for table, file in audeer.progress_bar(
         zip(table_ids, table_files),
-        desc="Find tables",
+        desc="Scan tables",
         disable=not verbose,
     ):
         checksum = utils.md5(os.path.join(db_root, file))

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -135,7 +135,7 @@ def _find_attachments(
     attachment_ids = []
     for attachment_id in audeer.progress_bar(
         list(db.attachments),
-        desc="Find attachments",
+        desc="Scan attachments",
         disable=not verbose,
     ):
         # use one archive per attachment ID
@@ -255,7 +255,7 @@ def _find_media(
         params=[([file], {}) for file in db_media_in_root],
         num_workers=num_workers,
         progress_bar=verbose,
-        task_description="Find media",
+        task_description="Scan media",
         maximum_refresh_time=define.MAXIMUM_REFRESH_TIME,
     )
 
@@ -299,7 +299,7 @@ def _find_tables(
     tables = []
     for table, file in audeer.progress_bar(
         zip(table_ids, table_files),
-        desc="Find tables",
+        desc="Scan tables",
         disable=not verbose,
     ):
         checksum = utils.md5(os.path.join(db_root, file))


### PR DESCRIPTION
I have the impression that the wording we have at the moment when iterating over files is too negative. I propose to replace the "Find" and "Missing" words in the verbose messages with the more neutral "Scan" in `load()`, `load_to()`, and `publish()` when local folder(s) are scanned for existing/matching files.