### PR TITLE
Include only audb* in Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,7 @@ convention = 'google'
 #
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
+include = ['audb*']
 
 [tool.setuptools.package-data]
 audb = ['core/etc/*']


### PR DESCRIPTION
Closes #559 

This restricts the files included in the Python package to `audb*`.