### PR TITLE
Depend on audformat>=1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] >=2.2.3',
     'audeer >=2.2.0',
-    'audformat >=1.4.0',
+    'audformat >=1.4.1',
     'audiofile >=1.0.0',
     'audobject >=0.5.0',
     'audresample >=0.1.6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] >=2.2.3',
     'audeer >=2.2.0',
-    'audformat >=1.3.4',
+    'audformat >=1.4.0',
     'audiofile >=1.0.0',
     'audobject >=0.5.0',
     'audresample >=0.1.6',


### PR DESCRIPTION
As `audformat.utils.hash()` has a breaking change in `audformat>=1.4.0` and we use it to determine if a table has changed, we should make sure that newer versions of `audb` never use an older version of `audformat`.

In addition, `audformat` 1.4.1 avoids a warning message during the tests and black lists broken pandas versions.