### PR TITLE
Use Backend.ls_dirs() for audb.available()

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -72,42 +72,14 @@ def available(
         try:
             backend_interface = repository.create_backend_interface()
             with backend_interface.backend as backend:
-                if repository.backend == "artifactory":  # pragma: nocover
-                    # avoid backend_interface.ls('/')
-                    # which is very slow on Artifactory
-                    # see https://github.com/audeering/audbackend/issues/132
-                    for p in backend.path("/"):
-                        name = p.name
-                        try:
-                            for version in [str(x).split("/")[-1] for x in p / "db"]:
-                                add_database(name, version, repository)
-                        except FileNotFoundError:
-                            # If the `db` folder does not exist,
-                            # we do not include the dataset
-                            pass
-
-                elif repository.backend in ["minio", "s3"]:
-                    # Avoid `ls(recursive=True)` for S3 and MinIO
-                    # as this is slow for large databases
-                    for obj in backend._client.list_objects(repository.name):
-                        name = obj.object_name[:-1]  # remove "/" at end
-                        header_file = f"/{name}/{define.HEADER_FILE}"
-                        for _obj in backend._client.list_objects(
-                            repository.name, f"{name}/"
-                        ):
-                            version = _obj.object_name.split("/")[1]
-                            header_file = f"/{name}/{version}/{define.HEADER_FILE}"
-                            if version not in [
-                                "attachment",
-                                "media",
-                                "meta",
-                            ] and backend.exists(header_file):
-                                add_database(name, version, repository)
-
-                else:
-                    for path, version in backend_interface.ls("/"):
-                        if path.endswith(define.HEADER_FILE):
-                            name = path.split("/")[1]
+                for name in backend.ls_dirs("/"):
+                    for version in backend.ls_dirs(f"/{name}/"):
+                        header_file = f"/{name}/{version}/{define.HEADER_FILE}"
+                        if version not in [
+                            "attachment",
+                            "media",
+                            "meta",
+                        ] and backend.exists(header_file):
                             add_database(name, version, repository)
 
         except (audbackend.BackendError, ValueError):

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -72,15 +72,14 @@ def available(
         try:
             backend_interface = repository.create_backend_interface()
             with backend_interface.backend as backend:
-                for name in backend.ls_dirs("/"):
-                    for version in backend.ls_dirs(f"/{name}/"):
-                        header_file = f"/{name}/{version}/{define.HEADER_FILE}"
-                        if version not in [
-                            "attachment",
-                            "media",
-                            "meta",
-                        ] and backend.exists(header_file):
-                            add_database(name, version, repository)
+                for db_name in backend.ls_dirs("/"):
+                    header_file = f"/{db_name}/{define.HEADER_FILE}"
+                    versions = (
+                        [backend_interface.latest_version(header_file)] if only_latest
+                        else backend_interface.versions(header_file)
+                    )
+                    for version in versions:
+                        add_database(db_name, version, repository)
 
         except (audbackend.BackendError, ValueError):
             continue
@@ -89,18 +88,6 @@ def available(
         databases,
         columns=["name", "backend", "host", "repository", "version"],
     )
-    if only_latest:
-        # Pick latest version for every database, see
-        # https://stackoverflow.com/a/53842408
-        df = df[
-            df["version"]
-            == df.groupby("name")["version"].transform(
-                lambda x: audeer.sort_versions(x)[-1]
-            )
-        ]
-    else:
-        # Sort by version
-        df = df.sort_values(by=["version"], key=audeer.sort_versions)
     df = df.sort_values(by=["name"])
     return df.set_index("name")
 


### PR DESCRIPTION
This is an alternative to https://github.com/audeering/audb/pull/555.

Updates the code of `audb.available()` to use the new `Backend.ls_dirs()`.

| Backend | only_latest | Before | Proposed |
| --- | --- | --- | --- |
| artifactory | False | 1.408s | 1.568s |
| artifactory | True | 0.682s |  0.681s |
| minio | False | 11.671s | 17.188s |
| minio | True | 11.603s | 16.909s |


<details><summary>Benchmark code</summary>

```python
import audb
import time


def measure(only_latest=False):
    t0 = time.time()
    df = audb.available()
    t = time.time() - t0
    print(f"Execution time: {t:.3f}s")
    
    
print("data-private-local")
repo = audb.Repository(
    name="audb-private-local",
    host="https://artifactory.audeering.com/artifactory",
    backend="artifactory",
)
audb.config.REPOSITORIES = [repo]
measure()
measure(only_latest=True)
 
print("audb-internal")
repo = audb.Repository(
    name="audb-internal",
    host="s3.dualstack.eu-north-1.amazonaws.com",
    backend="s3",
)
audb.config.REPOSITORIES = [repo]
measure()
measure(only_latest=True)
```

</details>