### PR TITLE
Require audformat>=1.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ requires-python = '>=3.10'
 dependencies = [
     'audbackend[all] >=2.4.0',
     'audeer >=2.2.0',
-    'audformat >=1.4.1',
+    'audformat >=1.4.2',
     'audiofile >=1.0.0',
     'audobject >=0.5.0',
     'audresample >=0.1.6',


### PR DESCRIPTION
Require `audformat >=1.4.2` to ensure we have full compatibility with `pandas` 3.0.