### PR TITLE
Animate name+version during load/publish

### DIFF
--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1147,6 +1147,7 @@ def load(
     db_root = database_cache_root(name, version, cache_root, flavor)
     scan_for_missing_files = not is_empty(db_root)
 
+    shimmer = None
     if verbose:  # pragma: no cover
         shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
@@ -1307,7 +1308,7 @@ def load(
             utils.timeout_warning()
 
     finally:
-        if verbose:  # pragma: no cover
+        if shimmer is not None:  # pragma: no cover
             shimmer.stop()
 
     return db
@@ -1354,6 +1355,7 @@ def load_attachment(
 
     db_root = database_cache_root(name, version, cache_root)
 
+    shimmer = None
     if verbose:  # pragma: no cover
         shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
@@ -1399,7 +1401,7 @@ def load_attachment(
             )
 
     finally:
-        if verbose:  # pragma: no cover
+        if shimmer is not None:  # pragma: no cover
             shimmer.stop()
 
     attachment_files = db.attachments[attachment].files
@@ -1589,6 +1591,7 @@ def load_media(
     db_root = database_cache_root(name, version, cache_root, flavor)
     scan_for_missing_files = not is_empty(db_root)
 
+    shimmer = None
     if verbose:  # pragma: no cover
         shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
@@ -1657,7 +1660,7 @@ def load_media(
             utils.timeout_warning()
 
     finally:
-        if verbose:  # pragma: no cover
+        if shimmer is not None:  # pragma: no cover
             shimmer.stop()
 
     return files
@@ -1753,6 +1756,7 @@ def load_table(
     db_root = database_cache_root(name, version, cache_root)
     scan_for_missing_files = not is_empty(db_root)
 
+    shimmer = None
     if verbose:  # pragma: no cover
         shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
@@ -1818,7 +1822,7 @@ def load_table(
                 db[_table].load(table_file)
 
     finally:
-        if verbose:  # pragma: no cover
+        if shimmer is not None:  # pragma: no cover
             shimmer.stop()
 
     if map is None:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1160,152 +1160,151 @@ def load(
             cache_root=cache_root,
         )
 
-        try:
-            with FolderLock(db_root, timeout=timeout):
-                # Start with database header without tables
-                db, backend_interface = load_header_to(
+        with FolderLock(db_root, timeout=timeout):
+            # Start with database header without tables
+            db, backend_interface = load_header_to(
+                db_root,
+                name,
+                version,
+                flavor=flavor,
+                add_audb_meta=True,
+            )
+
+            db_is_complete = _database_is_complete(db)
+
+            # load attachments
+            if not db_is_complete and not only_metadata:
+                # filter attachments
+                requested_attachments = filter_deps(
+                    attachments,
+                    db.attachments,
+                    "attachment",
+                )
+
+                cached_versions = _load_attachments(
+                    requested_attachments,
+                    backend_interface,
                     db_root,
-                    name,
-                    version,
-                    flavor=flavor,
-                    add_audb_meta=True,
-                )
-
-                db_is_complete = _database_is_complete(db)
-
-                # load attachments
-                if not db_is_complete and not only_metadata:
-                    # filter attachments
-                    requested_attachments = filter_deps(
-                        attachments,
-                        db.attachments,
-                        "attachment",
-                    )
-
-                    cached_versions = _load_attachments(
-                        requested_attachments,
-                        backend_interface,
-                        db_root,
-                        db,
-                        version,
-                        cached_versions,
-                        deps,
-                        flavor,
-                        cache_root,
-                        num_workers,
-                        verbose,
-                    )
-
-                # filter tables (convert regexp pattern to list of tables)
-                requested_tables = filter_deps(tables, list(db), "table")
-
-                # add/split into misc tables used in a scheme
-                # and all other (misc) tables
-                requested_misc_tables = _misc_tables_used_in_scheme(db)
-                requested_tables = [
-                    table
-                    for table in requested_tables
-                    if table not in requested_misc_tables
-                ]
-
-                # load missing tables
-                if not db_is_complete:
-                    for _tables in [
-                        requested_misc_tables,
-                        requested_tables,
-                    ]:
-                        # need to load misc tables used in a scheme first
-                        # as loading is done in parallel
-                        cached_versions = _load_files(
-                            _tables,
-                            "table",
-                            backend_interface,
-                            db_root,
-                            db,
-                            version,
-                            cached_versions,
-                            deps,
-                            flavor,
-                            cache_root,
-                            pickle_tables,
-                            scan_for_missing_files,
-                            num_workers,
-                            verbose,
-                        )
-                requested_tables = requested_misc_tables + requested_tables
-
-                # filter tables
-                if tables is not None:
-                    db.pick_tables(requested_tables)
-
-                # load tables
-                for table in requested_tables:
-                    db[table].load(os.path.join(db_root, f"db.{table}"))
-
-                # filter media
-                requested_media = filter_deps(
-                    media,
-                    db.files,
-                    "media",
-                    name,
-                    version,
-                )
-
-                # load missing media
-                if not db_is_complete and not only_metadata:
-                    cached_versions = _load_files(
-                        requested_media,
-                        "media",
-                        backend_interface,
-                        db_root,
-                        db,
-                        version,
-                        cached_versions,
-                        deps,
-                        flavor,
-                        cache_root,
-                        False,
-                        scan_for_missing_files,
-                        num_workers,
-                        verbose,
-                    )
-
-                # filter media
-                if media is not None or tables is not None:
-                    db.pick_files(requested_media)
-
-                if not removed_media:
-                    _remove_media(db, deps, num_workers, verbose)
-
-                # Adjust full paths and file extensions in tables
-                _update_path(
                     db,
-                    db_root,
-                    full_path,
-                    flavor.format,
+                    version,
+                    cached_versions,
+                    deps,
+                    flavor,
+                    cache_root,
                     num_workers,
                     verbose,
                 )
 
-                # set file durations
-                _files_duration(
-                    db,
-                    deps,
+            # filter tables (convert regexp pattern to list of tables)
+            requested_tables = filter_deps(tables, list(db), "table")
+
+            # add/split into misc tables used in a scheme
+            # and all other (misc) tables
+            requested_misc_tables = _misc_tables_used_in_scheme(db)
+            requested_tables = [
+                table
+                for table in requested_tables
+                if table not in requested_misc_tables
+            ]
+
+            # load missing tables
+            if not db_is_complete:
+                for _tables in [
+                    requested_misc_tables,
+                    requested_tables,
+                ]:
+                    # need to load misc tables used in a scheme first
+                    # as loading is done in parallel
+                    cached_versions = _load_files(
+                        _tables,
+                        "table",
+                        backend_interface,
+                        db_root,
+                        db,
+                        version,
+                        cached_versions,
+                        deps,
+                        flavor,
+                        cache_root,
+                        pickle_tables,
+                        scan_for_missing_files,
+                        num_workers,
+                        verbose,
+                    )
+            requested_tables = requested_misc_tables + requested_tables
+
+            # filter tables
+            if tables is not None:
+                db.pick_tables(requested_tables)
+
+            # load tables
+            for table in requested_tables:
+                db[table].load(os.path.join(db_root, f"db.{table}"))
+
+            # filter media
+            requested_media = filter_deps(
+                media,
+                db.files,
+                "media",
+                name,
+                version,
+            )
+
+            # load missing media
+            if not db_is_complete and not only_metadata:
+                cached_versions = _load_files(
                     requested_media,
-                    flavor.format,
+                    "media",
+                    backend_interface,
+                    db_root,
+                    db,
+                    version,
+                    cached_versions,
+                    deps,
+                    flavor,
+                    cache_root,
+                    False,
+                    scan_for_missing_files,
+                    num_workers,
+                    verbose,
                 )
 
-                # check if database is now complete
-                if not db_is_complete:
-                    _database_check_complete(
-                        db,
-                        db_root,
-                        flavor,
-                        deps,
-                    )
+            # filter media
+            if media is not None or tables is not None:
+                db.pick_files(requested_media)
 
-        except filelock.Timeout:
-            utils.timeout_warning()
+            if not removed_media:
+                _remove_media(db, deps, num_workers, verbose)
+
+            # Adjust full paths and file extensions in tables
+            _update_path(
+                db,
+                db_root,
+                full_path,
+                flavor.format,
+                num_workers,
+                verbose,
+            )
+
+            # set file durations
+            _files_duration(
+                db,
+                deps,
+                requested_media,
+                flavor.format,
+            )
+
+            # check if database is now complete
+            if not db_is_complete:
+                _database_check_complete(
+                    db,
+                    db_root,
+                    flavor,
+                    deps,
+                )
+
+    except filelock.Timeout:
+        utils.timeout_warning()
 
     finally:
         if shimmer is not None:  # pragma: no cover
@@ -1615,49 +1614,46 @@ def load_media(
             )
             raise ValueError(msg)
 
-        try:
-            with FolderLock(db_root, timeout=timeout):
-                # Start with database header without tables
-                db, backend_interface = load_header_to(
+        with FolderLock(db_root, timeout=timeout):
+            # Start with database header without tables
+            db, backend_interface = load_header_to(
+                db_root,
+                name,
+                version,
+                flavor=flavor,
+                add_audb_meta=True,
+            )
+
+            db_is_complete = _database_is_complete(db)
+
+            # load missing media
+            if not db_is_complete:
+                _load_files(
+                    media,
+                    "media",
+                    backend_interface,
                     db_root,
-                    name,
+                    db,
                     version,
-                    flavor=flavor,
-                    add_audb_meta=True,
+                    None,
+                    deps,
+                    flavor,
+                    cache_root,
+                    False,
+                    scan_for_missing_files,
+                    num_workers,
+                    verbose,
                 )
 
-                db_is_complete = _database_is_complete(db)
+            if format is not None:
+                media = [audeer.replace_file_extension(m, format) for m in media]
+            files = [
+                os.path.join(db_root, os.path.normpath(file))  # convert "/" to os.sep
+                for file in media
+            ]
 
-                # load missing media
-                if not db_is_complete:
-                    _load_files(
-                        media,
-                        "media",
-                        backend_interface,
-                        db_root,
-                        db,
-                        version,
-                        None,
-                        deps,
-                        flavor,
-                        cache_root,
-                        False,
-                        scan_for_missing_files,
-                        num_workers,
-                        verbose,
-                    )
-
-                if format is not None:
-                    media = [audeer.replace_file_extension(m, format) for m in media]
-                files = [
-                    os.path.join(
-                        db_root, os.path.normpath(file)
-                    )  # convert "/" to os.sep
-                    for file in media
-                ]
-
-        except filelock.Timeout:
-            utils.timeout_warning()
+    except filelock.Timeout:
+        utils.timeout_warning()
 
     finally:
         if shimmer is not None:  # pragma: no cover

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1148,7 +1148,7 @@ def load(
     scan_for_missing_files = not is_empty(db_root)
 
     if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
         print(f"Cache: {db_root}")
 
@@ -1356,7 +1356,7 @@ def load_attachment(
     db_root = database_cache_root(name, version, cache_root)
 
     if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
         print(f"Cache: {db_root}")
 
@@ -1592,7 +1592,7 @@ def load_media(
     scan_for_missing_files = not is_empty(db_root)
 
     if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
         print(f"Cache: {db_root}")
 
@@ -1757,7 +1757,7 @@ def load_table(
     scan_for_missing_files = not is_empty(db_root)
 
     if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
         print(f"Cache: {db_root}")
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1157,7 +1157,6 @@ def load(
             name,
             version=version,
             cache_root=cache_root,
-            verbose=verbose,
         )
 
         try:
@@ -1365,7 +1364,6 @@ def load_attachment(
             name,
             version=version,
             cache_root=cache_root,
-            verbose=verbose,
         )
 
         if attachment not in deps.archives:
@@ -1601,7 +1599,6 @@ def load_media(
             name,
             version=version,
             cache_root=cache_root,
-            verbose=verbose,
         )
 
         available_files = set(deps.media)
@@ -1766,7 +1763,6 @@ def load_table(
             name,
             version=version,
             cache_root=cache_root,
-            verbose=verbose,
         )
 
         if table not in deps.table_ids:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -24,6 +24,7 @@ from audb.core.dependencies import error_message_missing_object
 from audb.core.dependencies import filter_deps
 from audb.core.flavor import Flavor
 from audb.core.lock import FolderLock
+from audb.core.shimmer import Shimmer
 from audb.core.utils import is_empty
 from audb.core.utils import lookup_backend
 
@@ -1147,75 +1148,42 @@ def load(
     scan_for_missing_files = not is_empty(db_root)
 
     if verbose:  # pragma: no cover
-        print(f"Get:   {name} v{version}")
+        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer.start()
         print(f"Cache: {db_root}")
 
-    deps = dependencies(
-        name,
-        version=version,
-        cache_root=cache_root,
-        verbose=verbose,
-    )
-
     try:
-        with FolderLock(db_root, timeout=timeout):
-            # Start with database header without tables
-            db, backend_interface = load_header_to(
-                db_root,
-                name,
-                version,
-                flavor=flavor,
-                add_audb_meta=True,
-            )
+        deps = dependencies(
+            name,
+            version=version,
+            cache_root=cache_root,
+            verbose=verbose,
+        )
 
-            db_is_complete = _database_is_complete(db)
-
-            # load attachments
-            if not db_is_complete and not only_metadata:
-                # filter attachments
-                requested_attachments = filter_deps(
-                    attachments,
-                    db.attachments,
-                    "attachment",
-                )
-
-                cached_versions = _load_attachments(
-                    requested_attachments,
-                    backend_interface,
+        try:
+            with FolderLock(db_root, timeout=timeout):
+                # Start with database header without tables
+                db, backend_interface = load_header_to(
                     db_root,
-                    db,
+                    name,
                     version,
-                    cached_versions,
-                    deps,
-                    flavor,
-                    cache_root,
-                    num_workers,
-                    verbose,
+                    flavor=flavor,
+                    add_audb_meta=True,
                 )
 
-            # filter tables (convert regexp pattern to list of tables)
-            requested_tables = filter_deps(tables, list(db), "table")
+                db_is_complete = _database_is_complete(db)
 
-            # add/split into misc tables used in a scheme
-            # and all other (misc) tables
-            requested_misc_tables = _misc_tables_used_in_scheme(db)
-            requested_tables = [
-                table
-                for table in requested_tables
-                if table not in requested_misc_tables
-            ]
+                # load attachments
+                if not db_is_complete and not only_metadata:
+                    # filter attachments
+                    requested_attachments = filter_deps(
+                        attachments,
+                        db.attachments,
+                        "attachment",
+                    )
 
-            # load missing tables
-            if not db_is_complete:
-                for _tables in [
-                    requested_misc_tables,
-                    requested_tables,
-                ]:
-                    # need to load misc tables used in a scheme first
-                    # as loading is done in parallel
-                    cached_versions = _load_files(
-                        _tables,
-                        "table",
+                    cached_versions = _load_attachments(
+                        requested_attachments,
                         backend_interface,
                         db_root,
                         db,
@@ -1224,85 +1192,124 @@ def load(
                         deps,
                         flavor,
                         cache_root,
-                        pickle_tables,
+                        num_workers,
+                        verbose,
+                    )
+
+                # filter tables (convert regexp pattern to list of tables)
+                requested_tables = filter_deps(tables, list(db), "table")
+
+                # add/split into misc tables used in a scheme
+                # and all other (misc) tables
+                requested_misc_tables = _misc_tables_used_in_scheme(db)
+                requested_tables = [
+                    table
+                    for table in requested_tables
+                    if table not in requested_misc_tables
+                ]
+
+                # load missing tables
+                if not db_is_complete:
+                    for _tables in [
+                        requested_misc_tables,
+                        requested_tables,
+                    ]:
+                        # need to load misc tables used in a scheme first
+                        # as loading is done in parallel
+                        cached_versions = _load_files(
+                            _tables,
+                            "table",
+                            backend_interface,
+                            db_root,
+                            db,
+                            version,
+                            cached_versions,
+                            deps,
+                            flavor,
+                            cache_root,
+                            pickle_tables,
+                            scan_for_missing_files,
+                            num_workers,
+                            verbose,
+                        )
+                requested_tables = requested_misc_tables + requested_tables
+
+                # filter tables
+                if tables is not None:
+                    db.pick_tables(requested_tables)
+
+                # load tables
+                for table in requested_tables:
+                    db[table].load(os.path.join(db_root, f"db.{table}"))
+
+                # filter media
+                requested_media = filter_deps(
+                    media,
+                    db.files,
+                    "media",
+                    name,
+                    version,
+                )
+
+                # load missing media
+                if not db_is_complete and not only_metadata:
+                    cached_versions = _load_files(
+                        requested_media,
+                        "media",
+                        backend_interface,
+                        db_root,
+                        db,
+                        version,
+                        cached_versions,
+                        deps,
+                        flavor,
+                        cache_root,
+                        False,
                         scan_for_missing_files,
                         num_workers,
                         verbose,
                     )
-            requested_tables = requested_misc_tables + requested_tables
 
-            # filter tables
-            if tables is not None:
-                db.pick_tables(requested_tables)
+                # filter media
+                if media is not None or tables is not None:
+                    db.pick_files(requested_media)
 
-            # load tables
-            for table in requested_tables:
-                db[table].load(os.path.join(db_root, f"db.{table}"))
+                if not removed_media:
+                    _remove_media(db, deps, num_workers, verbose)
 
-            # filter media
-            requested_media = filter_deps(
-                media,
-                db.files,
-                "media",
-                name,
-                version,
-            )
-
-            # load missing media
-            if not db_is_complete and not only_metadata:
-                cached_versions = _load_files(
-                    requested_media,
-                    "media",
-                    backend_interface,
-                    db_root,
+                # Adjust full paths and file extensions in tables
+                _update_path(
                     db,
-                    version,
-                    cached_versions,
-                    deps,
-                    flavor,
-                    cache_root,
-                    False,
-                    scan_for_missing_files,
+                    db_root,
+                    full_path,
+                    flavor.format,
                     num_workers,
                     verbose,
                 )
 
-            # filter media
-            if media is not None or tables is not None:
-                db.pick_files(requested_media)
-
-            if not removed_media:
-                _remove_media(db, deps, num_workers, verbose)
-
-            # Adjust full paths and file extensions in tables
-            _update_path(
-                db,
-                db_root,
-                full_path,
-                flavor.format,
-                num_workers,
-                verbose,
-            )
-
-            # set file durations
-            _files_duration(
-                db,
-                deps,
-                requested_media,
-                flavor.format,
-            )
-
-            # check if database is now complete
-            if not db_is_complete:
-                _database_check_complete(
+                # set file durations
+                _files_duration(
                     db,
-                    db_root,
-                    flavor,
                     deps,
+                    requested_media,
+                    flavor.format,
                 )
 
-    except filelock.Timeout:
-        utils.timeout_warning()
+                # check if database is now complete
+                if not db_is_complete:
+                    _database_check_complete(
+                        db,
+                        db_root,
+                        flavor,
+                        deps,
+                    )
+
+        except filelock.Timeout:
+            utils.timeout_warning()
+
+    finally:
+        if verbose:  # pragma: no cover
+            shimmer.stop()
 
     return db
 
@@ -1349,47 +1356,53 @@ def load_attachment(
     db_root = database_cache_root(name, version, cache_root)
 
     if verbose:  # pragma: no cover
-        print(f"Get:   {name} v{version}")
+        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer.start()
         print(f"Cache: {db_root}")
 
-    deps = dependencies(
-        name,
-        version=version,
-        cache_root=cache_root,
-        verbose=verbose,
-    )
-
-    if attachment not in deps.archives:
-        msg = error_message_missing_object(
-            "attachment",
-            [attachment],
+    try:
+        deps = dependencies(
             name,
-            version,
-        )
-        raise ValueError(msg)
-
-    with FolderLock(db_root):
-        # Start with database header
-        db, backend_interface = load_header_to(
-            db_root,
-            name,
-            version,
+            version=version,
+            cache_root=cache_root,
+            verbose=verbose,
         )
 
-        # Load attachment
-        _load_attachments(
-            [attachment],
-            backend_interface,
-            db_root,
-            db,
-            version,
-            None,
-            deps,
-            Flavor(),
-            cache_root,
-            1,
-            verbose,
-        )
+        if attachment not in deps.archives:
+            msg = error_message_missing_object(
+                "attachment",
+                [attachment],
+                name,
+                version,
+            )
+            raise ValueError(msg)
+
+        with FolderLock(db_root):
+            # Start with database header
+            db, backend_interface = load_header_to(
+                db_root,
+                name,
+                version,
+            )
+
+            # Load attachment
+            _load_attachments(
+                [attachment],
+                backend_interface,
+                db_root,
+                db,
+                version,
+                None,
+                deps,
+                Flavor(),
+                cache_root,
+                1,
+                verbose,
+            )
+
+    finally:
+        if verbose:  # pragma: no cover
+            shimmer.stop()
 
     attachment_files = db.attachments[attachment].files
     attachment_files = [
@@ -1579,68 +1592,76 @@ def load_media(
     scan_for_missing_files = not is_empty(db_root)
 
     if verbose:  # pragma: no cover
-        print(f"Get:   {name} v{version}")
+        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer.start()
         print(f"Cache: {db_root}")
 
-    deps = dependencies(
-        name,
-        version=version,
-        cache_root=cache_root,
-        verbose=verbose,
-    )
-
-    available_files = set(deps.media)
-    missing = set(media) - available_files
-    if missing:
-        msg = error_message_missing_object(
-            "media",
-            sorted(missing),
-            name,
-            version,
-        )
-        raise ValueError(msg)
-
     try:
-        with FolderLock(db_root, timeout=timeout):
-            # Start with database header without tables
-            db, backend_interface = load_header_to(
-                db_root,
+        deps = dependencies(
+            name,
+            version=version,
+            cache_root=cache_root,
+            verbose=verbose,
+        )
+
+        available_files = set(deps.media)
+        missing = set(media) - available_files
+        if missing:
+            msg = error_message_missing_object(
+                "media",
+                sorted(missing),
                 name,
                 version,
-                flavor=flavor,
-                add_audb_meta=True,
             )
+            raise ValueError(msg)
 
-            db_is_complete = _database_is_complete(db)
-
-            # load missing media
-            if not db_is_complete:
-                _load_files(
-                    media,
-                    "media",
-                    backend_interface,
+        try:
+            with FolderLock(db_root, timeout=timeout):
+                # Start with database header without tables
+                db, backend_interface = load_header_to(
                     db_root,
-                    db,
+                    name,
                     version,
-                    None,
-                    deps,
-                    flavor,
-                    cache_root,
-                    False,
-                    scan_for_missing_files,
-                    num_workers,
-                    verbose,
+                    flavor=flavor,
+                    add_audb_meta=True,
                 )
 
-            if format is not None:
-                media = [audeer.replace_file_extension(m, format) for m in media]
-            files = [
-                os.path.join(db_root, os.path.normpath(file))  # convert "/" to os.sep
-                for file in media
-            ]
+                db_is_complete = _database_is_complete(db)
 
-    except filelock.Timeout:
-        utils.timeout_warning()
+                # load missing media
+                if not db_is_complete:
+                    _load_files(
+                        media,
+                        "media",
+                        backend_interface,
+                        db_root,
+                        db,
+                        version,
+                        None,
+                        deps,
+                        flavor,
+                        cache_root,
+                        False,
+                        scan_for_missing_files,
+                        num_workers,
+                        verbose,
+                    )
+
+                if format is not None:
+                    media = [audeer.replace_file_extension(m, format) for m in media]
+                files = [
+                    os.path.join(
+                        db_root, os.path.normpath(file)
+                    )  # convert "/" to os.sep
+                    for file in media
+                ]
+
+        except filelock.Timeout:
+            utils.timeout_warning()
+
+    finally:
+        if verbose:  # pragma: no cover
+            shimmer.stop()
 
     return files
 
@@ -1736,67 +1757,73 @@ def load_table(
     scan_for_missing_files = not is_empty(db_root)
 
     if verbose:  # pragma: no cover
-        print(f"Get:   {name} v{version}")
+        shimmer = Shimmer("Get:   ", name, f" v{version}")
+        shimmer.start()
         print(f"Cache: {db_root}")
 
-    deps = dependencies(
-        name,
-        version=version,
-        cache_root=cache_root,
-        verbose=verbose,
-    )
-
-    if table not in deps.table_ids:
-        msg = error_message_missing_object(
-            "table",
-            [table],
+    try:
+        deps = dependencies(
             name,
-            version,
-        )
-        raise ValueError(msg)
-
-    with FolderLock(db_root):
-        # Start with database header without tables
-        db, backend_interface = load_header_to(
-            db_root,
-            name,
-            version,
+            version=version,
+            cache_root=cache_root,
+            verbose=verbose,
         )
 
-        # Find only those misc tables used in schemes of the requested table
-        scheme_misc_tables = []
-        for column_id, column in db[table].columns.items():
-            if column.scheme_id is not None:
-                scheme = db.schemes[column.scheme_id]
-                if scheme.uses_table:
-                    scheme_misc_tables.append(scheme.labels)
-        scheme_misc_tables = audeer.unique(scheme_misc_tables)
+        if table not in deps.table_ids:
+            msg = error_message_missing_object(
+                "table",
+                [table],
+                name,
+                version,
+            )
+            raise ValueError(msg)
 
-        # Load table
-        tables = scheme_misc_tables + [table]
-        for _table in tables:
-            table_file = os.path.join(db_root, f"db.{_table}")
-            # `_load_files()` downloads a table
-            # from the backend,
-            # if it cannot find its corresponding csv or parquet file
-            if not os.path.exists(f"{table_file}.pkl"):
-                _load_files(
-                    [_table],
-                    "table",
-                    backend_interface,
-                    db_root,
-                    db,
-                    version,
-                    None,
-                    deps,
-                    Flavor(),
-                    cache_root,
-                    pickle_tables,
-                    scan_for_missing_files,
-                    num_workers,
-                    verbose,
-                )
-            db[_table].load(table_file)
+        with FolderLock(db_root):
+            # Start with database header without tables
+            db, backend_interface = load_header_to(
+                db_root,
+                name,
+                version,
+            )
+
+            # Find only those misc tables used in schemes of the requested table
+            scheme_misc_tables = []
+            for column_id, column in db[table].columns.items():
+                if column.scheme_id is not None:
+                    scheme = db.schemes[column.scheme_id]
+                    if scheme.uses_table:
+                        scheme_misc_tables.append(scheme.labels)
+            scheme_misc_tables = audeer.unique(scheme_misc_tables)
+
+            # Load table
+            tables = scheme_misc_tables + [table]
+            for _table in tables:
+                table_file = os.path.join(db_root, f"db.{_table}")
+                # `_load_files()` downloads a table
+                # from the backend,
+                # if it cannot find its corresponding csv or parquet file
+                if not os.path.exists(f"{table_file}.pkl"):
+                    _load_files(
+                        [_table],
+                        "table",
+                        backend_interface,
+                        db_root,
+                        db,
+                        version,
+                        None,
+                        deps,
+                        Flavor(),
+                        cache_root,
+                        pickle_tables,
+                        scan_for_missing_files,
+                        num_workers,
+                        verbose,
+                    )
+                db[_table].load(table_file)
+
+    finally:
+        if verbose:  # pragma: no cover
+            shimmer.stop()
 
     if map is None:
         df = db[table]._df

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1146,10 +1146,10 @@ def load(
     scan_for_missing_files = not is_empty(db_root)
 
     with shimmer(
-        "Get:   ",
-        f"{name} v{version}",
+        prefix="Get:   ",
+        text=f"{name} v{version}",
+        next_line=f"Cache: {db_root}",
         enabled=verbose,
-        message=f"Cache: {db_root}",
     ):
         db = _load(
             name,
@@ -1397,10 +1397,10 @@ def load_attachment(
     db_root = database_cache_root(name, version, cache_root)
 
     with shimmer(
-        "Get:   ",
-        f"{name} v{version}",
+        prefix="Get:   ",
+        text=f"{name} v{version}",
+        next_line=f"Cache: {db_root}",
         enabled=verbose,
-        message=f"Cache: {db_root}",
     ):
         deps = dependencies(
             name,
@@ -1627,10 +1627,10 @@ def load_media(
     scan_for_missing_files = not is_empty(db_root)
 
     with shimmer(
-        "Get:   ",
-        f"{name} v{version}",
+        prefix="Get:   ",
+        text=f"{name} v{version}",
+        next_line=f"Cache: {db_root}",
         enabled=verbose,
-        message=f"Cache: {db_root}",
     ):
         files = _load_media(
             name,
@@ -1823,10 +1823,10 @@ def load_table(
     scan_for_missing_files = not is_empty(db_root)
 
     with shimmer(
-        "Get:   ",
-        f"{name} v{version}",
+        prefix="Get:   ",
+        text=f"{name} v{version}",
+        next_line=f"Cache: {db_root}",
         enabled=verbose,
-        message=f"Cache: {db_root}",
     ):
         deps = dependencies(
             name,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -24,7 +24,7 @@ from audb.core.dependencies import error_message_missing_object
 from audb.core.dependencies import filter_deps
 from audb.core.flavor import Flavor
 from audb.core.lock import FolderLock
-from audb.core.shimmer import Shimmer
+from audb.core.shimmer import shimmer
 from audb.core.utils import is_empty
 from audb.core.utils import lookup_backend
 
@@ -1147,77 +1147,42 @@ def load(
     db_root = database_cache_root(name, version, cache_root, flavor)
     scan_for_missing_files = not is_empty(db_root)
 
-    shimmer = None
-    if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", f"{name} v{version}")
-        shimmer.start()
-        print(f"Cache: {db_root}")
-
-    try:
-        deps = dependencies(
-            name,
-            version=version,
-            cache_root=cache_root,
-        )
-
-        with FolderLock(db_root, timeout=timeout):
-            # Start with database header without tables
-            db, backend_interface = load_header_to(
-                db_root,
+    with shimmer(
+        "Get:   ",
+        f"{name} v{version}",
+        enabled=verbose,
+        message=f"Cache: {db_root}",
+    ):
+        try:
+            deps = dependencies(
                 name,
-                version,
-                flavor=flavor,
-                add_audb_meta=True,
+                version=version,
+                cache_root=cache_root,
             )
 
-            db_is_complete = _database_is_complete(db)
-
-            # load attachments
-            if not db_is_complete and not only_metadata:
-                # filter attachments
-                requested_attachments = filter_deps(
-                    attachments,
-                    db.attachments,
-                    "attachment",
-                )
-
-                cached_versions = _load_attachments(
-                    requested_attachments,
-                    backend_interface,
+            with FolderLock(db_root, timeout=timeout):
+                # Start with database header without tables
+                db, backend_interface = load_header_to(
                     db_root,
-                    db,
+                    name,
                     version,
-                    cached_versions,
-                    deps,
-                    flavor,
-                    cache_root,
-                    num_workers,
-                    verbose,
+                    flavor=flavor,
+                    add_audb_meta=True,
                 )
 
-            # filter tables (convert regexp pattern to list of tables)
-            requested_tables = filter_deps(tables, list(db), "table")
+                db_is_complete = _database_is_complete(db)
 
-            # add/split into misc tables used in a scheme
-            # and all other (misc) tables
-            requested_misc_tables = _misc_tables_used_in_scheme(db)
-            requested_tables = [
-                table
-                for table in requested_tables
-                if table not in requested_misc_tables
-            ]
+                # load attachments
+                if not db_is_complete and not only_metadata:
+                    # filter attachments
+                    requested_attachments = filter_deps(
+                        attachments,
+                        db.attachments,
+                        "attachment",
+                    )
 
-            # load missing tables
-            if not db_is_complete:
-                for _tables in [
-                    requested_misc_tables,
-                    requested_tables,
-                ]:
-                    # need to load misc tables used in a scheme first
-                    # as loading is done in parallel
-                    cached_versions = _load_files(
-                        _tables,
-                        "table",
+                    cached_versions = _load_attachments(
+                        requested_attachments,
                         backend_interface,
                         db_root,
                         db,
@@ -1226,89 +1191,120 @@ def load(
                         deps,
                         flavor,
                         cache_root,
-                        pickle_tables,
+                        num_workers,
+                        verbose,
+                    )
+
+                # filter tables (convert regexp pattern to list of tables)
+                requested_tables = filter_deps(tables, list(db), "table")
+
+                # add/split into misc tables used in a scheme
+                # and all other (misc) tables
+                requested_misc_tables = _misc_tables_used_in_scheme(db)
+                requested_tables = [
+                    table
+                    for table in requested_tables
+                    if table not in requested_misc_tables
+                ]
+
+                # load missing tables
+                if not db_is_complete:
+                    for _tables in [
+                        requested_misc_tables,
+                        requested_tables,
+                    ]:
+                        # need to load misc tables used in a scheme first
+                        # as loading is done in parallel
+                        cached_versions = _load_files(
+                            _tables,
+                            "table",
+                            backend_interface,
+                            db_root,
+                            db,
+                            version,
+                            cached_versions,
+                            deps,
+                            flavor,
+                            cache_root,
+                            pickle_tables,
+                            scan_for_missing_files,
+                            num_workers,
+                            verbose,
+                        )
+                requested_tables = requested_misc_tables + requested_tables
+
+                # filter tables
+                if tables is not None:
+                    db.pick_tables(requested_tables)
+
+                # load tables
+                for table in requested_tables:
+                    db[table].load(os.path.join(db_root, f"db.{table}"))
+
+                # filter media
+                requested_media = filter_deps(
+                    media,
+                    db.files,
+                    "media",
+                    name,
+                    version,
+                )
+
+                # load missing media
+                if not db_is_complete and not only_metadata:
+                    cached_versions = _load_files(
+                        requested_media,
+                        "media",
+                        backend_interface,
+                        db_root,
+                        db,
+                        version,
+                        cached_versions,
+                        deps,
+                        flavor,
+                        cache_root,
+                        False,
                         scan_for_missing_files,
                         num_workers,
                         verbose,
                     )
-            requested_tables = requested_misc_tables + requested_tables
 
-            # filter tables
-            if tables is not None:
-                db.pick_tables(requested_tables)
+                # filter media
+                if media is not None or tables is not None:
+                    db.pick_files(requested_media)
 
-            # load tables
-            for table in requested_tables:
-                db[table].load(os.path.join(db_root, f"db.{table}"))
+                if not removed_media:
+                    _remove_media(db, deps, num_workers, verbose)
 
-            # filter media
-            requested_media = filter_deps(
-                media,
-                db.files,
-                "media",
-                name,
-                version,
-            )
-
-            # load missing media
-            if not db_is_complete and not only_metadata:
-                cached_versions = _load_files(
-                    requested_media,
-                    "media",
-                    backend_interface,
-                    db_root,
+                # Adjust full paths and file extensions in tables
+                _update_path(
                     db,
-                    version,
-                    cached_versions,
-                    deps,
-                    flavor,
-                    cache_root,
-                    False,
-                    scan_for_missing_files,
+                    db_root,
+                    full_path,
+                    flavor.format,
                     num_workers,
                     verbose,
                 )
 
-            # filter media
-            if media is not None or tables is not None:
-                db.pick_files(requested_media)
-
-            if not removed_media:
-                _remove_media(db, deps, num_workers, verbose)
-
-            # Adjust full paths and file extensions in tables
-            _update_path(
-                db,
-                db_root,
-                full_path,
-                flavor.format,
-                num_workers,
-                verbose,
-            )
-
-            # set file durations
-            _files_duration(
-                db,
-                deps,
-                requested_media,
-                flavor.format,
-            )
-
-            # check if database is now complete
-            if not db_is_complete:
-                _database_check_complete(
+                # set file durations
+                _files_duration(
                     db,
-                    db_root,
-                    flavor,
                     deps,
+                    requested_media,
+                    flavor.format,
                 )
 
-    except filelock.Timeout:
-        utils.timeout_warning()
+                # check if database is now complete
+                if not db_is_complete:
+                    _database_check_complete(
+                        db,
+                        db_root,
+                        flavor,
+                        deps,
+                    )
 
-    finally:
-        if shimmer is not None:  # pragma: no cover
-            shimmer.stop()
+        except filelock.Timeout:
+            utils.timeout_warning()
 
     return db
 
@@ -1354,13 +1350,12 @@ def load_attachment(
 
     db_root = database_cache_root(name, version, cache_root)
 
-    shimmer = None
-    if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", f"{name} v{version}")
-        shimmer.start()
-        print(f"Cache: {db_root}")
-
-    try:
+    with shimmer(
+        "Get:   ",
+        f"{name} v{version}",
+        enabled=verbose,
+        message=f"Cache: {db_root}",
+    ):
         deps = dependencies(
             name,
             version=version,
@@ -1398,10 +1393,6 @@ def load_attachment(
                 1,
                 verbose,
             )
-
-    finally:
-        if shimmer is not None:  # pragma: no cover
-            shimmer.stop()
 
     attachment_files = db.attachments[attachment].files
     attachment_files = [
@@ -1590,74 +1581,72 @@ def load_media(
     db_root = database_cache_root(name, version, cache_root, flavor)
     scan_for_missing_files = not is_empty(db_root)
 
-    shimmer = None
-    if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", f"{name} v{version}")
-        shimmer.start()
-        print(f"Cache: {db_root}")
-
-    try:
-        deps = dependencies(
-            name,
-            version=version,
-            cache_root=cache_root,
-        )
-
-        available_files = set(deps.media)
-        missing = set(media) - available_files
-        if missing:
-            msg = error_message_missing_object(
-                "media",
-                sorted(missing),
+    with shimmer(
+        "Get:   ",
+        f"{name} v{version}",
+        enabled=verbose,
+        message=f"Cache: {db_root}",
+    ):
+        try:
+            deps = dependencies(
                 name,
-                version,
-            )
-            raise ValueError(msg)
-
-        with FolderLock(db_root, timeout=timeout):
-            # Start with database header without tables
-            db, backend_interface = load_header_to(
-                db_root,
-                name,
-                version,
-                flavor=flavor,
-                add_audb_meta=True,
+                version=version,
+                cache_root=cache_root,
             )
 
-            db_is_complete = _database_is_complete(db)
-
-            # load missing media
-            if not db_is_complete:
-                _load_files(
-                    media,
+            available_files = set(deps.media)
+            missing = set(media) - available_files
+            if missing:
+                msg = error_message_missing_object(
                     "media",
-                    backend_interface,
-                    db_root,
-                    db,
+                    sorted(missing),
+                    name,
                     version,
-                    None,
-                    deps,
-                    flavor,
-                    cache_root,
-                    False,
-                    scan_for_missing_files,
-                    num_workers,
-                    verbose,
+                )
+                raise ValueError(msg)
+
+            with FolderLock(db_root, timeout=timeout):
+                # Start with database header without tables
+                db, backend_interface = load_header_to(
+                    db_root,
+                    name,
+                    version,
+                    flavor=flavor,
+                    add_audb_meta=True,
                 )
 
-            if format is not None:
-                media = [audeer.replace_file_extension(m, format) for m in media]
-            files = [
-                os.path.join(db_root, os.path.normpath(file))  # convert "/" to os.sep
-                for file in media
-            ]
+                db_is_complete = _database_is_complete(db)
 
-    except filelock.Timeout:
-        utils.timeout_warning()
+                # load missing media
+                if not db_is_complete:
+                    _load_files(
+                        media,
+                        "media",
+                        backend_interface,
+                        db_root,
+                        db,
+                        version,
+                        None,
+                        deps,
+                        flavor,
+                        cache_root,
+                        False,
+                        scan_for_missing_files,
+                        num_workers,
+                        verbose,
+                    )
 
-    finally:
-        if shimmer is not None:  # pragma: no cover
-            shimmer.stop()
+                if format is not None:
+                    media = [audeer.replace_file_extension(m, format) for m in media]
+                files = [
+                    os.path.join(
+                        db_root, os.path.normpath(file)
+                    )  # convert "/" to os.sep
+                    for file in media
+                ]
+
+        except filelock.Timeout:
+            utils.timeout_warning()
 
     return files
 
@@ -1752,13 +1741,12 @@ def load_table(
     db_root = database_cache_root(name, version, cache_root)
     scan_for_missing_files = not is_empty(db_root)
 
-    shimmer = None
-    if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", f"{name} v{version}")
-        shimmer.start()
-        print(f"Cache: {db_root}")
-
-    try:
+    with shimmer(
+        "Get:   ",
+        f"{name} v{version}",
+        enabled=verbose,
+        message=f"Cache: {db_root}",
+    ):
         deps = dependencies(
             name,
             version=version,
@@ -1816,10 +1804,6 @@ def load_table(
                         verbose,
                     )
                 db[_table].load(table_file)
-
-    finally:
-        if shimmer is not None:  # pragma: no cover
-            shimmer.stop()
 
     if map is None:
         df = db[table]._df

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1135,8 +1135,6 @@ def load(
     if version is None:
         version = latest_version(name)
 
-    db = None
-    cached_versions = None
     flavor = Flavor(
         channels=channels,
         format=format,
@@ -1153,158 +1151,206 @@ def load(
         enabled=verbose,
         message=f"Cache: {db_root}",
     ):
-        try:
-            deps = dependencies(
+        db = _load(
+            name,
+            version,
+            only_metadata,
+            attachments,
+            tables,
+            media,
+            removed_media,
+            full_path,
+            pickle_tables,
+            cache_root,
+            num_workers,
+            timeout,
+            verbose,
+            flavor,
+            db_root,
+            scan_for_missing_files,
+        )
+
+    return db
+
+
+def _load(
+    name: str,
+    version: str,
+    only_metadata: bool,
+    attachments: str | Sequence[str],
+    tables: str | Sequence[str],
+    media: str | Sequence[str],
+    removed_media: bool,
+    full_path: bool,
+    pickle_tables: bool,
+    cache_root: str | None,
+    num_workers: int | None,
+    timeout: float,
+    verbose: bool,
+    flavor: Flavor,
+    db_root: str,
+    scan_for_missing_files: bool,
+) -> audformat.Database | None:
+    r"""Load database without the progress animation.
+
+    The body of :func:`load` lives here so that :func:`load`
+    only sets up and tears down the :func:`shimmer` animation.
+
+    """
+    db = None
+    cached_versions = None
+    try:
+        deps = dependencies(
+            name,
+            version=version,
+            cache_root=cache_root,
+        )
+
+        with FolderLock(db_root, timeout=timeout):
+            # Start with database header without tables
+            db, backend_interface = load_header_to(
+                db_root,
                 name,
-                version=version,
-                cache_root=cache_root,
+                version,
+                flavor=flavor,
+                add_audb_meta=True,
             )
 
-            with FolderLock(db_root, timeout=timeout):
-                # Start with database header without tables
-                db, backend_interface = load_header_to(
+            db_is_complete = _database_is_complete(db)
+
+            # load attachments
+            if not db_is_complete and not only_metadata:
+                # filter attachments
+                requested_attachments = filter_deps(
+                    attachments,
+                    db.attachments,
+                    "attachment",
+                )
+
+                cached_versions = _load_attachments(
+                    requested_attachments,
+                    backend_interface,
                     db_root,
-                    name,
-                    version,
-                    flavor=flavor,
-                    add_audb_meta=True,
-                )
-
-                db_is_complete = _database_is_complete(db)
-
-                # load attachments
-                if not db_is_complete and not only_metadata:
-                    # filter attachments
-                    requested_attachments = filter_deps(
-                        attachments,
-                        db.attachments,
-                        "attachment",
-                    )
-
-                    cached_versions = _load_attachments(
-                        requested_attachments,
-                        backend_interface,
-                        db_root,
-                        db,
-                        version,
-                        cached_versions,
-                        deps,
-                        flavor,
-                        cache_root,
-                        num_workers,
-                        verbose,
-                    )
-
-                # filter tables (convert regexp pattern to list of tables)
-                requested_tables = filter_deps(tables, list(db), "table")
-
-                # add/split into misc tables used in a scheme
-                # and all other (misc) tables
-                requested_misc_tables = _misc_tables_used_in_scheme(db)
-                requested_tables = [
-                    table
-                    for table in requested_tables
-                    if table not in requested_misc_tables
-                ]
-
-                # load missing tables
-                if not db_is_complete:
-                    for _tables in [
-                        requested_misc_tables,
-                        requested_tables,
-                    ]:
-                        # need to load misc tables used in a scheme first
-                        # as loading is done in parallel
-                        cached_versions = _load_files(
-                            _tables,
-                            "table",
-                            backend_interface,
-                            db_root,
-                            db,
-                            version,
-                            cached_versions,
-                            deps,
-                            flavor,
-                            cache_root,
-                            pickle_tables,
-                            scan_for_missing_files,
-                            num_workers,
-                            verbose,
-                        )
-                requested_tables = requested_misc_tables + requested_tables
-
-                # filter tables
-                if tables is not None:
-                    db.pick_tables(requested_tables)
-
-                # load tables
-                for table in requested_tables:
-                    db[table].load(os.path.join(db_root, f"db.{table}"))
-
-                # filter media
-                requested_media = filter_deps(
-                    media,
-                    db.files,
-                    "media",
-                    name,
-                    version,
-                )
-
-                # load missing media
-                if not db_is_complete and not only_metadata:
-                    cached_versions = _load_files(
-                        requested_media,
-                        "media",
-                        backend_interface,
-                        db_root,
-                        db,
-                        version,
-                        cached_versions,
-                        deps,
-                        flavor,
-                        cache_root,
-                        False,
-                        scan_for_missing_files,
-                        num_workers,
-                        verbose,
-                    )
-
-                # filter media
-                if media is not None or tables is not None:
-                    db.pick_files(requested_media)
-
-                if not removed_media:
-                    _remove_media(db, deps, num_workers, verbose)
-
-                # Adjust full paths and file extensions in tables
-                _update_path(
                     db,
-                    db_root,
-                    full_path,
-                    flavor.format,
+                    version,
+                    cached_versions,
+                    deps,
+                    flavor,
+                    cache_root,
                     num_workers,
                     verbose,
                 )
 
-                # set file durations
-                _files_duration(
-                    db,
-                    deps,
+            # filter tables (convert regexp pattern to list of tables)
+            requested_tables = filter_deps(tables, list(db), "table")
+
+            # add/split into misc tables used in a scheme
+            # and all other (misc) tables
+            requested_misc_tables = _misc_tables_used_in_scheme(db)
+            requested_tables = [
+                table
+                for table in requested_tables
+                if table not in requested_misc_tables
+            ]
+
+            # load missing tables
+            if not db_is_complete:
+                for _tables in [
+                    requested_misc_tables,
+                    requested_tables,
+                ]:
+                    # need to load misc tables used in a scheme first
+                    # as loading is done in parallel
+                    cached_versions = _load_files(
+                        _tables,
+                        "table",
+                        backend_interface,
+                        db_root,
+                        db,
+                        version,
+                        cached_versions,
+                        deps,
+                        flavor,
+                        cache_root,
+                        pickle_tables,
+                        scan_for_missing_files,
+                        num_workers,
+                        verbose,
+                    )
+            requested_tables = requested_misc_tables + requested_tables
+
+            # filter tables
+            if tables is not None:
+                db.pick_tables(requested_tables)
+
+            # load tables
+            for table in requested_tables:
+                db[table].load(os.path.join(db_root, f"db.{table}"))
+
+            # filter media
+            requested_media = filter_deps(
+                media,
+                db.files,
+                "media",
+                name,
+                version,
+            )
+
+            # load missing media
+            if not db_is_complete and not only_metadata:
+                cached_versions = _load_files(
                     requested_media,
-                    flavor.format,
+                    "media",
+                    backend_interface,
+                    db_root,
+                    db,
+                    version,
+                    cached_versions,
+                    deps,
+                    flavor,
+                    cache_root,
+                    False,
+                    scan_for_missing_files,
+                    num_workers,
+                    verbose,
                 )
 
-                # check if database is now complete
-                if not db_is_complete:
-                    _database_check_complete(
-                        db,
-                        db_root,
-                        flavor,
-                        deps,
-                    )
+            # filter media
+            if media is not None or tables is not None:
+                db.pick_files(requested_media)
 
-        except filelock.Timeout:
-            utils.timeout_warning()
+            if not removed_media:
+                _remove_media(db, deps, num_workers, verbose)
+
+            # Adjust full paths and file extensions in tables
+            _update_path(
+                db,
+                db_root,
+                full_path,
+                flavor.format,
+                num_workers,
+                verbose,
+            )
+
+            # set file durations
+            _files_duration(
+                db,
+                deps,
+                requested_media,
+                flavor.format,
+            )
+
+            # check if database is now complete
+            if not db_is_complete:
+                _database_check_complete(
+                    db,
+                    db_root,
+                    flavor,
+                    deps,
+                )
+
+    except filelock.Timeout:
+        utils.timeout_warning()
 
     return db
 
@@ -1570,7 +1616,6 @@ def load_media(
     if version is None:
         version = latest_version(name)
 
-    files = None
     flavor = Flavor(
         channels=channels,
         format=format,
@@ -1587,66 +1632,102 @@ def load_media(
         enabled=verbose,
         message=f"Cache: {db_root}",
     ):
-        try:
-            deps = dependencies(
+        files = _load_media(
+            name,
+            media,
+            version,
+            format,
+            cache_root,
+            num_workers,
+            timeout,
+            verbose,
+            flavor,
+            db_root,
+            scan_for_missing_files,
+        )
+
+    return files
+
+
+def _load_media(
+    name: str,
+    media: Sequence[str],
+    version: str,
+    format: str | None,
+    cache_root: str | None,
+    num_workers: int | None,
+    timeout: float,
+    verbose: bool,
+    flavor: Flavor,
+    db_root: str,
+    scan_for_missing_files: bool,
+) -> list | None:
+    r"""Load media file(s) without the progress animation.
+
+    The body of :func:`load_media` lives here so that
+    :func:`load_media` only sets up and tears down the
+    :func:`shimmer` animation.
+
+    """
+    files = None
+    try:
+        deps = dependencies(
+            name,
+            version=version,
+            cache_root=cache_root,
+        )
+
+        available_files = set(deps.media)
+        missing = set(media) - available_files
+        if missing:
+            msg = error_message_missing_object(
+                "media",
+                sorted(missing),
                 name,
-                version=version,
-                cache_root=cache_root,
+                version,
+            )
+            raise ValueError(msg)
+
+        with FolderLock(db_root, timeout=timeout):
+            # Start with database header without tables
+            db, backend_interface = load_header_to(
+                db_root,
+                name,
+                version,
+                flavor=flavor,
+                add_audb_meta=True,
             )
 
-            available_files = set(deps.media)
-            missing = set(media) - available_files
-            if missing:
-                msg = error_message_missing_object(
+            db_is_complete = _database_is_complete(db)
+
+            # load missing media
+            if not db_is_complete:
+                _load_files(
+                    media,
                     "media",
-                    sorted(missing),
-                    name,
-                    version,
-                )
-                raise ValueError(msg)
-
-            with FolderLock(db_root, timeout=timeout):
-                # Start with database header without tables
-                db, backend_interface = load_header_to(
+                    backend_interface,
                     db_root,
-                    name,
+                    db,
                     version,
-                    flavor=flavor,
-                    add_audb_meta=True,
+                    None,
+                    deps,
+                    flavor,
+                    cache_root,
+                    False,
+                    scan_for_missing_files,
+                    num_workers,
+                    verbose,
                 )
 
-                db_is_complete = _database_is_complete(db)
+            if format is not None:
+                media = [audeer.replace_file_extension(m, format) for m in media]
+            files = [
+                os.path.join(db_root, os.path.normpath(file))  # convert "/" to os.sep
+                for file in media
+            ]
 
-                # load missing media
-                if not db_is_complete:
-                    _load_files(
-                        media,
-                        "media",
-                        backend_interface,
-                        db_root,
-                        db,
-                        version,
-                        None,
-                        deps,
-                        flavor,
-                        cache_root,
-                        False,
-                        scan_for_missing_files,
-                        num_workers,
-                        verbose,
-                    )
-
-                if format is not None:
-                    media = [audeer.replace_file_extension(m, format) for m in media]
-                files = [
-                    os.path.join(
-                        db_root, os.path.normpath(file)
-                    )  # convert "/" to os.sep
-                    for file in media
-                ]
-
-        except filelock.Timeout:
-            utils.timeout_warning()
+    except filelock.Timeout:
+        utils.timeout_warning()
 
     return files
 

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -344,7 +344,7 @@ def load_to(
     if verbose:  # pragma: no cover
         shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
-        print(f"Root: {db_root}")
+        print(f"To: {db_root}")
 
     try:
         # remove files with a wrong checksum

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -14,6 +14,7 @@ from audb.core.api import latest_version
 from audb.core.dependencies import Dependencies
 from audb.core.load import database_tmp_root
 from audb.core.load import load_header_to
+from audb.core.shimmer import Shimmer
 
 
 def _find_attachments(
@@ -340,101 +341,70 @@ def load_to(
     db_root = audeer.path(root, follow_symlink=True)
     db_root_tmp = database_tmp_root(db_root)
 
-    # remove files with a wrong checksum
-    # to ensure we load correct version
-    update = os.path.exists(db_root) and os.listdir(db_root)
-    audeer.mkdir(db_root)
-    deps = dependencies(
-        name,
-        version=version,
-        cache_root=cache_root,
-        verbose=verbose,
-    )
-    if update:
-        if only_metadata:
-            files = deps.tables
-        else:
-            files = deps.attachments + deps.files
-        for file in files:
-            full_file = os.path.join(db_root, file)
-            if os.path.exists(full_file):
-                checksum = utils.md5(full_file)
-                if checksum != deps.checksum(file):
-                    if os.path.isdir(full_file):
-                        audeer.rmdir(full_file)
-                    else:
-                        os.remove(full_file)
+    if verbose:  # pragma: no cover
+        shimmer = Shimmer("Get:   ", f"{name} v{version}")
+        shimmer.start()
+        print(f"Root: {db_root}")
 
-    # load database header without tables from backend
-
-    db_header, backend_interface = load_header_to(
-        db_root_tmp,
-        name,
-        version,
-        overwrite=True,
-    )
-    db_header.save(db_root_tmp, header_only=True)
-
-    # get altered and new attachments
-
-    if not only_metadata:
-        attachments = _find_attachments(
-            db_root,
-            deps,
-        )
-        _get_attachments(
-            attachments,
-            db_root,
-            db_root_tmp,
-            name,
-            deps,
-            backend_interface,
-            num_workers,
-            verbose,
-        )
-
-    # get altered and new tables
-
-    tables = _find_tables(db_header, db_root, deps, num_workers, verbose)
-    _get_tables(
-        tables,
-        db_root,
-        db_root_tmp,
-        name,
-        deps,
-        backend_interface,
-        num_workers,
-        verbose,
-    )
-
-    # load database
-
-    # move header to root and load database ...
-    audeer.move_file(
-        os.path.join(db_root_tmp, define.HEADER_FILE),
-        os.path.join(db_root, define.HEADER_FILE),
-    )
     try:
-        db = audformat.Database.load(
-            db_root,
-            num_workers=num_workers,
+        # remove files with a wrong checksum
+        # to ensure we load correct version
+        update = os.path.exists(db_root) and os.listdir(db_root)
+        audeer.mkdir(db_root)
+        deps = dependencies(
+            name,
+            version=version,
+            cache_root=cache_root,
             verbose=verbose,
         )
-    except (KeyboardInterrupt, Exception):  # pragma: no cover
-        # make sure to remove header if user interrupts
-        os.remove(os.path.join(db_root, define.HEADER_FILE))
-        raise
+        if update:
+            if only_metadata:
+                files = deps.tables
+            else:
+                files = deps.attachments + deps.files
+            for file in files:
+                full_file = os.path.join(db_root, file)
+                if os.path.exists(full_file):
+                    checksum = utils.md5(full_file)
+                    if checksum != deps.checksum(file):
+                        if os.path.isdir(full_file):
+                            audeer.rmdir(full_file)
+                        else:
+                            os.remove(full_file)
 
-    # afterwards remove header to avoid the database
-    # can be loaded before download is complete
-    os.remove(os.path.join(db_root, define.HEADER_FILE))
+        # load database header without tables from backend
 
-    # get altered and new media files
+        db_header, backend_interface = load_header_to(
+            db_root_tmp,
+            name,
+            version,
+            overwrite=True,
+        )
+        db_header.save(db_root_tmp, header_only=True)
 
-    if not only_metadata:
-        media = _find_media(db, db_root, deps, num_workers, verbose)
-        _get_media(
-            media,
+        # get altered and new attachments
+
+        if not only_metadata:
+            attachments = _find_attachments(
+                db_root,
+                deps,
+            )
+            _get_attachments(
+                attachments,
+                db_root,
+                db_root_tmp,
+                name,
+                deps,
+                backend_interface,
+                num_workers,
+                verbose,
+            )
+
+        # get altered and new tables
+
+        tables = _find_tables(db_header, db_root, deps, num_workers, verbose)
+        _get_tables(
+            tables,
             db_root,
             db_root_tmp,
             name,
@@ -444,37 +414,78 @@ def load_to(
             verbose,
         )
 
-    # save dependencies
+        # load database
 
-    dep_path_tmp = os.path.join(db_root_tmp, define.DEPENDENCY_FILE)
-    deps.save(dep_path_tmp)
-    audeer.move_file(
-        dep_path_tmp,
-        os.path.join(db_root, define.DEPENDENCY_FILE),
-    )
-
-    # save database and PKL tables
-
-    if pickle_tables:
-        # Store database header,
-        # and add table as pickle files
-        # (tables are already stored in their original format).
-        # Uses `num_workers` to save tables in parallel.
-        db.save(
-            db_root,
-            storage_format=audformat.define.TableStorageFormat.PICKLE,
-            update_other_formats=False,
-            num_workers=num_workers,
-            verbose=verbose,
+        # move header to root and load database ...
+        audeer.move_file(
+            os.path.join(db_root_tmp, define.HEADER_FILE),
+            os.path.join(db_root, define.HEADER_FILE),
         )
-    else:
-        # Store database header
-        # (tables are already stored)
-        db.save(
-            db_root,
-            header_only=True,
-            verbose=verbose,
+        try:
+            db = audformat.Database.load(
+                db_root,
+                num_workers=num_workers,
+                verbose=verbose,
+            )
+        except (KeyboardInterrupt, Exception):  # pragma: no cover
+            # make sure to remove header if user interrupts
+            os.remove(os.path.join(db_root, define.HEADER_FILE))
+            raise
+
+        # afterwards remove header to avoid the database
+        # can be loaded before download is complete
+        os.remove(os.path.join(db_root, define.HEADER_FILE))
+
+        # get altered and new media files
+
+        if not only_metadata:
+            media = _find_media(db, db_root, deps, num_workers, verbose)
+            _get_media(
+                media,
+                db_root,
+                db_root_tmp,
+                name,
+                deps,
+                backend_interface,
+                num_workers,
+                verbose,
+            )
+
+        # save dependencies
+
+        dep_path_tmp = os.path.join(db_root_tmp, define.DEPENDENCY_FILE)
+        deps.save(dep_path_tmp)
+        audeer.move_file(
+            dep_path_tmp,
+            os.path.join(db_root, define.DEPENDENCY_FILE),
         )
+
+        # save database and PKL tables
+
+        if pickle_tables:
+            # Store database header,
+            # and add table as pickle files
+            # (tables are already stored in their original format).
+            # Uses `num_workers` to save tables in parallel.
+            db.save(
+                db_root,
+                storage_format=audformat.define.TableStorageFormat.PICKLE,
+                update_other_formats=False,
+                num_workers=num_workers,
+                verbose=verbose,
+            )
+        else:
+            # Store database header
+            # (tables are already stored)
+            db.save(
+                db_root,
+                header_only=True,
+                verbose=verbose,
+            )
+
+    finally:
+        if verbose:  # pragma: no cover
+            shimmer.stop()
 
     # remove the temporal directory
     # to signal all files were correctly loaded

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -356,7 +356,6 @@ def load_to(
             name,
             version=version,
             cache_root=cache_root,
-            verbose=verbose,
         )
         if update:
             if only_metadata:

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -341,6 +341,7 @@ def load_to(
     db_root = audeer.path(root, follow_symlink=True)
     db_root_tmp = database_tmp_root(db_root)
 
+    shimmer = None
     if verbose:  # pragma: no cover
         shimmer = Shimmer("Get:   ", f"{name} v{version}")
         shimmer.start()
@@ -484,7 +485,7 @@ def load_to(
             )
 
     finally:
-        if verbose:  # pragma: no cover
+        if shimmer is not None:  # pragma: no cover
             shimmer.stop()
 
     # remove the temporal directory

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -14,7 +14,7 @@ from audb.core.api import latest_version
 from audb.core.dependencies import Dependencies
 from audb.core.load import database_tmp_root
 from audb.core.load import load_header_to
-from audb.core.shimmer import Shimmer
+from audb.core.shimmer import shimmer
 
 
 def _find_attachments(
@@ -341,13 +341,12 @@ def load_to(
     db_root = audeer.path(root, follow_symlink=True)
     db_root_tmp = database_tmp_root(db_root)
 
-    shimmer = None
-    if verbose:  # pragma: no cover
-        shimmer = Shimmer("Get:   ", f"{name} v{version}")
-        shimmer.start()
-        print(f"To: {db_root}")
-
-    try:
+    with shimmer(
+        "Get:   ",
+        f"{name} v{version}",
+        enabled=verbose,
+        message=f"To: {db_root}",
+    ):
         db = _load_to(
             db_root,
             db_root_tmp,
@@ -359,9 +358,6 @@ def load_to(
             num_workers,
             verbose,
         )
-    finally:
-        if shimmer is not None:  # pragma: no cover
-            shimmer.stop()
 
     # remove the temporal directory
     # to signal all files were correctly loaded

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -348,141 +348,17 @@ def load_to(
         print(f"To: {db_root}")
 
     try:
-        # remove files with a wrong checksum
-        # to ensure we load correct version
-        update = os.path.exists(db_root) and os.listdir(db_root)
-        audeer.mkdir(db_root)
-        deps = dependencies(
-            name,
-            version=version,
-            cache_root=cache_root,
-        )
-        if update:
-            if only_metadata:
-                files = deps.tables
-            else:
-                files = deps.attachments + deps.files
-            for file in files:
-                full_file = os.path.join(db_root, file)
-                if os.path.exists(full_file):
-                    checksum = utils.md5(full_file)
-                    if checksum != deps.checksum(file):
-                        if os.path.isdir(full_file):
-                            audeer.rmdir(full_file)
-                        else:
-                            os.remove(full_file)
-
-        # load database header without tables from backend
-
-        db_header, backend_interface = load_header_to(
-            db_root_tmp,
-            name,
-            version,
-            overwrite=True,
-        )
-        db_header.save(db_root_tmp, header_only=True)
-
-        # get altered and new attachments
-
-        if not only_metadata:
-            attachments = _find_attachments(
-                db_root,
-                deps,
-            )
-            _get_attachments(
-                attachments,
-                db_root,
-                db_root_tmp,
-                name,
-                deps,
-                backend_interface,
-                num_workers,
-                verbose,
-            )
-
-        # get altered and new tables
-
-        tables = _find_tables(db_header, db_root, deps, num_workers, verbose)
-        _get_tables(
-            tables,
+        db = _load_to(
             db_root,
             db_root_tmp,
             name,
-            deps,
-            backend_interface,
+            version,
+            only_metadata,
+            pickle_tables,
+            cache_root,
             num_workers,
             verbose,
         )
-
-        # load database
-
-        # move header to root and load database ...
-        audeer.move_file(
-            os.path.join(db_root_tmp, define.HEADER_FILE),
-            os.path.join(db_root, define.HEADER_FILE),
-        )
-        try:
-            db = audformat.Database.load(
-                db_root,
-                num_workers=num_workers,
-                verbose=verbose,
-            )
-        except (KeyboardInterrupt, Exception):  # pragma: no cover
-            # make sure to remove header if user interrupts
-            os.remove(os.path.join(db_root, define.HEADER_FILE))
-            raise
-
-        # afterwards remove header to avoid the database
-        # can be loaded before download is complete
-        os.remove(os.path.join(db_root, define.HEADER_FILE))
-
-        # get altered and new media files
-
-        if not only_metadata:
-            media = _find_media(db, db_root, deps, num_workers, verbose)
-            _get_media(
-                media,
-                db_root,
-                db_root_tmp,
-                name,
-                deps,
-                backend_interface,
-                num_workers,
-                verbose,
-            )
-
-        # save dependencies
-
-        dep_path_tmp = os.path.join(db_root_tmp, define.DEPENDENCY_FILE)
-        deps.save(dep_path_tmp)
-        audeer.move_file(
-            dep_path_tmp,
-            os.path.join(db_root, define.DEPENDENCY_FILE),
-        )
-
-        # save database and PKL tables
-
-        if pickle_tables:
-            # Store database header,
-            # and add table as pickle files
-            # (tables are already stored in their original format).
-            # Uses `num_workers` to save tables in parallel.
-            db.save(
-                db_root,
-                storage_format=audformat.define.TableStorageFormat.PICKLE,
-                update_other_formats=False,
-                num_workers=num_workers,
-                verbose=verbose,
-            )
-        else:
-            # Store database header
-            # (tables are already stored)
-            db.save(
-                db_root,
-                header_only=True,
-                verbose=verbose,
-            )
-
     finally:
         if shimmer is not None:  # pragma: no cover
             shimmer.stop()
@@ -496,6 +372,162 @@ def load_to(
             "Could not remove temporary directory, "
             "probably there are some leftover files. "
             "This should not happen."
+        )
+
+    return db
+
+
+def _load_to(
+    db_root: str,
+    db_root_tmp: str,
+    name: str,
+    version: str,
+    only_metadata: bool,
+    pickle_tables: bool,
+    cache_root: str | None,
+    num_workers: int | None,
+    verbose: bool,
+) -> audformat.Database:
+    r"""Load database to directory without the progress animation.
+
+    The body of :func:`load_to` lives here so that :func:`load_to`
+    only sets up and tears down the :class:`Shimmer` animation
+    and performs the final temporary-directory cleanup.
+
+    """
+    # remove files with a wrong checksum
+    # to ensure we load correct version
+    update = os.path.exists(db_root) and os.listdir(db_root)
+    audeer.mkdir(db_root)
+    deps = dependencies(
+        name,
+        version=version,
+        cache_root=cache_root,
+    )
+    if update:
+        if only_metadata:
+            files = deps.tables
+        else:
+            files = deps.attachments + deps.files
+        for file in files:
+            full_file = os.path.join(db_root, file)
+            if os.path.exists(full_file):
+                checksum = utils.md5(full_file)
+                if checksum != deps.checksum(file):
+                    if os.path.isdir(full_file):
+                        audeer.rmdir(full_file)
+                    else:
+                        os.remove(full_file)
+
+    # load database header without tables from backend
+
+    db_header, backend_interface = load_header_to(
+        db_root_tmp,
+        name,
+        version,
+        overwrite=True,
+    )
+    db_header.save(db_root_tmp, header_only=True)
+
+    # get altered and new attachments
+
+    if not only_metadata:
+        attachments = _find_attachments(
+            db_root,
+            deps,
+        )
+        _get_attachments(
+            attachments,
+            db_root,
+            db_root_tmp,
+            name,
+            deps,
+            backend_interface,
+            num_workers,
+            verbose,
+        )
+
+    # get altered and new tables
+
+    tables = _find_tables(db_header, db_root, deps, num_workers, verbose)
+    _get_tables(
+        tables,
+        db_root,
+        db_root_tmp,
+        name,
+        deps,
+        backend_interface,
+        num_workers,
+        verbose,
+    )
+
+    # load database
+
+    # move header to root and load database ...
+    audeer.move_file(
+        os.path.join(db_root_tmp, define.HEADER_FILE),
+        os.path.join(db_root, define.HEADER_FILE),
+    )
+    try:
+        db = audformat.Database.load(
+            db_root,
+            num_workers=num_workers,
+            verbose=verbose,
+        )
+    except (KeyboardInterrupt, Exception):  # pragma: no cover
+        # make sure to remove header if user interrupts
+        os.remove(os.path.join(db_root, define.HEADER_FILE))
+        raise
+
+    # afterwards remove header to avoid the database
+    # can be loaded before download is complete
+    os.remove(os.path.join(db_root, define.HEADER_FILE))
+
+    # get altered and new media files
+
+    if not only_metadata:
+        media = _find_media(db, db_root, deps, num_workers, verbose)
+        _get_media(
+            media,
+            db_root,
+            db_root_tmp,
+            name,
+            deps,
+            backend_interface,
+            num_workers,
+            verbose,
+        )
+
+    # save dependencies
+
+    dep_path_tmp = os.path.join(db_root_tmp, define.DEPENDENCY_FILE)
+    deps.save(dep_path_tmp)
+    audeer.move_file(
+        dep_path_tmp,
+        os.path.join(db_root, define.DEPENDENCY_FILE),
+    )
+
+    # save database and PKL tables
+
+    if pickle_tables:
+        # Store database header,
+        # and add table as pickle files
+        # (tables are already stored in their original format).
+        # Uses `num_workers` to save tables in parallel.
+        db.save(
+            db_root,
+            storage_format=audformat.define.TableStorageFormat.PICKLE,
+            update_other_formats=False,
+            num_workers=num_workers,
+            verbose=verbose,
+        )
+    else:
+        # Store database header
+        # (tables are already stored)
+        db.save(
+            db_root,
+            header_only=True,
+            verbose=verbose,
         )
 
     return db

--- a/audb/core/load_to.py
+++ b/audb/core/load_to.py
@@ -342,10 +342,10 @@ def load_to(
     db_root_tmp = database_tmp_root(db_root)
 
     with shimmer(
-        "Get:   ",
-        f"{name} v{version}",
+        prefix="Get:   ",
+        text=f"{name} v{version}",
+        next_line=f"To: {db_root}",
         enabled=verbose,
-        message=f"To: {db_root}",
     ):
         db = _load_to(
             db_root,

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -818,7 +818,6 @@ def publish(
                 db.name,
                 version=previous_version,
                 cache_root=cache_root,
-                verbose=verbose,
             )
             if not deps().equals(previous_deps()):
                 raise RuntimeError(

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -19,6 +19,7 @@ from audb.core.api import versions as api_versions
 from audb.core.dependencies import Dependencies
 from audb.core.dependencies import upload_dependencies
 from audb.core.repository import Repository
+from audb.core.shimmer import Shimmer
 
 
 def _check_for_duplicates(
@@ -738,195 +739,224 @@ def publish(
         verbose=verbose,
     )
 
-    backend_interface = repository.create_backend_interface()
+    if verbose:  # pragma: no cover
+        shimmer = Shimmer("Put:   ", f"{db.name} v{version}")
+        shimmer.start()
+        print(f"Source: {db_root}")
 
-    with backend_interface.backend:
-        remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
-        versions = backend_interface.versions(
-            remote_header,
-            suppress_backend_errors=True,
-        )
+    try:
+        backend_interface = repository.create_backend_interface()
 
-    if version in versions:
-        raise RuntimeError(
-            f"A version '{version}' already exists for database '{db.name}'."
-        )
-    if previous_version == "latest":
-        # Find latest version across all repositories (like audb.latest_version)
-        all_versions = api_versions(db.name)
-        previous_version = all_versions[-1] if len(all_versions) > 0 else None
-    # Check repository consistency when previous_version is specified
-    if previous_version is not None:
-        previous_repository = utils._lookup(db.name, previous_version)[0]
-        if previous_repository != repository:
-            raise RuntimeError(
-                f"Cannot publish version '{version}' "
-                f"to repository '{repository.name}' "
-                f"based on previous version '{previous_version}'. "
-                "The previous version is stored in repository "
-                f"'{previous_repository.name}'. "
-                "Publishing to a different repository would split the database "
-                "across multiple repositories, "
-                "which can create data privacy risks "
-                "and is not supported. "
-                "Use previous_version=None "
-                f"to start a new database in '{repository.name}' "
-                f"or publish to the same repository '{previous_repository.name}'."
+        with backend_interface.backend:
+            remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
+            versions = backend_interface.versions(
+                remote_header,
+                suppress_backend_errors=True,
             )
 
-    # load database and dependencies
-    deps = Dependencies()
-    for deps_file in [define.DEPENDENCY_FILE, define.LEGACY_DEPENDENCY_FILE]:
-        deps_path = os.path.join(db_root, deps_file)
-        if os.path.exists(deps_path):
-            deps.load(deps_path)
-            break
+        if version in versions:
+            raise RuntimeError(
+                f"A version '{version}' already exists for database '{db.name}'."
+            )
+        if previous_version == "latest":
+            # Find latest version across all repositories (like audb.latest_version)
+            all_versions = api_versions(db.name)
+            previous_version = all_versions[-1] if len(all_versions) > 0 else None
+        # Check repository consistency when previous_version is specified
+        if previous_version is not None:
+            previous_repository = utils._lookup(db.name, previous_version)[0]
+            if previous_repository != repository:
+                raise RuntimeError(
+                    f"Cannot publish version '{version}' "
+                    f"to repository '{repository.name}' "
+                    f"based on previous version '{previous_version}'. "
+                    "The previous version is stored in repository "
+                    f"'{previous_repository.name}'. "
+                    "Publishing to a different repository would split the database "
+                    "across multiple repositories, "
+                    "which can create data privacy risks "
+                    "and is not supported. "
+                    "Use previous_version=None "
+                    f"to start a new database in '{repository.name}' "
+                    f"or publish to the same repository '{previous_repository.name}'."
+                )
 
-    # check if database folder depends on the right version
+        # load database and dependencies
+        deps = Dependencies()
+        for deps_file in [define.DEPENDENCY_FILE, define.LEGACY_DEPENDENCY_FILE]:
+            deps_path = os.path.join(db_root, deps_file)
+            if os.path.exists(deps_path):
+                deps.load(deps_path)
+                break
 
-    # dependencies shouldn't be there
-    if previous_version is None and len(deps) > 0:
-        raise RuntimeError(
-            f"You did not set a dependency to a previous version, "
-            f"but you have a '{deps_file}' file present "
-            f"in {db_root}."
-        )
+        # check if database folder depends on the right version
 
-    # dependencies missing
-    if previous_version is not None and len(deps) == 0:
-        raise RuntimeError(
-            f"You want to depend on '{previous_version}' "
-            f"of {db.name}, "
-            f"but you don't have a '{define.DEPENDENCY_FILE}' file present "
-            f"in {db_root}. "
-            f"Did you forgot to call "
-            f"'audb.load_to({db_root}, {db.name}, "
-            f"version={previous_version}?"
-        )
+        # dependencies shouldn't be there
+        if previous_version is None and len(deps) > 0:
+            raise RuntimeError(
+                f"You did not set a dependency to a previous version, "
+                f"but you have a '{deps_file}' file present "
+                f"in {db_root}."
+            )
 
-    # dependencies do not match version
-    if previous_version is not None and len(deps) > 0:
-        previous_deps = dependencies(
-            db.name,
-            version=previous_version,
-            cache_root=cache_root,
-            verbose=verbose,
-        )
-        if not deps().equals(previous_deps()):
+        # dependencies missing
+        if previous_version is not None and len(deps) == 0:
             raise RuntimeError(
                 f"You want to depend on '{previous_version}' "
                 f"of {db.name}, "
-                f"but the dependency file '{deps_file}' "
-                f"in {db_root} "
-                f"does not match the dependency file "
-                f"for the requested version in the repository. "
+                f"but you don't have a '{define.DEPENDENCY_FILE}' file present "
+                f"in {db_root}. "
                 f"Did you forgot to call "
                 f"'audb.load_to({db_root}, {db.name}, "
-                f"version='{previous_version}') "
-                f"or modified the file manually?"
+                f"version={previous_version}?"
             )
 
-    # load database with table data
-    db = audformat.Database.load(
-        db_root,
-        load_data=True,
-        num_workers=num_workers,
-        verbose=verbose,
-    )
-
-    # ensure table and attachment IDs
-    # contain only chars allowed by the backend
-    # as the IDs are included in the filenames of the archives
-    # uploaded to the backend
-    allowed_chars = audbackend.core.utils.BACKEND_ALLOWED_CHARS
-    allowed_chars = allowed_chars.replace("/", "")
-    allowed_chars_compiled = re.compile(allowed_chars)
-    for table_id in list(db):
-        if allowed_chars_compiled.fullmatch(table_id) is None:
-            raise RuntimeError(
-                "Table IDs must only contain chars from "
-                f"{allowed_chars[:-1]}, "
-                f"which is not the case for table '{table_id}'."
+        # dependencies do not match version
+        if previous_version is not None and len(deps) > 0:
+            previous_deps = dependencies(
+                db.name,
+                version=previous_version,
+                cache_root=cache_root,
+                verbose=verbose,
             )
-    for attachment_id in list(db.attachments):
-        if allowed_chars_compiled.fullmatch(attachment_id) is None:
-            raise RuntimeError(
-                "Attachment IDs must only contain chars from "
-                f"{allowed_chars[:-1]}, "
-                f"which is not the case for attachment '{attachment_id}'."
-            )
+            if not deps().equals(previous_deps()):
+                raise RuntimeError(
+                    f"You want to depend on '{previous_version}' "
+                    f"of {db.name}, "
+                    f"but the dependency file '{deps_file}' "
+                    f"in {db_root} "
+                    f"does not match the dependency file "
+                    f"for the requested version in the repository. "
+                    f"Did you forgot to call "
+                    f"'audb.load_to({db_root}, {db.name}, "
+                    f"version='{previous_version}') "
+                    f"or modified the file manually?"
+                )
 
-    # check all tables are conform with audformat
-    if not db.is_portable:
-        raise RuntimeError(
-            "Some files in the tables have absolute paths "
-            "or use '\\', '.', '..' in its path. "
-            "Please replace those paths by relative paths, "
-            "use folder names instead of dots, "
-            "and avoid Windows path notation."
-        )
-    _check_for_duplicates(db, num_workers, verbose)
-
-    # check all media referenced in a table exist
-    # on disk or are already part of the database
-    db_root_files = _get_root_files(db_root)
-    _check_for_missing_media(db, db_root, db_root_files, deps)
-
-    # Make sure all tables are stored in CSV or PARQUET format.
-    # If only a PKL is found,
-    # the table is stored as PARQUET instead
-    for table_id in list(db):
-        table = db[table_id]
-        table_path = os.path.join(db_root, f"db.{table_id}")
-        if not os.path.exists(f"{table_path}.csv") and not os.path.exists(
-            f"{table_path}.parquet"
-        ):
-            table.save(table_path, storage_format="parquet")
-
-    # check archives
-    archives = archives or {}
-
-    with backend_interface.backend:
-        # publish attachments
-        attachments = _find_attachments(db, db_root, version, deps, verbose)
-        _put_attachments(
-            attachments, db_root, db, version, backend_interface, num_workers, verbose
-        )
-
-        # publish tables
-        tables = _find_tables(db, db_root, version, deps, verbose)
-        _put_tables(
-            tables, db_root, db.name, version, backend_interface, num_workers, verbose
-        )
-
-        # publish media
-        media_archives = _find_media(
-            db, db_root, db_root_files, version, deps, archives, num_workers, verbose
-        )
-        _put_media(
-            media_archives,
+        # load database with table data
+        db = audformat.Database.load(
             db_root,
-            db.name,
-            version,
-            previous_version,
-            deps,
-            backend_interface,
-            num_workers,
-            verbose,
+            load_data=True,
+            num_workers=num_workers,
+            verbose=verbose,
         )
 
-        # publish dependencies and header
-        upload_dependencies(backend_interface, deps, db_root, db.name, version)
-        try:
-            local_header = os.path.join(db_root, define.HEADER_FILE)
-            remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
-            backend_interface.put_file(local_header, remote_header, version)
-        except Exception:  # pragma: no cover
-            # after the header is published
-            # the new version becomes visible,
-            # so if something goes wrong here
-            # we better clean up
-            if backend_interface.exists(remote_header, version):
-                backend_interface.remove_file(remote_header, version)
+        # ensure table and attachment IDs
+        # contain only chars allowed by the backend
+        # as the IDs are included in the filenames of the archives
+        # uploaded to the backend
+        allowed_chars = audbackend.core.utils.BACKEND_ALLOWED_CHARS
+        allowed_chars = allowed_chars.replace("/", "")
+        allowed_chars_compiled = re.compile(allowed_chars)
+        for table_id in list(db):
+            if allowed_chars_compiled.fullmatch(table_id) is None:
+                raise RuntimeError(
+                    "Table IDs must only contain chars from "
+                    f"{allowed_chars[:-1]}, "
+                    f"which is not the case for table '{table_id}'."
+                )
+        for attachment_id in list(db.attachments):
+            if allowed_chars_compiled.fullmatch(attachment_id) is None:
+                raise RuntimeError(
+                    "Attachment IDs must only contain chars from "
+                    f"{allowed_chars[:-1]}, "
+                    f"which is not the case for attachment '{attachment_id}'."
+                )
+
+        # check all tables are conform with audformat
+        if not db.is_portable:
+            raise RuntimeError(
+                "Some files in the tables have absolute paths "
+                "or use '\\', '.', '..' in its path. "
+                "Please replace those paths by relative paths, "
+                "use folder names instead of dots, "
+                "and avoid Windows path notation."
+            )
+        _check_for_duplicates(db, num_workers, verbose)
+
+        # check all media referenced in a table exist
+        # on disk or are already part of the database
+        db_root_files = _get_root_files(db_root)
+        _check_for_missing_media(db, db_root, db_root_files, deps)
+
+        # Make sure all tables are stored in CSV or PARQUET format.
+        # If only a PKL is found,
+        # the table is stored as PARQUET instead
+        for table_id in list(db):
+            table = db[table_id]
+            table_path = os.path.join(db_root, f"db.{table_id}")
+            if not os.path.exists(f"{table_path}.csv") and not os.path.exists(
+                f"{table_path}.parquet"
+            ):
+                table.save(table_path, storage_format="parquet")
+
+        # check archives
+        archives = archives or {}
+
+        with backend_interface.backend:
+            # publish attachments
+            attachments = _find_attachments(db, db_root, version, deps, verbose)
+            _put_attachments(
+                attachments,
+                db_root,
+                db,
+                version,
+                backend_interface,
+                num_workers,
+                verbose,
+            )
+
+            # publish tables
+            tables = _find_tables(db, db_root, version, deps, verbose)
+            _put_tables(
+                tables,
+                db_root,
+                db.name,
+                version,
+                backend_interface,
+                num_workers,
+                verbose,
+            )
+
+            # publish media
+            media_archives = _find_media(
+                db,
+                db_root,
+                db_root_files,
+                version,
+                deps,
+                archives,
+                num_workers,
+                verbose,
+            )
+            _put_media(
+                media_archives,
+                db_root,
+                db.name,
+                version,
+                previous_version,
+                deps,
+                backend_interface,
+                num_workers,
+                verbose,
+            )
+
+            # publish dependencies and header
+            upload_dependencies(backend_interface, deps, db_root, db.name, version)
+            try:
+                local_header = os.path.join(db_root, define.HEADER_FILE)
+                remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
+                backend_interface.put_file(local_header, remote_header, version)
+            except Exception:  # pragma: no cover
+                # after the header is published
+                # the new version becomes visible,
+                # so if something goes wrong here
+                # we better clean up
+                if backend_interface.exists(remote_header, version):
+                    backend_interface.remove_file(remote_header, version)
+
+    finally:
+        if verbose:  # pragma: no cover
+            shimmer.stop()
 
     return deps

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -739,6 +739,7 @@ def publish(
         verbose=verbose,
     )
 
+    shimmer = None
     if verbose:  # pragma: no cover
         shimmer = Shimmer("Put:   ", f"{db.name} v{version}")
         shimmer.start()
@@ -956,7 +957,7 @@ def publish(
                     backend_interface.remove_file(remote_header, version)
 
     finally:
-        if verbose:  # pragma: no cover
+        if shimmer is not None:  # pragma: no cover
             shimmer.stop()
 
     return deps

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -746,217 +746,251 @@ def publish(
         print(f"Source: {db_root}")
 
     try:
-        backend_interface = repository.create_backend_interface()
-
-        with backend_interface.backend:
-            remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
-            versions = backend_interface.versions(
-                remote_header,
-                suppress_backend_errors=True,
-            )
-
-        if version in versions:
-            raise RuntimeError(
-                f"A version '{version}' already exists for database '{db.name}'."
-            )
-        if previous_version == "latest":
-            # Find latest version across all repositories (like audb.latest_version)
-            all_versions = api_versions(db.name)
-            previous_version = all_versions[-1] if len(all_versions) > 0 else None
-        # Check repository consistency when previous_version is specified
-        if previous_version is not None:
-            previous_repository = utils._lookup(db.name, previous_version)[0]
-            if previous_repository != repository:
-                raise RuntimeError(
-                    f"Cannot publish version '{version}' "
-                    f"to repository '{repository.name}' "
-                    f"based on previous version '{previous_version}'. "
-                    "The previous version is stored in repository "
-                    f"'{previous_repository.name}'. "
-                    "Publishing to a different repository would split the database "
-                    "across multiple repositories, "
-                    "which can create data privacy risks "
-                    "and is not supported. "
-                    "Use previous_version=None "
-                    f"to start a new database in '{repository.name}' "
-                    f"or publish to the same repository '{previous_repository.name}'."
-                )
-
-        # load database and dependencies
-        deps = Dependencies()
-        for deps_file in [define.DEPENDENCY_FILE, define.LEGACY_DEPENDENCY_FILE]:
-            deps_path = os.path.join(db_root, deps_file)
-            if os.path.exists(deps_path):
-                deps.load(deps_path)
-                break
-
-        # check if database folder depends on the right version
-
-        # dependencies shouldn't be there
-        if previous_version is None and len(deps) > 0:
-            raise RuntimeError(
-                f"You did not set a dependency to a previous version, "
-                f"but you have a '{deps_file}' file present "
-                f"in {db_root}."
-            )
-
-        # dependencies missing
-        if previous_version is not None and len(deps) == 0:
-            raise RuntimeError(
-                f"You want to depend on '{previous_version}' "
-                f"of {db.name}, "
-                f"but you don't have a '{define.DEPENDENCY_FILE}' file present "
-                f"in {db_root}. "
-                f"Did you forgot to call "
-                f"'audb.load_to({db_root}, {db.name}, "
-                f"version={previous_version}?"
-            )
-
-        # dependencies do not match version
-        if previous_version is not None and len(deps) > 0:
-            previous_deps = dependencies(
-                db.name,
-                version=previous_version,
-                cache_root=cache_root,
-            )
-            if not deps().equals(previous_deps()):
-                raise RuntimeError(
-                    f"You want to depend on '{previous_version}' "
-                    f"of {db.name}, "
-                    f"but the dependency file '{deps_file}' "
-                    f"in {db_root} "
-                    f"does not match the dependency file "
-                    f"for the requested version in the repository. "
-                    f"Did you forgot to call "
-                    f"'audb.load_to({db_root}, {db.name}, "
-                    f"version='{previous_version}') "
-                    f"or modified the file manually?"
-                )
-
-        # load database with table data
-        db = audformat.Database.load(
+        deps = _publish(
+            db,
             db_root,
-            load_data=True,
-            num_workers=num_workers,
-            verbose=verbose,
+            version,
+            repository,
+            archives,
+            previous_version,
+            cache_root,
+            num_workers,
+            verbose,
         )
-
-        # ensure table and attachment IDs
-        # contain only chars allowed by the backend
-        # as the IDs are included in the filenames of the archives
-        # uploaded to the backend
-        allowed_chars = audbackend.core.utils.BACKEND_ALLOWED_CHARS
-        allowed_chars = allowed_chars.replace("/", "")
-        allowed_chars_compiled = re.compile(allowed_chars)
-        for table_id in list(db):
-            if allowed_chars_compiled.fullmatch(table_id) is None:
-                raise RuntimeError(
-                    "Table IDs must only contain chars from "
-                    f"{allowed_chars[:-1]}, "
-                    f"which is not the case for table '{table_id}'."
-                )
-        for attachment_id in list(db.attachments):
-            if allowed_chars_compiled.fullmatch(attachment_id) is None:
-                raise RuntimeError(
-                    "Attachment IDs must only contain chars from "
-                    f"{allowed_chars[:-1]}, "
-                    f"which is not the case for attachment '{attachment_id}'."
-                )
-
-        # check all tables are conform with audformat
-        if not db.is_portable:
-            raise RuntimeError(
-                "Some files in the tables have absolute paths "
-                "or use '\\', '.', '..' in its path. "
-                "Please replace those paths by relative paths, "
-                "use folder names instead of dots, "
-                "and avoid Windows path notation."
-            )
-        _check_for_duplicates(db, num_workers, verbose)
-
-        # check all media referenced in a table exist
-        # on disk or are already part of the database
-        db_root_files = _get_root_files(db_root)
-        _check_for_missing_media(db, db_root, db_root_files, deps)
-
-        # Make sure all tables are stored in CSV or PARQUET format.
-        # If only a PKL is found,
-        # the table is stored as PARQUET instead
-        for table_id in list(db):
-            table = db[table_id]
-            table_path = os.path.join(db_root, f"db.{table_id}")
-            if not os.path.exists(f"{table_path}.csv") and not os.path.exists(
-                f"{table_path}.parquet"
-            ):
-                table.save(table_path, storage_format="parquet")
-
-        # check archives
-        archives = archives or {}
-
-        with backend_interface.backend:
-            # publish attachments
-            attachments = _find_attachments(db, db_root, version, deps, verbose)
-            _put_attachments(
-                attachments,
-                db_root,
-                db,
-                version,
-                backend_interface,
-                num_workers,
-                verbose,
-            )
-
-            # publish tables
-            tables = _find_tables(db, db_root, version, deps, verbose)
-            _put_tables(
-                tables,
-                db_root,
-                db.name,
-                version,
-                backend_interface,
-                num_workers,
-                verbose,
-            )
-
-            # publish media
-            media_archives = _find_media(
-                db,
-                db_root,
-                db_root_files,
-                version,
-                deps,
-                archives,
-                num_workers,
-                verbose,
-            )
-            _put_media(
-                media_archives,
-                db_root,
-                db.name,
-                version,
-                previous_version,
-                deps,
-                backend_interface,
-                num_workers,
-                verbose,
-            )
-
-            # publish dependencies and header
-            upload_dependencies(backend_interface, deps, db_root, db.name, version)
-            try:
-                local_header = os.path.join(db_root, define.HEADER_FILE)
-                remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
-                backend_interface.put_file(local_header, remote_header, version)
-            except Exception:  # pragma: no cover
-                # after the header is published
-                # the new version becomes visible,
-                # so if something goes wrong here
-                # we better clean up
-                if backend_interface.exists(remote_header, version):
-                    backend_interface.remove_file(remote_header, version)
-
     finally:
         if shimmer is not None:  # pragma: no cover
             shimmer.stop()
+
+    return deps
+
+
+def _publish(
+    db: audformat.Database,
+    db_root: str,
+    version: str,
+    repository: Repository,
+    archives: Mapping[str, str] | None,
+    previous_version: str | None,
+    cache_root: str | None,
+    num_workers: int | None,
+    verbose: bool,
+) -> Dependencies:
+    r"""Publish database without the progress animation.
+
+    The body of :func:`publish` lives here so that :func:`publish`
+    only sets up and tears down the :class:`Shimmer` animation,
+    keeping that plumbing separate from the publication logic.
+    ``db`` is the database header (loaded with ``load_data=False``);
+    it is reloaded with table data below.
+
+    """
+    backend_interface = repository.create_backend_interface()
+
+    with backend_interface.backend:
+        remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
+        versions = backend_interface.versions(
+            remote_header,
+            suppress_backend_errors=True,
+        )
+
+    if version in versions:
+        raise RuntimeError(
+            f"A version '{version}' already exists for database '{db.name}'."
+        )
+    if previous_version == "latest":
+        # Find latest version across all repositories (like audb.latest_version)
+        all_versions = api_versions(db.name)
+        previous_version = all_versions[-1] if len(all_versions) > 0 else None
+    # Check repository consistency when previous_version is specified
+    if previous_version is not None:
+        previous_repository = utils._lookup(db.name, previous_version)[0]
+        if previous_repository != repository:
+            raise RuntimeError(
+                f"Cannot publish version '{version}' "
+                f"to repository '{repository.name}' "
+                f"based on previous version '{previous_version}'. "
+                "The previous version is stored in repository "
+                f"'{previous_repository.name}'. "
+                "Publishing to a different repository would split the database "
+                "across multiple repositories, "
+                "which can create data privacy risks "
+                "and is not supported. "
+                "Use previous_version=None "
+                f"to start a new database in '{repository.name}' "
+                f"or publish to the same repository '{previous_repository.name}'."
+            )
+
+    # load database and dependencies
+    deps = Dependencies()
+    for deps_file in [define.DEPENDENCY_FILE, define.LEGACY_DEPENDENCY_FILE]:
+        deps_path = os.path.join(db_root, deps_file)
+        if os.path.exists(deps_path):
+            deps.load(deps_path)
+            break
+
+    # check if database folder depends on the right version
+
+    # dependencies shouldn't be there
+    if previous_version is None and len(deps) > 0:
+        raise RuntimeError(
+            f"You did not set a dependency to a previous version, "
+            f"but you have a '{deps_file}' file present "
+            f"in {db_root}."
+        )
+
+    # dependencies missing
+    if previous_version is not None and len(deps) == 0:
+        raise RuntimeError(
+            f"You want to depend on '{previous_version}' "
+            f"of {db.name}, "
+            f"but you don't have a '{define.DEPENDENCY_FILE}' file present "
+            f"in {db_root}. "
+            f"Did you forgot to call "
+            f"'audb.load_to({db_root}, {db.name}, "
+            f"version={previous_version}?"
+        )
+
+    # dependencies do not match version
+    if previous_version is not None and len(deps) > 0:
+        previous_deps = dependencies(
+            db.name,
+            version=previous_version,
+            cache_root=cache_root,
+        )
+        if not deps().equals(previous_deps()):
+            raise RuntimeError(
+                f"You want to depend on '{previous_version}' "
+                f"of {db.name}, "
+                f"but the dependency file '{deps_file}' "
+                f"in {db_root} "
+                f"does not match the dependency file "
+                f"for the requested version in the repository. "
+                f"Did you forgot to call "
+                f"'audb.load_to({db_root}, {db.name}, "
+                f"version='{previous_version}') "
+                f"or modified the file manually?"
+            )
+
+    # load database with table data
+    db = audformat.Database.load(
+        db_root,
+        load_data=True,
+        num_workers=num_workers,
+        verbose=verbose,
+    )
+
+    # ensure table and attachment IDs
+    # contain only chars allowed by the backend
+    # as the IDs are included in the filenames of the archives
+    # uploaded to the backend
+    allowed_chars = audbackend.core.utils.BACKEND_ALLOWED_CHARS
+    allowed_chars = allowed_chars.replace("/", "")
+    allowed_chars_compiled = re.compile(allowed_chars)
+    for table_id in list(db):
+        if allowed_chars_compiled.fullmatch(table_id) is None:
+            raise RuntimeError(
+                "Table IDs must only contain chars from "
+                f"{allowed_chars[:-1]}, "
+                f"which is not the case for table '{table_id}'."
+            )
+    for attachment_id in list(db.attachments):
+        if allowed_chars_compiled.fullmatch(attachment_id) is None:
+            raise RuntimeError(
+                "Attachment IDs must only contain chars from "
+                f"{allowed_chars[:-1]}, "
+                f"which is not the case for attachment '{attachment_id}'."
+            )
+
+    # check all tables are conform with audformat
+    if not db.is_portable:
+        raise RuntimeError(
+            "Some files in the tables have absolute paths "
+            "or use '\\', '.', '..' in its path. "
+            "Please replace those paths by relative paths, "
+            "use folder names instead of dots, "
+            "and avoid Windows path notation."
+        )
+    _check_for_duplicates(db, num_workers, verbose)
+
+    # check all media referenced in a table exist
+    # on disk or are already part of the database
+    db_root_files = _get_root_files(db_root)
+    _check_for_missing_media(db, db_root, db_root_files, deps)
+
+    # Make sure all tables are stored in CSV or PARQUET format.
+    # If only a PKL is found,
+    # the table is stored as PARQUET instead
+    for table_id in list(db):
+        table = db[table_id]
+        table_path = os.path.join(db_root, f"db.{table_id}")
+        if not os.path.exists(f"{table_path}.csv") and not os.path.exists(
+            f"{table_path}.parquet"
+        ):
+            table.save(table_path, storage_format="parquet")
+
+    # check archives
+    archives = archives or {}
+
+    with backend_interface.backend:
+        # publish attachments
+        attachments = _find_attachments(db, db_root, version, deps, verbose)
+        _put_attachments(
+            attachments,
+            db_root,
+            db,
+            version,
+            backend_interface,
+            num_workers,
+            verbose,
+        )
+
+        # publish tables
+        tables = _find_tables(db, db_root, version, deps, verbose)
+        _put_tables(
+            tables,
+            db_root,
+            db.name,
+            version,
+            backend_interface,
+            num_workers,
+            verbose,
+        )
+
+        # publish media
+        media_archives = _find_media(
+            db,
+            db_root,
+            db_root_files,
+            version,
+            deps,
+            archives,
+            num_workers,
+            verbose,
+        )
+        _put_media(
+            media_archives,
+            db_root,
+            db.name,
+            version,
+            previous_version,
+            deps,
+            backend_interface,
+            num_workers,
+            verbose,
+        )
+
+        # publish dependencies and header
+        upload_dependencies(backend_interface, deps, db_root, db.name, version)
+        try:
+            local_header = os.path.join(db_root, define.HEADER_FILE)
+            remote_header = backend_interface.join("/", db.name, define.HEADER_FILE)
+            backend_interface.put_file(local_header, remote_header, version)
+        except Exception:  # pragma: no cover
+            # after the header is published
+            # the new version becomes visible,
+            # so if something goes wrong here
+            # we better clean up
+            if backend_interface.exists(remote_header, version):
+                backend_interface.remove_file(remote_header, version)
 
     return deps

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -19,7 +19,7 @@ from audb.core.api import versions as api_versions
 from audb.core.dependencies import Dependencies
 from audb.core.dependencies import upload_dependencies
 from audb.core.repository import Repository
-from audb.core.shimmer import Shimmer
+from audb.core.shimmer import shimmer
 
 
 def _check_for_duplicates(
@@ -739,13 +739,12 @@ def publish(
         verbose=verbose,
     )
 
-    shimmer = None
-    if verbose:  # pragma: no cover
-        shimmer = Shimmer("Put:   ", f"{db.name} v{version}")
-        shimmer.start()
-        print(f"Source: {db_root}")
-
-    try:
+    with shimmer(
+        "Put:   ",
+        f"{db.name} v{version}",
+        enabled=verbose,
+        message=f"Source: {db_root}",
+    ):
         deps = _publish(
             db,
             db_root,
@@ -757,9 +756,6 @@ def publish(
             num_workers,
             verbose,
         )
-    finally:
-        if shimmer is not None:  # pragma: no cover
-            shimmer.stop()
 
     return deps
 

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -740,10 +740,10 @@ def publish(
     )
 
     with shimmer(
-        "Put:   ",
-        f"{db.name} v{version}",
+        prefix="Put:   ",
+        text=f"{db.name} v{version}",
+        next_line=f"Source: {db_root}",
         enabled=verbose,
-        message=f"Source: {db_root}",
     ):
         deps = _publish(
             db,

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -1,0 +1,225 @@
+"""Shimmer text animation for terminal output."""
+
+from __future__ import annotations
+
+import io
+import math
+import sys
+import threading
+
+
+# ANSI escape codes
+BOLD = "\033[1m"
+RESET = "\033[0m"
+SAVE_CURSOR = "\033[s"
+RESTORE_CURSOR = "\033[u"
+CLEAR_LINE_RIGHT = "\033[K"
+
+
+class _StreamProxy(io.TextIOBase):
+    """Proxy for a text stream that observes writes.
+
+    Calls *on_write* for every ``write()`` so the shimmer
+    can count newlines and detect progress-bar activity.
+
+    """
+
+    def __init__(self, target: io.TextIOBase, on_write):
+        self._target = target
+        self._on_write = on_write
+
+    def write(self, s: str) -> int:
+        self._on_write(s)
+        return self._target.write(s)
+
+    def flush(self):
+        self._target.flush()
+
+    def fileno(self):
+        return self._target.fileno()
+
+    @property
+    def encoding(self):
+        return self._target.encoding
+
+    def isatty(self):
+        return self._target.isatty()
+
+    def writable(self):
+        return True
+
+
+class Shimmer:
+    """Animate text with a bright shimmer sweeping across.
+
+    The shimmer highlights a moving window of characters
+    in bold/bright while the rest stays in the default color.
+    The animation runs in a background thread and uses
+    ANSI cursor movement to update the animated line
+    even as new content appears below it.
+
+    Args:
+        prefix: static text before the animated portion
+            (e.g. ``"Get:   "``).
+        text: the text to animate (e.g. the database name).
+        suffix: static text after the animated portion
+            (e.g. ``" v1.0.0"``).
+        interval: seconds between animation frames.
+        width: number of characters in the bright window.
+
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        text: str,
+        suffix: str = "",
+        *,
+        interval: float = 0.05,
+        width: int = 5,
+    ):
+        self._prefix = prefix
+        self._text = text
+        self._suffix = suffix
+        self._interval = interval
+        self._width = width
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._lines_below = 0
+        self._paused = False
+        self._lock = threading.Lock()
+        self._original_stdout: io.TextIOBase | None = None
+        self._original_stderr: io.TextIOBase | None = None
+        self._stdout_proxy: _StreamProxy | None = None
+        self._stderr_proxy: _StreamProxy | None = None
+
+    def start(self):
+        """Start the shimmer animation in a background thread."""
+        self._original_stdout = sys.stdout
+        self._original_stderr = sys.stderr
+        # Print the initial static line with a newline
+        # so subsequent output appears below it.
+        self._original_stdout.write(f"{self._prefix}{self._text}{self._suffix}\n")
+        self._original_stdout.flush()
+        self._stdout_proxy = _StreamProxy(self._original_stdout, self._on_stdout_write)
+        self._stderr_proxy = _StreamProxy(self._original_stderr, self._on_stderr_write)
+        sys.stdout = self._stdout_proxy
+        sys.stderr = self._stderr_proxy
+        self._thread = threading.Thread(target=self._animate, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        """Stop the animation and restore streams."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+        # Restore original streams
+        if self._original_stdout is not None:
+            sys.stdout = self._original_stdout
+        if self._original_stderr is not None:
+            sys.stderr = self._original_stderr
+        # Write final static line over the animated one
+        self._write_frame(self._text)
+
+    def _on_stdout_write(self, s: str):
+        """Track newlines from stdout to update line count."""
+        count = s.count("\n")
+        if count:
+            with self._lock:
+                self._lines_below += count
+
+    def _on_stderr_write(self, s: str):
+        r"""Detect progress-bar activity on stderr.
+
+        Progress bars (tqdm) write ``\r`` followed by bar content
+        to update in-place. When the bar finishes with
+        ``leave=False``, tqdm clears it by writing
+        ``\r`` + whitespace + ``\r``.
+
+        We pause when we see ``\r`` followed by visible
+        (non-whitespace) content, and resume when we see
+        ``\n`` or the clear pattern (only whitespace after ``\r``).
+
+        """
+        with self._lock:
+            if "\r" in s:
+                # Text after the last \r determines
+                # whether a bar is on screen.
+                after_cr = s.rsplit("\r", 1)[1]
+                if after_cr.strip():
+                    # Visible bar content → pause
+                    self._paused = True
+                else:
+                    # Only whitespace after \r → bar cleared
+                    self._paused = False
+            if "\n" in s:
+                self._paused = False
+
+    def _write_frame(self, rendered_text: str):
+        """Write a single frame to the terminal.
+
+        Moves cursor up to the animated line,
+        rewrites it, then moves back down.
+
+        """
+        out = self._original_stdout
+        with self._lock:
+            n = self._lines_below
+        # Always move up: +1 accounts for the newline
+        # printed by start() after the shimmer line.
+        up = n + 1
+        buf = [
+            SAVE_CURSOR,
+            f"\033[{up}A",
+            f"\r{self._prefix}{rendered_text}{self._suffix}{CLEAR_LINE_RIGHT}",
+            RESTORE_CURSOR,
+        ]
+        out.write("".join(buf))
+        out.flush()
+
+    def _render_frame(self, center: float) -> str:
+        """Render one frame with a bright window centered at *center*."""
+        chars = []
+        half = self._width / 2
+        for i, ch in enumerate(self._text):
+            dist = abs(i - center)
+            if dist < half:
+                brightness = math.cos(dist / half * (math.pi / 2))
+                if brightness > 0.3:
+                    chars.append(f"{BOLD}{ch}{RESET}")
+                else:
+                    chars.append(ch)
+            else:
+                chars.append(ch)
+        return "".join(chars)
+
+    def _animate(self):
+        """Animation loop running in a background thread."""
+        n = len(self._text)
+        if n == 0:
+            return
+
+        sweep_start = -self._width
+        sweep_end = n + self._width
+        sweep_range = sweep_end - sweep_start
+        pos = 0.0
+        speed = 0.8  # characters per frame
+
+        while not self._stop_event.is_set():
+            with self._lock:
+                paused = self._paused
+            if not paused:
+                center = sweep_start + (pos % sweep_range)
+                frame = self._render_frame(center)
+                self._write_frame(frame)
+                pos += speed
+            self._stop_event.wait(self._interval)
+
+    def __enter__(self):
+        """Start shimmer as context manager."""
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        """Stop shimmer when exiting context manager."""
+        self.stop()

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import math
-import os
 import sys
 import threading
 
@@ -68,7 +67,6 @@ class Shimmer:
 
         * ``sys.stdout`` is not a TTY
           (e.g. redirected output, Jupyter, CI logs).
-        * The environment variable ``AUDB_NO_SHIMMER=1`` is set.
         * Another ``Shimmer`` instance is already active
           (only one may run at a time).
 
@@ -76,11 +74,7 @@ class Shimmer:
         global _active_shimmer
 
         # Skip animation in non-interactive environments
-        if (
-            not hasattr(sys.stdout, "isatty")
-            or not sys.stdout.isatty()
-            or os.environ.get("AUDB_NO_SHIMMER", "") == "1"
-        ):
+        if not hasattr(sys.stdout, "isatty") or not sys.stdout.isatty():
             sys.stdout.write(f"{self._prefix}{self._text}{self._suffix}\n")
             sys.stdout.flush()
             self._noop = True

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import shutil
 import sys
 import threading
 
@@ -185,6 +186,13 @@ class Shimmer:
         Moves cursor up to the animated line,
         rewrites it, then moves back down.
 
+        Skipped entirely when the shimmer line would sit at
+        or beyond the top of the viewport: cursor-up is clamped
+        to row 0 by the terminal and cannot reach into scrollback,
+        so moving up further would land on an unrelated visible
+        row and corrupt it. Terminal size is re-read on each call
+        to pick up window resizes mid-run.
+
         """
         write = self._original_stdout_write or sys.stdout.write
         with self._lock:
@@ -192,6 +200,11 @@ class Shimmer:
             # Always move up: +1 accounts for the newline
             # printed by start() after the shimmer line.
             up = n + 1
+            # Bail if the shimmer line has scrolled into (or past)
+            # the top of the viewport. get_terminal_size falls back
+            # to (80, 24) if the size cannot be determined.
+            if up >= shutil.get_terminal_size().lines:
+                return
             buf = [
                 SAVE_CURSOR,
                 f"\033[{up}A",

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import math
 import sys
 import threading
@@ -14,39 +13,6 @@ RESET = "\033[0m"
 SAVE_CURSOR = "\033[s"
 RESTORE_CURSOR = "\033[u"
 CLEAR_LINE_RIGHT = "\033[K"
-
-
-class _StreamProxy(io.TextIOBase):
-    """Proxy for a text stream that observes writes.
-
-    Calls *on_write* for every ``write()`` so the shimmer
-    can count newlines and detect progress-bar activity.
-
-    """
-
-    def __init__(self, target: io.TextIOBase, on_write):
-        self._target = target
-        self._on_write = on_write
-
-    def write(self, s: str) -> int:
-        self._on_write(s)
-        return self._target.write(s)
-
-    def flush(self):
-        self._target.flush()
-
-    def fileno(self):
-        return self._target.fileno()
-
-    @property
-    def encoding(self):
-        return self._target.encoding
-
-    def isatty(self):
-        return self._target.isatty()
-
-    def writable(self):
-        return True
 
 
 class Shimmer:
@@ -88,23 +54,21 @@ class Shimmer:
         self._lines_below = 0
         self._paused = False
         self._lock = threading.Lock()
-        self._original_stdout: io.TextIOBase | None = None
-        self._original_stderr: io.TextIOBase | None = None
-        self._stdout_proxy: _StreamProxy | None = None
-        self._stderr_proxy: _StreamProxy | None = None
+        self._original_stdout_write = None
+        self._original_stderr_write = None
 
     def start(self):
         """Start the shimmer animation in a background thread."""
-        self._original_stdout = sys.stdout
-        self._original_stderr = sys.stderr
         # Print the initial static line with a newline
         # so subsequent output appears below it.
-        self._original_stdout.write(f"{self._prefix}{self._text}{self._suffix}\n")
-        self._original_stdout.flush()
-        self._stdout_proxy = _StreamProxy(self._original_stdout, self._on_stdout_write)
-        self._stderr_proxy = _StreamProxy(self._original_stderr, self._on_stderr_write)
-        sys.stdout = self._stdout_proxy
-        sys.stderr = self._stderr_proxy
+        sys.stdout.write(f"{self._prefix}{self._text}{self._suffix}\n")
+        sys.stdout.flush()
+        # Monkey-patch write() on the existing stream objects
+        # so all other attributes (fileno, encoding, isatty, …) stay intact.
+        self._original_stdout_write = sys.stdout.write
+        self._original_stderr_write = sys.stderr.write
+        sys.stdout.write = self._stdout_write_hook
+        sys.stderr.write = self._stderr_write_hook
         self._thread = threading.Thread(target=self._animate, daemon=True)
         self._thread.start()
 
@@ -113,23 +77,24 @@ class Shimmer:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join()
-        # Restore original streams
-        if self._original_stdout is not None:
-            sys.stdout = self._original_stdout
-        if self._original_stderr is not None:
-            sys.stderr = self._original_stderr
+        # Restore original write methods
+        if self._original_stdout_write is not None:
+            sys.stdout.write = self._original_stdout_write
+        if self._original_stderr_write is not None:
+            sys.stderr.write = self._original_stderr_write
         # Write final static line over the animated one
         self._write_frame(self._text)
 
-    def _on_stdout_write(self, s: str):
-        """Track newlines from stdout to update line count."""
+    def _stdout_write_hook(self, s: str) -> int:
+        """Wrap stdout.write to track newlines."""
         count = s.count("\n")
         if count:
             with self._lock:
                 self._lines_below += count
+        return self._original_stdout_write(s)
 
-    def _on_stderr_write(self, s: str):
-        r"""Detect progress-bar activity on stderr.
+    def _stderr_write_hook(self, s: str) -> int:
+        r"""Wrap stderr.write to detect progress-bar activity.
 
         Progress bars (tqdm) write ``\r`` followed by bar content
         to update in-place. When the bar finishes with
@@ -154,6 +119,7 @@ class Shimmer:
                     self._paused = False
             if "\n" in s:  # pragma: no cover
                 self._paused = False
+        return self._original_stderr_write(s)
 
     def _write_frame(self, rendered_text: str):
         """Write a single frame to the terminal.
@@ -162,7 +128,7 @@ class Shimmer:
         rewrites it, then moves back down.
 
         """
-        out = self._original_stdout
+        write = self._original_stdout_write or sys.stdout.write
         with self._lock:
             n = self._lines_below
         # Always move up: +1 accounts for the newline
@@ -174,8 +140,8 @@ class Shimmer:
             f"\r{self._prefix}{rendered_text}{self._suffix}{CLEAR_LINE_RIGHT}",
             RESTORE_CURSOR,
         ]
-        out.write("".join(buf))
-        out.flush()
+        write("".join(buf))
+        sys.stdout.flush()
 
     def _render_frame(self, center: float) -> str:
         """Render one frame with a bright window centered at *center*."""

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -26,10 +26,8 @@ class Shimmer:
 
     Args:
         prefix: static text before the animated portion
-            (e.g. ``"Get:   "``).
         text: the text to animate (e.g. the database name).
         suffix: static text after the animated portion
-            (e.g. ``" v1.0.0"``).
         interval: seconds between animation frames.
         width: number of characters in the bright window.
 

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -131,17 +131,17 @@ class Shimmer:
         write = self._original_stdout_write or sys.stdout.write
         with self._lock:
             n = self._lines_below
-        # Always move up: +1 accounts for the newline
-        # printed by start() after the shimmer line.
-        up = n + 1
-        buf = [
-            SAVE_CURSOR,
-            f"\033[{up}A",
-            f"\r{self._prefix}{rendered_text}{self._suffix}{CLEAR_LINE_RIGHT}",
-            RESTORE_CURSOR,
-        ]
-        write("".join(buf))
-        sys.stdout.flush()
+            # Always move up: +1 accounts for the newline
+            # printed by start() after the shimmer line.
+            up = n + 1
+            buf = [
+                SAVE_CURSOR,
+                f"\033[{up}A",
+                f"\r{self._prefix}{rendered_text}{self._suffix}{CLEAR_LINE_RIGHT}",
+                RESTORE_CURSOR,
+            ]
+            write("".join(buf))
+            sys.stdout.flush()
 
     def _render_frame(self, center: float) -> str:
         """Render one frame with a bright window centered at *center*."""

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -205,6 +205,7 @@ class Shimmer:
         pos = 0.0
         speed = 0.8  # characters per frame
 
+        was_paused = False
         while not self._stop_event.is_set():
             with self._lock:
                 paused = self._paused
@@ -213,6 +214,12 @@ class Shimmer:
                 frame = self._render_frame(center)
                 self._write_frame(frame)
                 pos += speed
+                was_paused = False
+            elif not was_paused:
+                # Write plain text on first paused frame
+                # to clear any leftover bold highlighting.
+                self._write_frame(self._text)
+                was_paused = True
             self._stop_event.wait(self._interval)
 
     def __enter__(self):

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import os
 import sys
 import threading
 
@@ -13,6 +14,10 @@ RESET = "\033[0m"
 SAVE_CURSOR = "\033[s"
 RESTORE_CURSOR = "\033[u"
 CLEAR_LINE_RIGHT = "\033[K"
+
+# Global lock and reference for enforcing single active Shimmer
+_active_lock = threading.Lock()
+_active_shimmer: Shimmer | None = None
 
 
 class Shimmer:
@@ -54,9 +59,42 @@ class Shimmer:
         self._lock = threading.Lock()
         self._original_stdout_write = None
         self._original_stderr_write = None
+        self._noop = False
 
     def start(self):
-        """Start the shimmer animation in a background thread."""
+        """Start the shimmer animation in a background thread.
+
+        The animation is silently skipped (no-op) when:
+
+        * ``sys.stdout`` is not a TTY
+          (e.g. redirected output, Jupyter, CI logs).
+        * The environment variable ``AUDB_NO_SHIMMER=1`` is set.
+        * Another ``Shimmer`` instance is already active
+          (only one may run at a time).
+
+        """
+        global _active_shimmer
+
+        # Skip animation in non-interactive environments
+        if (
+            not hasattr(sys.stdout, "isatty")
+            or not sys.stdout.isatty()
+            or os.environ.get("AUDB_NO_SHIMMER", "") == "1"
+        ):
+            sys.stdout.write(f"{self._prefix}{self._text}{self._suffix}\n")
+            sys.stdout.flush()
+            self._noop = True
+            return
+
+        # Enforce single active Shimmer
+        with _active_lock:
+            if _active_shimmer is not None:
+                sys.stdout.write(f"{self._prefix}{self._text}{self._suffix}\n")
+                sys.stdout.flush()
+                self._noop = True
+                return
+            _active_shimmer = self
+
         # Print the initial static line with a newline
         # so subsequent output appears below it.
         sys.stdout.write(f"{self._prefix}{self._text}{self._suffix}\n")
@@ -72,6 +110,11 @@ class Shimmer:
 
     def stop(self):
         """Stop the animation and restore streams."""
+        global _active_shimmer
+
+        if self._noop:
+            return
+
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join()
@@ -82,6 +125,10 @@ class Shimmer:
             sys.stderr.write = self._original_stderr_write
         # Write final static line over the animated one
         self._write_frame(self._text)
+
+        with _active_lock:
+            if _active_shimmer is self:
+                _active_shimmer = None
 
     def _stdout_write_hook(self, s: str) -> int:
         """Wrap stdout.write to track newlines."""

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -55,7 +55,10 @@ class Shimmer:
         self._thread: threading.Thread | None = None
         self._lines_below = 0
         self._paused = False
-        self._lock = threading.Lock()
+        # RLock so _animate can hold the lock across pause-check + frame
+        # emission while _write_frame still takes it internally. Also lets
+        # _write_frame be called from stop() with no lock held.
+        self._lock = threading.RLock()
         self._original_stdout_write = None
         self._original_stderr_write = None
         self._noop = False
@@ -125,12 +128,20 @@ class Shimmer:
                 _active_shimmer = None
 
     def _stdout_write_hook(self, s: str) -> int:
-        """Wrap stdout.write to track newlines."""
-        count = s.count("\n")
-        if count:
-            with self._lock:
+        """Wrap stdout.write to track newlines.
+
+        The lock is held across the actual write so that a concurrent
+        shimmer frame on the other thread cannot interleave between
+        this write and its bookkeeping — otherwise SAVE_CURSOR /
+        cursor-up / RESTORE_CURSOR from the animation thread could
+        land mid-write on the terminal and leave visual artifacts.
+
+        """
+        with self._lock:
+            count = s.count("\n")
+            if count:
                 self._lines_below += count
-        return self._original_stdout_write(s)
+            return self._original_stdout_write(s)
 
     def _stderr_write_hook(self, s: str) -> int:
         r"""Wrap stderr.write to detect progress-bar activity.
@@ -164,7 +175,9 @@ class Shimmer:
             if newline_count:
                 self._lines_below += newline_count
                 self._paused = False
-        return self._original_stderr_write(s)
+            # Write under the lock so shimmer frames on stdout cannot
+            # interleave at the terminal with a tqdm bar update on stderr.
+            return self._original_stderr_write(s)
 
     def _write_frame(self, rendered_text: str):
         """Write a single frame to the terminal.
@@ -218,19 +231,22 @@ class Shimmer:
 
         was_paused = False
         while not self._stop_event.is_set():
+            # Hold the lock across the pause check *and* the frame emit,
+            # so another thread cannot flip _paused or scroll the terminal
+            # between the decision and the draw. _write_frame reacquires
+            # the lock; RLock makes that safe.
             with self._lock:
-                paused = self._paused
-            if not paused:
-                center = sweep_start + (pos % sweep_range)
-                frame = self._render_frame(center)
-                self._write_frame(frame)
-                pos += speed
-                was_paused = False
-            elif not was_paused:
-                # Write plain text on first paused frame
-                # to clear any leftover bold highlighting.
-                self._write_frame(self._text)
-                was_paused = True
+                if not self._paused:
+                    center = sweep_start + (pos % sweep_range)
+                    frame = self._render_frame(center)
+                    self._write_frame(frame)
+                    pos += speed
+                    was_paused = False
+                elif not was_paused:
+                    # Write plain text on first paused frame
+                    # to clear any leftover bold highlighting.
+                    self._write_frame(self._text)
+                    was_paused = True
             self._stop_event.wait(self._interval)
 
     def __enter__(self):  # pragma: no cover

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -250,10 +250,15 @@ class Shimmer:
             # the lock; RLock makes that safe.
             with self._lock:
                 if not self._paused:
-                    center = sweep_start + (pos % sweep_range)
+                    center = sweep_start + pos
                     frame = self._render_frame(center)
                     self._write_frame(frame)
-                    pos += speed
+                    # Wrap pos each step so it stays bounded in
+                    # [0, sweep_range). Over a long publish (hours
+                    # at 20 Hz) an unbounded float would grow into
+                    # the range where adding 0.8 loses precision and
+                    # the modulo-on-render drifts.
+                    pos = (pos + speed) % sweep_range
                     was_paused = False
                 elif not was_paused:
                     # Write plain text on first paused frame

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -152,7 +152,7 @@ class Shimmer:
                 else:
                     # Only whitespace after \r → bar cleared
                     self._paused = False
-            if "\n" in s:
+            if "\n" in s:  # pragma: no cover
                 self._paused = False
 
     def _write_frame(self, rendered_text: str):
@@ -196,7 +196,7 @@ class Shimmer:
     def _animate(self):
         """Animation loop running in a background thread."""
         n = len(self._text)
-        if n == 0:
+        if n == 0:  # pragma: no cover
             return
 
         sweep_start = -self._width
@@ -222,11 +222,11 @@ class Shimmer:
                 was_paused = True
             self._stop_event.wait(self._interval)
 
-    def __enter__(self):
+    def __enter__(self):  # pragma: no cover
         """Start shimmer as context manager."""
         self.start()
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *args):  # pragma: no cover
         """Stop shimmer when exiting context manager."""
         self.stop()

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -138,7 +138,11 @@ class Shimmer:
         Progress bars (tqdm) write ``\r`` followed by bar content
         to update in-place. When the bar finishes with
         ``leave=False``, tqdm clears it by writing
-        ``\r`` + whitespace + ``\r``.
+        ``\r`` + whitespace + ``\r``. When it finishes with
+        ``leave=True`` (the default), tqdm emits a trailing ``\n``,
+        which scrolls the terminal and pushes the animated line
+        one row further up — so we must track ``\n`` here too,
+        otherwise subsequent frames render on the wrong row.
 
         We pause when we see ``\r`` followed by visible
         (non-whitespace) content, and resume when we see
@@ -156,7 +160,9 @@ class Shimmer:
                 else:
                     # Only whitespace after \r → bar cleared
                     self._paused = False
-            if "\n" in s:  # pragma: no cover
+            newline_count = s.count("\n")
+            if newline_count:
+                self._lines_below += newline_count
                 self._paused = False
         return self._original_stderr_write(s)
 

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -257,15 +257,6 @@ class Shimmer:
                 pos = (pos + speed) % sweep_range
             self._stop_event.wait(self._interval)
 
-    def __enter__(self):  # pragma: no cover
-        """Start shimmer as context manager."""
-        self.start()
-        return self
-
-    def __exit__(self, *args):  # pragma: no cover
-        """Stop shimmer when exiting context manager."""
-        self.stop()
-
 
 @contextlib.contextmanager
 def shimmer(

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -61,6 +61,10 @@ class Shimmer:
         self._lock = threading.RLock()
         self._original_stdout_write = None
         self._original_stderr_write = None
+        # Whether stdout/stderr already had an instance-level ``write``
+        # override before we patched, so stop() can restore exactly.
+        self._stdout_had_own_write = False
+        self._stderr_had_own_write = False
         self._noop = False
 
     def start(self):
@@ -98,6 +102,11 @@ class Shimmer:
         sys.stdout.flush()
         # Monkey-patch write() on the existing stream objects
         # so all other attributes (fileno, encoding, isatty, …) stay intact.
+        # Remember whether ``write`` already lived in the stream's instance
+        # __dict__ (vs. being the class method) so stop() can decide between
+        # deleting our override and restoring a pre-existing one.
+        self._stdout_had_own_write = "write" in vars(sys.stdout)
+        self._stderr_had_own_write = "write" in vars(sys.stderr)
         self._original_stdout_write = sys.stdout.write
         self._original_stderr_write = sys.stderr.write
         sys.stdout.write = self._stdout_write_hook
@@ -115,11 +124,20 @@ class Shimmer:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join()
-        # Restore original write methods
+        # Restore original write methods. If we introduced the instance-level
+        # override, delete it so attribute lookup falls back to the class
+        # method and the stream's __dict__ returns to its pre-patch state.
+        # If an override already existed, put that exact object back.
         if self._original_stdout_write is not None:
-            sys.stdout.write = self._original_stdout_write
+            if self._stdout_had_own_write:
+                sys.stdout.write = self._original_stdout_write
+            else:
+                del sys.stdout.write
         if self._original_stderr_write is not None:
-            sys.stderr.write = self._original_stderr_write
+            if self._stderr_had_own_write:
+                sys.stderr.write = self._original_stderr_write
+            else:
+                del sys.stderr.write
         # Write final static line over the animated one
         self._write_frame(self._text)
 

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import math
 import shutil
 import sys
@@ -264,3 +265,42 @@ class Shimmer:
     def __exit__(self, *args):  # pragma: no cover
         """Stop shimmer when exiting context manager."""
         self.stop()
+
+
+@contextlib.contextmanager
+def shimmer(
+    prefix: str,
+    text: str,
+    *,
+    enabled: bool = True,
+    message: str | None = None,
+):
+    r"""Animate *text* for the duration of the ``with`` block.
+
+    Wraps :class:`Shimmer` so a call site needs only a single
+    ``with`` statement instead of the
+    ``start()`` / ``try`` / ``finally`` / ``stop()`` dance.
+    The animation is always stopped on exit,
+    including when the block raises.
+
+    Args:
+        prefix: static text before the animated portion
+        text: text to animate (e.g. the database name)
+        enabled: whether to run the animation at all.
+            When ``False`` the block runs untouched,
+            which is typically wired to ``verbose``
+        message: optional line printed right after the
+            animation starts, e.g. the cache or target directory
+
+    """
+    if not enabled:
+        yield
+        return
+    animation = Shimmer(prefix, text)
+    animation.start()
+    if message is not None:
+        print(message)
+    try:
+        yield
+    finally:
+        animation.stop()

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -55,9 +55,8 @@ class Shimmer:
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
         self._lines_below = 0
-        self._paused = False
-        # RLock so _animate can hold the lock across pause-check + frame
-        # emission while _write_frame still takes it internally. Also lets
+        # RLock so _animate can hold the lock across the frame emission
+        # while _write_frame still takes it internally. Also lets
         # _write_frame be called from stop() with no lock held.
         self._lock = threading.RLock()
         self._original_stdout_write = None
@@ -145,37 +144,18 @@ class Shimmer:
             return self._original_stdout_write(s)
 
     def _stderr_write_hook(self, s: str) -> int:
-        r"""Wrap stderr.write to detect progress-bar activity.
+        r"""Wrap stderr.write to track newlines.
 
-        Progress bars (tqdm) write ``\r`` followed by bar content
-        to update in-place. When the bar finishes with
-        ``leave=False``, tqdm clears it by writing
-        ``\r`` + whitespace + ``\r``. When it finishes with
-        ``leave=True`` (the default), tqdm emits a trailing ``\n``,
-        which scrolls the terminal and pushes the animated line
-        one row further up — so we must track ``\n`` here too,
-        otherwise subsequent frames render on the wrong row.
-
-        We pause when we see ``\r`` followed by visible
-        (non-whitespace) content, and resume when we see
-        ``\n`` or the clear pattern (only whitespace after ``\r``).
+        A ``\n`` on stderr (e.g. tqdm finishing with ``leave=True``,
+        log records, warnings) scrolls the terminal and pushes the
+        animated line one row further up — so we must track ``\n``
+        here too, otherwise subsequent frames render on the wrong row.
 
         """
         with self._lock:
-            if "\r" in s:
-                # Text after the last \r determines
-                # whether a bar is on screen.
-                after_cr = s.rsplit("\r", 1)[1]
-                if after_cr.strip():
-                    # Visible bar content → pause
-                    self._paused = True
-                else:
-                    # Only whitespace after \r → bar cleared
-                    self._paused = False
             newline_count = s.count("\n")
             if newline_count:
                 self._lines_below += newline_count
-                self._paused = False
             # Write under the lock so shimmer frames on stdout cannot
             # interleave at the terminal with a tqdm bar update on stderr.
             return self._original_stderr_write(s)
@@ -242,29 +222,20 @@ class Shimmer:
         pos = 0.0
         speed = 0.8  # characters per frame
 
-        was_paused = False
         while not self._stop_event.is_set():
-            # Hold the lock across the pause check *and* the frame emit,
-            # so another thread cannot flip _paused or scroll the terminal
-            # between the decision and the draw. _write_frame reacquires
-            # the lock; RLock makes that safe.
+            # Hold the lock across the frame emit, so another thread
+            # cannot scroll the terminal between rendering and the draw.
+            # _write_frame reacquires the lock; RLock makes that safe.
             with self._lock:
-                if not self._paused:
-                    center = sweep_start + pos
-                    frame = self._render_frame(center)
-                    self._write_frame(frame)
-                    # Wrap pos each step so it stays bounded in
-                    # [0, sweep_range). Over a long publish (hours
-                    # at 20 Hz) an unbounded float would grow into
-                    # the range where adding 0.8 loses precision and
-                    # the modulo-on-render drifts.
-                    pos = (pos + speed) % sweep_range
-                    was_paused = False
-                elif not was_paused:
-                    # Write plain text on first paused frame
-                    # to clear any leftover bold highlighting.
-                    self._write_frame(self._text)
-                    was_paused = True
+                center = sweep_start + pos
+                frame = self._render_frame(center)
+                self._write_frame(frame)
+                # Wrap pos each step so it stays bounded in
+                # [0, sweep_range). Over a long publish (hours
+                # at 20 Hz) an unbounded float would grow into
+                # the range where adding 0.8 loses precision and
+                # the modulo-on-render drifts.
+                pos = (pos + speed) % sweep_range
             self._stop_event.wait(self._interval)
 
     def __enter__(self):  # pragma: no cover

--- a/audb/core/shimmer.py
+++ b/audb/core/shimmer.py
@@ -263,8 +263,8 @@ def shimmer(
     prefix: str,
     text: str,
     *,
+    next_line: str | None = None,
     enabled: bool = True,
-    message: str | None = None,
 ):
     r"""Animate *text* for the duration of the ``with`` block.
 
@@ -277,11 +277,11 @@ def shimmer(
     Args:
         prefix: static text before the animated portion
         text: text to animate (e.g. the database name)
+        next_line: optional line printed right after the
+            animation starts, e.g. the cache or target directory
         enabled: whether to run the animation at all.
             When ``False`` the block runs untouched,
             which is typically wired to ``verbose``
-        message: optional line printed right after the
-            animation starts, e.g. the cache or target directory
 
     """
     if not enabled:
@@ -289,8 +289,8 @@ def shimmer(
         return
     animation = Shimmer(prefix, text)
     animation.start()
-    if message is not None:
-        print(message)
+    if next_line is not None:
+        print(next_line)
     try:
         yield
     finally:

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -126,18 +126,19 @@ def test_animate_paused_clears_bold(monkeypatch):
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     frames = []
     shimmer = Shimmer("", "hello", interval=0.01)
+
+    # Patch _write_frame before start() to avoid race with animation thread
+    original_write_frame = shimmer._write_frame
+
+    def capture_frame(rendered_text):
+        frames.append(rendered_text)
+        original_write_frame(rendered_text)
+
+    shimmer._write_frame = capture_frame
     shimmer.start()
     try:
-        # Capture frames written by the animation thread
-        original_write_frame = shimmer._write_frame
-
-        def capture_frame(rendered_text):
-            frames.append(rendered_text)
-            original_write_frame(rendered_text)
-
-        shimmer._write_frame = capture_frame
         # Let animation run a couple of frames unpaused
-        time.sleep(0.05)
+        time.sleep(0.2)
         # At least one animated frame should contain BOLD
         assert any(BOLD in f for f in frames)
         # Simulate a progress bar pausing the shimmer
@@ -145,7 +146,7 @@ def test_animate_paused_clears_bold(monkeypatch):
         with shimmer._lock:
             shimmer._paused = True
         # Let the animation loop pick up the paused state
-        time.sleep(0.05)
+        time.sleep(0.2)
         # The paused frame should be plain text without BOLD
         assert len(frames) == 1
         assert BOLD not in frames[0]

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -29,6 +29,17 @@ def test_stream_proxy_isatty():
     assert proxy_non_tty.isatty() is False
 
 
+def test_stream_proxy_fileno():
+    """Ensure _StreamProxy delegates fileno() to the target stream."""
+
+    class FakeStream(io.StringIO):
+        def fileno(self):
+            return 42
+
+    proxy = _StreamProxy(FakeStream(), on_write=lambda s: None)
+    assert proxy.fileno() == 42
+
+
 def test_stream_proxy_writable():
     """Ensure _StreamProxy reports as writable.
 

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -1,0 +1,37 @@
+import io
+
+from audb.core.shimmer import _StreamProxy
+
+
+def test_stream_proxy_isatty():
+    """Ensure _StreamProxy delegates isatty() to the target stream.
+
+    tqdm checks isatty() to decide whether to render progress bars.
+    If the proxy returns False for a TTY target, bars silently vanish.
+
+    """
+
+    class FakeTTY(io.StringIO):
+        def isatty(self):
+            return True
+
+    class FakeNonTTY(io.StringIO):
+        def isatty(self):
+            return False
+
+    proxy_tty = _StreamProxy(FakeTTY(), on_write=lambda s: None)
+    assert proxy_tty.isatty() is True
+
+    proxy_non_tty = _StreamProxy(FakeNonTTY(), on_write=lambda s: None)
+    assert proxy_non_tty.isatty() is False
+
+
+def test_stream_proxy_writable():
+    """Ensure _StreamProxy reports as writable.
+
+    Code that checks writable() before writing
+    would skip the proxy otherwise.
+
+    """
+    proxy = _StreamProxy(io.StringIO(), on_write=lambda s: None)
+    assert proxy.writable() is True

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -1,5 +1,8 @@
 import io
 
+from audb.core.shimmer import BOLD
+from audb.core.shimmer import RESET
+from audb.core.shimmer import Shimmer
 from audb.core.shimmer import _StreamProxy
 
 
@@ -35,3 +38,28 @@ def test_stream_proxy_writable():
     """
     proxy = _StreamProxy(io.StringIO(), on_write=lambda s: None)
     assert proxy.writable() is True
+
+
+def test_render_frame():
+    """Test that _render_frame highlights characters near center."""
+    shimmer = Shimmer("", "abcde", width=4)
+
+    # Center on character 2 ('c'): nearby chars should be bold
+    frame = shimmer._render_frame(2.0)
+    assert f"{BOLD}c{RESET}" in frame
+
+    # Characters far from center should be plain
+    assert frame.startswith("a") or frame.startswith(f"{BOLD}a{RESET}")
+
+    # Character at fading edge (within window but low brightness)
+    # should appear plain. With width=4, half=2.0, a character at
+    # dist ~1.9 from center has brightness cos(1.9/2.0 * pi/2) ≈ 0.08.
+    frame_edge = shimmer._render_frame(0.1)
+    # 'a' is at index 0, dist=0.1 → bold; 'c' at index 2, dist=1.9 → plain
+    assert f"{BOLD}a{RESET}" in frame_edge
+    assert f"{BOLD}c{RESET}" not in frame_edge
+
+    # Center far outside text: no characters should be bold
+    frame_outside = shimmer._render_frame(-10.0)
+    assert BOLD not in frame_outside
+    assert frame_outside == "abcde"

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -3,6 +3,13 @@ import os
 import sys
 import time
 
+import numpy as np
+
+import audeer
+import audformat
+import audiofile
+
+import audb
 from audb.core import shimmer as shimmer_module
 from audb.core.shimmer import BOLD
 from audb.core.shimmer import RESET
@@ -235,3 +242,83 @@ def test_write_frame_skips_when_scrolled_off(monkeypatch):
     shimmer._lines_below = 1000
     shimmer._write_frame("test")
     assert buf.getvalue() == ""
+
+
+def test_shimmer_load_table_smoke(tmp_path, monkeypatch, repository):
+    """End-to-end smoke test for the Shimmer <-> load_table integration.
+
+    The call sites in ``load.py`` / ``load_to.py`` / ``publish.py``
+    that instantiate ``Shimmer`` are all marked ``# pragma: no cover``
+    because ``Shimmer.start()`` becomes a no-op under pytest (stdout
+    is not a TTY). This test forces ``isatty=True`` so the Shimmer
+    genuinely starts its animation thread and installs the stdout /
+    stderr write hooks, then runs ``audb.load_table`` against a tiny
+    freshly-published fixture. It verifies:
+
+    * the call returns correct data;
+    * the Shimmer is torn down (no global reference leak);
+    * the monkey-patched write methods are restored after the call.
+
+    This is a smoke test: it does not assert anything about the
+    animation frames themselves — those are covered by the unit
+    tests above. Its job is to catch regressions where the hooks,
+    locking, or lifecycle break the real load pipeline.
+
+    """
+    # Build a minimal database: one silent wav, one filewise table.
+    build_dir = audeer.mkdir(tmp_path, "build")
+    media_rel = "data/file1.wav"
+    audeer.mkdir(build_dir, os.path.dirname(media_rel))
+    audio_path = audeer.path(build_dir, media_rel)
+    audiofile.write(audio_path, np.zeros((1, 800)), 8000)
+
+    db_name = "shimmer-smoke-db"
+    db = audformat.Database(db_name)
+    db.schemes["speaker"] = audformat.Scheme("str")
+    db["files"] = audformat.Table(audformat.filewise_index([media_rel]))
+    db["files"]["speaker"] = audformat.Column(scheme_id="speaker")
+    db["files"]["speaker"].set(["adam"])
+    db.save(build_dir)
+
+    # Publish with verbose=False so no Shimmer is created during publish,
+    # keeping the shimmer activation isolated to the load_table call below.
+    audb.publish(build_dir, "1.0.0", repository, verbose=False)
+
+    # Force stdout/stderr to look like a TTY so Shimmer.start() takes the
+    # real path instead of the no-op branch.
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: True)
+
+    # Track that at least one Shimmer actually took the non-noop path —
+    # otherwise the test would silently pass even if the TTY forcing
+    # above stopped working (e.g. pytest capture changes).
+    real_starts: list[bool] = []
+    original_start = Shimmer.start
+
+    def tracking_start(self):
+        original_start(self)
+        real_starts.append(not self._noop)
+
+    monkeypatch.setattr(Shimmer, "start", tracking_start)
+
+    # Sanity: no shimmer leaking in from an earlier test.
+    assert shimmer_module._active_shimmer is None
+    original_stdout_write = sys.stdout.write
+    original_stderr_write = sys.stderr.write
+
+    df = audb.load_table(db_name, "files", version="1.0.0", verbose=True)
+
+    # At least one Shimmer must have been started AND taken the real path.
+    assert real_starts, "no Shimmer was started — load_table path changed?"
+    assert any(real_starts), "every Shimmer became a no-op — TTY guard fired"
+
+    assert list(df.columns) == ["speaker"]
+    assert len(df) == 1
+    assert df["speaker"].iloc[0] == "adam"
+    # The shimmer must have cleaned up after itself.
+    assert shimmer_module._active_shimmer is None
+    # The hooks must have been uninstalled. Bound methods compare by
+    # value, not identity — a fresh attribute access returns a new
+    # bound method object, so use ``==`` rather than ``is``.
+    assert sys.stdout.write == original_stdout_write
+    assert sys.stderr.write == original_stderr_write

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -1,6 +1,7 @@
 import io
 import sys
 
+from audb.core import shimmer as shimmer_module
 from audb.core.shimmer import BOLD
 from audb.core.shimmer import RESET
 from audb.core.shimmer import Shimmer
@@ -38,7 +39,7 @@ def test_stderr_write_hook():
     assert shimmer._paused is False
 
 
-def test_write_hooks_preserve_stream_identity():
+def test_write_hooks_preserve_stream_identity(monkeypatch):
     """Ensure monkey-patching does not replace the stream objects.
 
     After start(), sys.stdout must still be the same object
@@ -46,6 +47,7 @@ def test_write_hooks_preserve_stream_identity():
     isatty(), encoding, etc. continues to work.
 
     """
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
     original_stdout = sys.stdout
     original_stderr = sys.stderr
     shimmer = Shimmer("", "test")
@@ -53,10 +55,82 @@ def test_write_hooks_preserve_stream_identity():
     try:
         assert sys.stdout is original_stdout
         assert sys.stderr is original_stderr
+        # write should be replaced with the hook
+        assert sys.stdout.write == shimmer._stdout_write_hook
     finally:
         shimmer.stop()
-    assert sys.stdout.write is original_stdout.write
-    assert sys.stderr.write is original_stderr.write
+    # After stop, write should no longer be the hook
+    assert sys.stdout.write != shimmer._stdout_write_hook
+
+
+def test_start_stop_tracks_newlines(monkeypatch):
+    """Integration test: start installs hook, stdout tracks newlines, stop restores."""
+    # Ensure stdout looks like a TTY for the shimmer to activate
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    original_write = sys.stdout.write
+
+    shimmer = Shimmer("", "test")
+    shimmer.start()
+    try:
+        # The hook should be installed
+        assert sys.stdout.write is not original_write
+        # Write text with newlines via the hooked stdout
+        sys.stdout.write("line1\nline2\nline3\n")
+        assert shimmer._lines_below == 3
+        # Write more
+        sys.stdout.write("another\n")
+        assert shimmer._lines_below == 4
+    finally:
+        shimmer.stop()
+
+    # After stop(), original write must be restored
+    assert sys.stdout.write is original_write
+
+
+def test_noop_when_not_a_tty(monkeypatch):
+    """Shimmer becomes a no-op when stdout is not a TTY."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    original_write = sys.stdout.write
+
+    shimmer = Shimmer("", "test")
+    shimmer.start()
+    # Should not have patched stdout
+    assert sys.stdout.write is original_write
+    assert shimmer._noop is True
+    shimmer.stop()
+
+
+def test_noop_with_env_var(monkeypatch):
+    """Shimmer becomes a no-op when AUDB_NO_SHIMMER=1."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    monkeypatch.setenv("AUDB_NO_SHIMMER", "1")
+    original_write = sys.stdout.write
+
+    shimmer = Shimmer("", "test")
+    shimmer.start()
+    assert sys.stdout.write is original_write
+    assert shimmer._noop is True
+    shimmer.stop()
+
+
+def test_second_shimmer_becomes_noop(monkeypatch):
+    """Only one Shimmer can be active; a second one becomes a no-op."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+
+    s1 = Shimmer("", "first")
+    s1.start()
+    try:
+        s2 = Shimmer("", "second")
+        s2.start()
+        assert s2._noop is True
+        s2.stop()
+        # s1 should still be the active shimmer
+        assert shimmer_module._active_shimmer is s1
+    finally:
+        s1.stop()
+
+    # After both stopped, no active shimmer
+    assert shimmer_module._active_shimmer is None
 
 
 def test_render_frame():

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -1,4 +1,5 @@
 import io
+import os
 import sys
 import time
 
@@ -191,3 +192,46 @@ def test_render_frame():
     frame_outside = shimmer._render_frame(-10.0)
     assert BOLD not in frame_outside
     assert frame_outside == "abcde"
+
+
+def test_write_frame_skips_when_scrolled_off(monkeypatch):
+    """Frame is skipped once the shimmer line has scrolled off the viewport.
+
+    Cursor-up is clamped to row 0 by the terminal and cannot reach
+    into scrollback, so writing anyway would corrupt an unrelated
+    visible row. Simulated here by pinning terminal height via the
+    ``LINES`` env var (which ``shutil.get_terminal_size`` honours).
+
+    """
+    buf = io.StringIO()
+    shimmer = Shimmer("", "test")
+    shimmer._original_stdout_write = buf.write
+
+    # Pin a small terminal height. COLUMNS must also be set for
+    # get_terminal_size to take the env-var path on some platforms.
+    monkeypatch.setenv("LINES", "10")
+    monkeypatch.setenv("COLUMNS", "80")
+    # get_terminal_size prefers an actual TTY over env vars when
+    # stdout is a terminal; force the env path by detaching fileno.
+    monkeypatch.setattr(
+        shimmer_module.shutil,
+        "get_terminal_size",
+        lambda fallback=(80, 24): os.terminal_size((80, 10)),
+    )
+
+    # Still within viewport: 0 lines below + 1 = 1 < 10
+    shimmer._lines_below = 0
+    shimmer._write_frame("test")
+    assert buf.getvalue() != ""
+    buf.truncate(0)
+    buf.seek(0)
+
+    # Right at the boundary: up = 10 == height → skip
+    shimmer._lines_below = 9
+    shimmer._write_frame("test")
+    assert buf.getvalue() == ""
+
+    # Well past the boundary: still skip, no corruption
+    shimmer._lines_below = 1000
+    shimmer._write_frame("test")
+    assert buf.getvalue() == ""

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -124,16 +124,32 @@ def test_second_shimmer_becomes_noop(monkeypatch):
 def test_animate_paused_clears_bold(monkeypatch):
     """When paused, the animation writes plain text to clear bold."""
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    frames = []
     shimmer = Shimmer("", "hello", interval=0.01)
     shimmer.start()
     try:
+        # Capture frames written by the animation thread
+        original_write_frame = shimmer._write_frame
+
+        def capture_frame(rendered_text):
+            frames.append(rendered_text)
+            original_write_frame(rendered_text)
+
+        shimmer._write_frame = capture_frame
         # Let animation run a couple of frames unpaused
         time.sleep(0.05)
+        # At least one animated frame should contain BOLD
+        assert any(BOLD in f for f in frames)
         # Simulate a progress bar pausing the shimmer
+        frames.clear()
         with shimmer._lock:
             shimmer._paused = True
         # Let the animation loop pick up the paused state
         time.sleep(0.05)
+        # The paused frame should be plain text without BOLD
+        assert len(frames) == 1
+        assert BOLD not in frames[0]
+        assert frames[0] == "hello"
     finally:
         shimmer.stop()
 

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -25,6 +25,9 @@ def test_stderr_write_hook():
 
     A ``\r`` followed by visible content pauses the shimmer,
     and ``\r`` followed by only whitespace resumes it.
+    A ``\n`` on stderr (e.g. tqdm finishing with ``leave=True``,
+    log records, warnings) scrolls the terminal and must
+    advance ``_lines_below``.
 
     """
     buf = io.StringIO()
@@ -38,6 +41,16 @@ def test_stderr_write_hook():
     # Only whitespace after \r → resume
     shimmer._stderr_write_hook("\r   \r")
     assert shimmer._paused is False
+
+    # tqdm leave=True finisher: trailing \n scrolls the terminal
+    assert shimmer._lines_below == 0
+    shimmer._stderr_write_hook("\n")
+    assert shimmer._lines_below == 1
+    assert shimmer._paused is False
+
+    # Plain stderr log line with an embedded newline also scrolls
+    shimmer._stderr_write_hook("oops\nmore\n")
+    assert shimmer._lines_below == 3
 
 
 def test_write_hooks_preserve_stream_identity(monkeypatch):

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -1,54 +1,62 @@
 import io
+import sys
 
 from audb.core.shimmer import BOLD
 from audb.core.shimmer import RESET
 from audb.core.shimmer import Shimmer
-from audb.core.shimmer import _StreamProxy
 
 
-def test_stream_proxy_isatty():
-    """Ensure _StreamProxy delegates isatty() to the target stream.
+def test_stdout_write_hook():
+    """Ensure stdout write hook tracks newlines and delegates."""
+    buf = io.StringIO()
+    shimmer = Shimmer("", "test")
+    shimmer._original_stdout_write = buf.write
 
-    tqdm checks isatty() to decide whether to render progress bars.
-    If the proxy returns False for a TTY target, bars silently vanish.
-
-    """
-
-    class FakeTTY(io.StringIO):
-        def isatty(self):
-            return True
-
-    class FakeNonTTY(io.StringIO):
-        def isatty(self):
-            return False
-
-    proxy_tty = _StreamProxy(FakeTTY(), on_write=lambda s: None)
-    assert proxy_tty.isatty() is True
-
-    proxy_non_tty = _StreamProxy(FakeNonTTY(), on_write=lambda s: None)
-    assert proxy_non_tty.isatty() is False
+    result = shimmer._stdout_write_hook("hello\nworld\n")
+    assert result == 12
+    assert buf.getvalue() == "hello\nworld\n"
+    assert shimmer._lines_below == 2
 
 
-def test_stream_proxy_fileno():
-    """Ensure _StreamProxy delegates fileno() to the target stream."""
+def test_stderr_write_hook():
+    r"""Ensure stderr write hook detects progress-bar activity.
 
-    class FakeStream(io.StringIO):
-        def fileno(self):
-            return 42
-
-    proxy = _StreamProxy(FakeStream(), on_write=lambda s: None)
-    assert proxy.fileno() == 42
-
-
-def test_stream_proxy_writable():
-    """Ensure _StreamProxy reports as writable.
-
-    Code that checks writable() before writing
-    would skip the proxy otherwise.
+    A ``\r`` followed by visible content pauses the shimmer,
+    and ``\r`` followed by only whitespace resumes it.
 
     """
-    proxy = _StreamProxy(io.StringIO(), on_write=lambda s: None)
-    assert proxy.writable() is True
+    buf = io.StringIO()
+    shimmer = Shimmer("", "test")
+    shimmer._original_stderr_write = buf.write
+
+    # Visible bar content after \r → pause
+    shimmer._stderr_write_hook("\r50%|####")
+    assert shimmer._paused is True
+
+    # Only whitespace after \r → resume
+    shimmer._stderr_write_hook("\r   \r")
+    assert shimmer._paused is False
+
+
+def test_write_hooks_preserve_stream_identity():
+    """Ensure monkey-patching does not replace the stream objects.
+
+    After start(), sys.stdout must still be the same object
+    (not a proxy), so that attribute access like fileno(),
+    isatty(), encoding, etc. continues to work.
+
+    """
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    shimmer = Shimmer("", "test")
+    shimmer.start()
+    try:
+        assert sys.stdout is original_stdout
+        assert sys.stderr is original_stderr
+    finally:
+        shimmer.stop()
+    assert sys.stdout.write is original_stdout.write
+    assert sys.stderr.write is original_stderr.write
 
 
 def test_render_frame():

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -14,8 +14,8 @@ def test_stdout_write_hook():
     shimmer = Shimmer("", "test")
     shimmer._original_stdout_write = buf.write
 
-    result = shimmer._stdout_write_hook("hello\nworld\n")
-    assert result == 12
+    num_chars = shimmer._stdout_write_hook("hello\nworld\n")
+    assert num_chars == 12
     assert buf.getvalue() == "hello\nworld\n"
     assert shimmer._lines_below == 2
 

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -1,5 +1,6 @@
 import io
 import sys
+import time
 
 from audb.core import shimmer as shimmer_module
 from audb.core.shimmer import BOLD
@@ -100,19 +101,6 @@ def test_noop_when_not_a_tty(monkeypatch):
     shimmer.stop()
 
 
-def test_noop_with_env_var(monkeypatch):
-    """Shimmer becomes a no-op when AUDB_NO_SHIMMER=1."""
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
-    monkeypatch.setenv("AUDB_NO_SHIMMER", "1")
-    original_write = sys.stdout.write
-
-    shimmer = Shimmer("", "test")
-    shimmer.start()
-    assert sys.stdout.write is original_write
-    assert shimmer._noop is True
-    shimmer.stop()
-
-
 def test_second_shimmer_becomes_noop(monkeypatch):
     """Only one Shimmer can be active; a second one becomes a no-op."""
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
@@ -131,6 +119,23 @@ def test_second_shimmer_becomes_noop(monkeypatch):
 
     # After both stopped, no active shimmer
     assert shimmer_module._active_shimmer is None
+
+
+def test_animate_paused_clears_bold(monkeypatch):
+    """When paused, the animation writes plain text to clear bold."""
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    shimmer = Shimmer("", "hello", interval=0.01)
+    shimmer.start()
+    try:
+        # Let animation run a couple of frames unpaused
+        time.sleep(0.05)
+        # Simulate a progress bar pausing the shimmer
+        with shimmer._lock:
+            shimmer._paused = True
+        # Let the animation loop pick up the paused state
+        time.sleep(0.05)
+    finally:
+        shimmer.stop()
 
 
 def test_render_frame():

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -194,6 +194,13 @@ def test_write_frame_skips_when_scrolled_off(monkeypatch):
     buf.truncate(0)
     buf.seek(0)
 
+    # Still within viewport: 8 lines below + 1 = 9 < 10
+    shimmer._lines_below = 8
+    shimmer._write_frame("test")
+    assert buf.getvalue() != ""
+    buf.truncate(0)
+    buf.seek(0)
+
     # Right at the boundary: up = 10 == height → skip
     shimmer._lines_below = 9
     shimmer._write_frame("test")

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -145,7 +145,8 @@ def test_render_frame():
     assert f"{BOLD}c{RESET}" in frame
 
     # Characters far from center should be plain
-    assert frame.startswith("a") or frame.startswith(f"{BOLD}a{RESET}")
+    assert frame.startswith("a")
+    assert frame.endswith("e")
 
     # Character at fading edge (within window but low brightness)
     # should appear plain. With width=4, half=2.0, a character at

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -83,13 +83,17 @@ def test_start_stop_tracks_newlines(monkeypatch):
     """Integration test: start installs hook, stdout tracks newlines, stop restores."""
     # Ensure stdout looks like a TTY for the shimmer to activate
     monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    # stdout normally exposes ``write`` as a class method, so there is
+    # no instance-level override before we patch.
+    assert "write" not in vars(sys.stdout)
     original_write = sys.stdout.write
 
     shimmer = Shimmer("", "test")
     shimmer.start()
     try:
-        # The hook should be installed
+        # The hook should be installed as an instance-level override
         assert sys.stdout.write is not original_write
+        assert "write" in vars(sys.stdout)
         # Write text with newlines via the hooked stdout
         sys.stdout.write("line1\nline2\nline3\n")
         assert shimmer._lines_below == 3
@@ -99,8 +103,12 @@ def test_start_stop_tracks_newlines(monkeypatch):
     finally:
         shimmer.stop()
 
-    # After stop(), original write must be restored
-    assert sys.stdout.write is original_write
+    # After stop(), the instance-level override must be removed entirely
+    # (not merely re-pointed at the original), so attribute lookup falls
+    # back to the class method. Bound methods compare equal by value, so
+    # use ``==`` rather than ``is``.
+    assert "write" not in vars(sys.stdout)
+    assert sys.stdout.write == original_write
 
 
 def test_noop_when_not_a_tty(monkeypatch):
@@ -110,10 +118,63 @@ def test_noop_when_not_a_tty(monkeypatch):
 
     shimmer = Shimmer("", "test")
     shimmer.start()
-    # Should not have patched stdout
-    assert sys.stdout.write is original_write
+    # Should not have patched stdout: no instance-level override installed.
+    # (Bound methods compare equal by value, not identity, so use ``==``.)
+    assert "write" not in vars(sys.stdout)
+    assert sys.stdout.write == original_write
     assert shimmer._noop is True
     shimmer.stop()
+
+
+def test_restores_pre_existing_instance_write(monkeypatch):
+    """A pre-existing instance-level ``write`` is restored, not deleted.
+
+    When the stream already carries its own ``write`` in ``__dict__``
+    (e.g. it has been wrapped by another tool), stop() must put that
+    exact object back rather than removing the attribute and exposing
+    a class method that does not exist on such a stream.
+
+    """
+
+    class _FakeTTY:
+        def __init__(self):
+            self.data = []
+            # Pre-existing instance-level write override.
+            self.write = self._write
+
+        def _write(self, s):
+            self.data.append(s)
+            return len(s)
+
+        def flush(self):
+            pass
+
+        def isatty(self):
+            return True
+
+    fake_out = _FakeTTY()
+    fake_err = _FakeTTY()
+    monkeypatch.setattr(sys, "stdout", fake_out)
+    monkeypatch.setattr(sys, "stderr", fake_err)
+
+    original_out_write = fake_out.write
+    original_err_write = fake_err.write
+    assert "write" in vars(fake_out)
+    assert "write" in vars(fake_err)
+
+    shimmer = Shimmer("", "test")
+    shimmer.start()
+    try:
+        # Hooks installed over the pre-existing overrides.
+        assert fake_out.write == shimmer._stdout_write_hook
+        assert fake_err.write == shimmer._stderr_write_hook
+    finally:
+        shimmer.stop()
+
+    # The original instance-level overrides are restored exactly,
+    # not removed (which would have re-exposed a non-existent class method).
+    assert fake_out.write is original_out_write
+    assert fake_err.write is original_err_write
 
 
 def test_second_shimmer_becomes_noop(monkeypatch):

--- a/tests/test_shimmer.py
+++ b/tests/test_shimmer.py
@@ -1,7 +1,6 @@
 import io
 import os
 import sys
-import time
 
 import numpy as np
 
@@ -29,32 +28,27 @@ def test_stdout_write_hook():
 
 
 def test_stderr_write_hook():
-    r"""Ensure stderr write hook detects progress-bar activity.
+    r"""Ensure stderr write hook tracks newlines.
 
-    A ``\r`` followed by visible content pauses the shimmer,
-    and ``\r`` followed by only whitespace resumes it.
     A ``\n`` on stderr (e.g. tqdm finishing with ``leave=True``,
     log records, warnings) scrolls the terminal and must
-    advance ``_lines_below``.
+    advance ``_lines_below``. Carriage returns from in-place
+    progress-bar updates do not scroll and must be ignored.
 
     """
     buf = io.StringIO()
     shimmer = Shimmer("", "test")
     shimmer._original_stderr_write = buf.write
 
-    # Visible bar content after \r → pause
+    # Carriage-return bar updates do not scroll the terminal
+    assert shimmer._lines_below == 0
     shimmer._stderr_write_hook("\r50%|####")
-    assert shimmer._paused is True
-
-    # Only whitespace after \r → resume
     shimmer._stderr_write_hook("\r   \r")
-    assert shimmer._paused is False
+    assert shimmer._lines_below == 0
 
     # tqdm leave=True finisher: trailing \n scrolls the terminal
-    assert shimmer._lines_below == 0
     shimmer._stderr_write_hook("\n")
     assert shimmer._lines_below == 1
-    assert shimmer._paused is False
 
     # Plain stderr log line with an embedded newline also scrolls
     shimmer._stderr_write_hook("oops\nmore\n")
@@ -140,40 +134,6 @@ def test_second_shimmer_becomes_noop(monkeypatch):
 
     # After both stopped, no active shimmer
     assert shimmer_module._active_shimmer is None
-
-
-def test_animate_paused_clears_bold(monkeypatch):
-    """When paused, the animation writes plain text to clear bold."""
-    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
-    frames = []
-    shimmer = Shimmer("", "hello", interval=0.01)
-
-    # Patch _write_frame before start() to avoid race with animation thread
-    original_write_frame = shimmer._write_frame
-
-    def capture_frame(rendered_text):
-        frames.append(rendered_text)
-        original_write_frame(rendered_text)
-
-    shimmer._write_frame = capture_frame
-    shimmer.start()
-    try:
-        # Let animation run a couple of frames unpaused
-        time.sleep(0.2)
-        # At least one animated frame should contain BOLD
-        assert any(BOLD in f for f in frames)
-        # Simulate a progress bar pausing the shimmer
-        frames.clear()
-        with shimmer._lock:
-            shimmer._paused = True
-        # Let the animation loop pick up the paused state
-        time.sleep(0.2)
-        # The paused frame should be plain text without BOLD
-        assert len(frames) == 1
-        assert BOLD not in frames[0]
-        assert frames[0] == "hello"
-    finally:
-        shimmer.stop()
 
 
 def test_render_frame():


### PR DESCRIPTION
Closes https://github.com/audeering/audb/issues/553

 Adds a "shimmer" animation (bold text sweeping across the database name) to `load()`, `load_attachment()`, `load_media()`, `load_table()`, `load_to()`, and `publish()`. The animation  
  runs in a background thread and is implemented in `audb/core/shimmer.py`.

Example video:

[Screencast from 07.04.2026 13:36:20.webm](https://github.com/user-attachments/assets/ca424ac6-af74-4545-9d39-8737dc6d97ee)


<details><summary>Code for video</summary>

```python
import audb
from tempfile import TemporaryDirectory

with TemporaryDirectory() as tmpdir:
    db = audb.load("librispeech", version="3.2.0", cache_root=tmpdir)
```
</details>

For `audb.load_to()` and `audb.publish()` we also add the following print statements to allow for the animation (before nothing was shown):

```
Get: emodb v2.0.0
To: /path/to/db_root
```

```
Put: emodb v2.0.1
Source: /path/to/db_root
```

As we now have an animation directly at the start, I removed showing a progress bar for downloading `db.parquet`  as it downloads in reasonable time and most users do not know what `db.parquet` is.

---

An alternative implementation would be to stop the animation, when progress bars are active:

[Screencast from 07.04.2026 13:33:55.webm](https://github.com/user-attachments/assets/7aa82f22-aa20-42e8-8c1d-39d0c083b197)
