### PR TITLE
Speedup audb.available()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -90,20 +90,15 @@ def available(
                     # Avoid `ls(recursive=True)` for S3 and MinIO
                     # as this is slow for large databases
                     for obj in backend._client.list_objects(repository.name):
+                        sub_folders = backend._client.list_objects(
+                            repository.name, obj.object_name
+                        )
                         name = obj.object_name[:-1]  # remove "/" at end
-                        header_file = f"/{name}/{define.HEADER_FILE}"
-                        for _obj in backend._client.list_objects(
-                            repository.name, f"{name}/"
-                        ):
-                            version = _obj.object_name.split("/")[1]
-                            header_file = f"/{name}/{version}/{define.HEADER_FILE}"
-                            if version not in [
-                                "attachment",
-                                "media",
-                                "meta",
-                            ] and backend.exists(header_file):
-                                add_database(name, version, repository)
-
+                        for sub_folder in sub_folders:
+                            version = sub_folder.object_name.split("/")[1]
+                            if version in ["attachment", "media", "meta"]:
+                                continue
+                            add_database(name, version, repository)
                 else:
                     for path, version in backend_interface.ls("/"):
                         if path.endswith(define.HEADER_FILE):

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -74,7 +74,13 @@ def available(
             with backend_interface.backend as backend:
                 for name in backend.ls_dirs("/"):
                     for version in backend.ls_dirs(f"/{name}/"):
-                        add_database(name, version, repository)
+                        header_file = f"/{name}/{version}/{define.HEADER_FILE}"
+                        if version not in [
+                            "attachment",
+                            "media",
+                            "meta",
+                        ] and backend.exists(header_file):
+                            add_database(name, version, repository)
 
         except (audbackend.BackendError, ValueError):
             continue

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -72,38 +72,9 @@ def available(
         try:
             backend_interface = repository.create_backend_interface()
             with backend_interface.backend as backend:
-                if repository.backend == "artifactory":  # pragma: nocover
-                    # avoid backend_interface.ls('/')
-                    # which is very slow on Artifactory
-                    # see https://github.com/audeering/audbackend/issues/132
-                    for p in backend.path("/"):
-                        name = p.name
-                        try:
-                            for version in [str(x).split("/")[-1] for x in p / "db"]:
-                                add_database(name, version, repository)
-                        except FileNotFoundError:
-                            # If the `db` folder does not exist,
-                            # we do not include the dataset
-                            pass
-
-                elif repository.backend in ["minio", "s3"]:
-                    # Avoid `ls(recursive=True)` for S3 and MinIO
-                    # as this is slow for large databases
-                    for obj in backend._client.list_objects(repository.name):
-                        sub_folders = backend._client.list_objects(
-                            repository.name, obj.object_name
-                        )
-                        name = obj.object_name[:-1]  # remove "/" at end
-                        for sub_folder in sub_folders:
-                            version = sub_folder.object_name.split("/")[1]
-                            if version in ["attachment", "media", "meta"]:
-                                continue
-                            add_database(name, version, repository)
-                else:
-                    for path, version in backend_interface.ls("/"):
-                        if path.endswith(define.HEADER_FILE):
-                            name = path.split("/")[1]
-                            add_database(name, version, repository)
+                for name in backend.ls_dirs("/"):
+                    for version in backend.ls_dirs(f"/{name}/"):
+                        add_database(name, version, repository)
 
         except (audbackend.BackendError, ValueError):
             continue


### PR DESCRIPTION
Unifies the code for `audb.available()` to rely on `Backend.ls_dirs()` for all backends. This would result in roughly the same speed as we had before.

As in most cases we can assume that the repositories are not interrupted changed by other processes, we can further speed this up by not checking if the header file exists. The downside is that a broken dataset or a dataset that is currently uploaded will appear in `audb.available()`.

Execution time.

| Backend | main | ls_dirs | ls_dirs wo exists |
| --- | --- | --- | --- |
| artifactory | 2.382s | 1.954s | 1.508s |
| minio | 11.577s | 12.096s | 4.016s |

<details><summary>Benchmark code</summary>

```python
import audb
import time


def measure():
    t0 = time.time()
    df = audb.available()
    t = time.time() - t0
    print(f"Execution time: {t:.3f}s")
    
    
print("data-private-local")
repo = audb.Repository(
    name="audb-private-local",
    host="https://artifactory.audeering.com/artifactory",
    backend="artifactory",
)
audb.config.REPOSITORIES = [repo]
measure()
 
print("audb-internal")
repo = audb.Repository(
    name="audb-internal",
    host="s3.dualstack.eu-north-1.amazonaws.com",
    backend="s3",
)
audb.config.REPOSITORIES = [repo]
measure() 
```

</details>