### PR TITLE
CI: cache apt packages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -44,7 +44,9 @@ jobs:
       with:
         packages: graphviz
         version: 1.0
-        execute_install_scripts: true
+
+    - name: Ubuntu - register graphviz plugins
+      run: sudo dot -c
 
     - name: Test building documentation
       run: uv run python -m sphinx docs/ docs/_build/ -b html -W

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -33,13 +33,17 @@ jobs:
       uses: astral-sh/setup-uv@v5
 
     - name: Ubuntu - install libsndfile
-      run: |
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: libsndfile1
+        version: 1.0
 
       # DOCS
     - name: Ubuntu - install graphviz
-      run: sudo apt-get install --yes graphviz
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: graphviz
+        version: 1.0
 
     - name: Test building documentation
       run: uv run python -m sphinx docs/ docs/_build/ -b html -W

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         packages: graphviz
         version: 1.0
+        execute_install_scripts: true
 
     - name: Test building documentation
       run: uv run python -m sphinx docs/ docs/_build/ -b html -W

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -33,14 +33,14 @@ jobs:
       uses: astral-sh/setup-uv@v5
 
     - name: Ubuntu - install libsndfile
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
       with:
         packages: libsndfile1
         version: 1.0
 
       # DOCS
     - name: Ubuntu - install graphviz
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
       with:
         packages: graphviz
         version: 1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Documentation
     - name: Install doc dependencies
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
       with:
         packages: libsndfile1 sox graphviz
         version: 1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,7 @@ jobs:
       with:
         packages: libsndfile1 sox graphviz
         version: 1.0
+        execute_install_scripts: true
 
     - name: Build documentation
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,10 @@ jobs:
 
     # Documentation
     - name: Install doc dependencies
-      run: |
-        sudo apt-get install --no-install-recommends --yes libsndfile1 sox
-        sudo apt-get install --yes graphviz
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: libsndfile1 sox graphviz
+        version: 1.0
 
     - name: Build documentation
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,9 @@ jobs:
       with:
         packages: libsndfile1 sox graphviz
         version: 1.0
-        execute_install_scripts: true
+
+    - name: Register graphviz plugins
+      run: sudo dot -c
 
     - name: Build documentation
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,10 @@ jobs:
       uses: astral-sh/setup-uv@v5
 
     - name: Ubuntu - install libsndfile
-      run: |
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: libsndfile1
+        version: 1.0
       if: matrix.os == 'ubuntu-latest'
 
     - name: Install requested pandas version
@@ -70,9 +71,10 @@ jobs:
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo
-      run: |
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes ffmpeg mediainfo
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: ffmpeg mediainfo
+        version: 1.0
       if: matrix.os == 'ubuntu-latest'
 
     - name: OSX - install ffmpeg/mediainfo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
 
     - name: Ubuntu - install libsndfile
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
       with:
         packages: libsndfile1
         version: 1.0
@@ -71,7 +71,7 @@ jobs:
 
     # TESTS
     - name: Ubuntu - install ffmpeg/mediainfo
-      uses: awalsh128/cache-apt-pkgs-action@v1
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
       with:
         packages: ffmpeg mediainfo
         version: 1.0


### PR DESCRIPTION
Use [awalsh128/cache-apt-pkgs-action](https://github.com/awalsh128/cache-apt-pkgs-action) to cache apt packages, which caused very slow CI pipelines from time to time before.