### PR TITLE
Require audbackend[all]>=2.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audbackend[all] >=2.2.3',
+    'audbackend[all] >=2.4.0',
     'audeer >=2.2.0',
     'audformat >=1.4.1',
     'audiofile >=1.0.0',


### PR DESCRIPTION
Require latest `audbackend` to ensure we use `stream-unzip` under Python 3.14 and can ensure that `audb.versions()` is faster.

Benchmark results from https://github.com/audeering/audbackend/pull/291:

| Dataset | Backend | audbackend<2.4 | audbackend>=2.4 |
| --- | --- | --- | --- |
| librispeech | minio | 103.469s | 1.773s |
| aisoundlab-covid-19 | artifactory | 3.544s | 2.303s |