### PR TITLE
Mark fully cached dbs with a .complete file

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -285,10 +285,10 @@ def cached(
                     # Completeness is indicated by a ``.complete`` file.
                     # For databases cached with an older version of audb,
                     # it is still stored in the database header,
-                    # see https://github.com/audeering/audb/issues/197
-                    complete = utils.database_is_complete(flavor_id_path)
-                    if not complete:
-                        complete = db.meta["audb"].get("complete", False)
+                    # see https://github.com/audeering/audb/pull/569
+                    complete = utils.database_is_complete(
+                        flavor_id_path
+                    ) or utils.database_is_complete_in_header(db)
                     df.loc[flavor_id_path] = [
                         database,
                         flavor_id,

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -282,7 +282,13 @@ def cached(
                         load_data=False,
                     )
                     flavor = db.meta["audb"]["flavor"]
-                    complete = db.meta["audb"]["complete"]
+                    # Completeness is indicated by a ``.complete`` file.
+                    # For databases cached with an older version of audb,
+                    # it is still stored in the database header,
+                    # see https://github.com/audeering/audb/issues/197
+                    complete = utils.database_is_complete(flavor_id_path)
+                    if not complete:
+                        complete = db.meta["audb"].get("complete", False)
                     df.loc[flavor_id_path] = [
                         database,
                         flavor_id,

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -20,7 +20,7 @@ If this file is present
 in the cache folder of a database,
 the database is loaded completely
 and its cache folder does not need to be locked,
-see https://github.com/audeering/audb/issues/197.
+see https://github.com/audeering/audb/pull/569.
 
 """
 

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -13,6 +13,17 @@ DEPRECATED_USER_CONFIG_FILE = "~/.audb.yaml"
 DB = "db"
 HEADER_FILE = f"{DB}.yaml"
 
+COMPLETE_FILE = ".complete"
+r"""Filename of marker file for a complete database.
+
+If this file is present
+in the cache folder of a database,
+the database is loaded completely
+and its cache folder does not need to be locked,
+see https://github.com/audeering/audb/issues/197.
+
+"""
+
 # Dependencies
 DEPENDENCY_FILE = f"{DB}.parquet"
 r"""Filename and extension of dependency table file."""

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import contextlib
 import os
 import shutil
 
@@ -162,48 +163,67 @@ def _copy_path(
 
 
 def _database_check_complete(
-    db: audformat.Database,
     db_root: str,
     flavor: Flavor,
     deps: Dependencies,
-):
-    def check() -> bool:
-        complete = True
-        for attachment in deps.attachments:
-            if not os.path.exists(os.path.join(db_root, attachment)):
+) -> bool:
+    r"""Check if all files of a database are present in cache.
+
+    If the database is complete,
+    a ``.complete`` file is created
+    in its cache folder
+    (see :func:`audb.core.utils.database_is_complete`).
+    The presence of this file
+    allows to load the database afterwards
+    without locking its cache folder.
+
+    Args:
+        db_root: database cache folder
+        flavor: database flavor
+        deps: database dependencies
+
+    Returns:
+        ``True`` if the database is complete
+
+    """
+    for attachment in deps.attachments:
+        if not os.path.exists(os.path.join(db_root, attachment)):
+            return False
+    for table in deps.tables:
+        if not os.path.exists(os.path.join(db_root, table)):
+            return False
+    for media in deps.media:
+        if not deps.removed(media):
+            path = os.path.join(db_root, media)
+            path = flavor.destination(path)
+            if not os.path.exists(path):
                 return False
-        for table in deps.tables:
-            if not os.path.exists(os.path.join(db_root, table)):
-                return False
-        for media in deps.media:
-            if not deps.removed(media):
-                path = os.path.join(db_root, media)
-                path = flavor.destination(path)
-                if not os.path.exists(path):
-                    return False
-        return complete
 
-    if check():
-        db_root_tmp = database_tmp_root(db_root)
-        db.meta["audb"]["complete"] = True
-        db_original = audformat.Database.load(db_root, load_data=False)
-        db_original.meta["audb"]["complete"] = True
-        db_original.save(db_root_tmp, header_only=True)
-        audeer.move_file(
-            os.path.join(db_root_tmp, define.HEADER_FILE),
-            os.path.join(db_root, define.HEADER_FILE),
-        )
-        audeer.rmdir(db_root_tmp)
+    utils.mark_database_complete(db_root)
+    return True
 
 
-def _database_is_complete(
+def _database_is_complete_in_header(
     db: audformat.Database,
 ) -> bool:
-    complete = False
-    if "audb" in db.meta:
-        if "complete" in db.meta["audb"]:
-            complete = db.meta["audb"]["complete"]
-    return complete
+    r"""Check if a database is marked complete in its header.
+
+    Before the introduction of the ``.complete`` file,
+    the information if a database is complete
+    was stored in the database header (``db.yaml``).
+    This is still checked
+    for databases that were cached
+    with such an older version of audb,
+    see :func:`audb.core.utils.database_is_complete`.
+
+    Args:
+        db: database object
+
+    Returns:
+        ``True`` if the header marks the database as complete
+
+    """
+    return db.meta.get("audb", {}).get("complete", False)
 
 
 def _files_duration(
@@ -1206,7 +1226,18 @@ def _load(
             cache_root=cache_root,
         )
 
-        with FolderLock(db_root, timeout=timeout):
+        # A complete database is never modified,
+        # so its cache folder does not need to be locked.
+        # Completeness is indicated by a ``.complete`` file,
+        # which can be checked without acquiring the lock,
+        # see https://github.com/audeering/audb/issues/197
+        complete = utils.database_is_complete(db_root)
+        if complete:
+            lock = contextlib.nullcontext()
+        else:
+            lock = FolderLock(db_root, timeout=timeout)
+
+        with lock:
             # Start with database header without tables
             db, backend_interface = load_header_to(
                 db_root,
@@ -1216,7 +1247,15 @@ def _load(
                 add_audb_meta=True,
             )
 
-            db_is_complete = _database_is_complete(db)
+            db_is_complete = complete
+            if not db_is_complete and _database_is_complete_in_header(db):
+                # Database was cached as complete
+                # with an older version of audb,
+                # which stored this information in the header.
+                # Create the ``.complete`` file,
+                # so locking can be skipped next time.
+                db_is_complete = True
+                utils.mark_database_complete(db_root)
 
             # load attachments
             if not db_is_complete and not only_metadata:
@@ -1342,12 +1381,17 @@ def _load(
 
             # check if database is now complete
             if not db_is_complete:
-                _database_check_complete(
-                    db,
+                db_is_complete = _database_check_complete(
                     db_root,
                     flavor,
                     deps,
                 )
+
+            # Store completeness in the returned database object.
+            # It is no longer written to the database header,
+            # see https://github.com/audeering/audb/issues/197
+            if "audb" in db.meta:
+                db.meta["audb"]["complete"] = db_is_complete
 
     except filelock.Timeout:
         utils.timeout_warning()
@@ -1417,7 +1461,7 @@ def load_attachment(
             )
             raise ValueError(msg)
 
-        with FolderLock(db_root):
+        with utils.lock_cache(db_root):
             # Start with database header
             db, backend_interface = load_header_to(
                 db_root,
@@ -1471,7 +1515,7 @@ def load_header(
 
     db_root = database_cache_root(name, version, cache_root)
 
-    with FolderLock(db_root):
+    with utils.lock_cache(db_root):
         db, _ = load_header_to(db_root, name, version)
 
     return db
@@ -1519,11 +1563,14 @@ def load_header_to(
         backend_interface.get_file(remote_header, local_header, version)
         if add_audb_meta:
             db = audformat.Database.load(db_root_tmp, load_data=False)
+            # Whether a database is complete
+            # is no longer stored in the header,
+            # but indicated by a ``.complete`` file in the cache folder,
+            # see https://github.com/audeering/audb/issues/197
             db.meta["audb"] = {
                 "root": db_root,
                 "version": version,
                 "flavor": flavor.arguments,
-                "complete": False,
             }
             db.save(db_root_tmp, header_only=True)
             audeer.move_file(
@@ -1688,7 +1735,16 @@ def _load_media(
             )
             raise ValueError(msg)
 
-        with FolderLock(db_root, timeout=timeout):
+        # A complete database is never modified,
+        # so its cache folder does not need to be locked,
+        # see https://github.com/audeering/audb/issues/197
+        complete = utils.database_is_complete(db_root)
+        if complete:
+            lock = contextlib.nullcontext()
+        else:
+            lock = FolderLock(db_root, timeout=timeout)
+
+        with lock:
             # Start with database header without tables
             db, backend_interface = load_header_to(
                 db_root,
@@ -1698,7 +1754,13 @@ def _load_media(
                 add_audb_meta=True,
             )
 
-            db_is_complete = _database_is_complete(db)
+            db_is_complete = complete
+            if not db_is_complete and _database_is_complete_in_header(db):
+                # Database was cached as complete
+                # with an older version of audb,
+                # which stored this information in the header.
+                db_is_complete = True
+                utils.mark_database_complete(db_root)
 
             # load missing media
             if not db_is_complete:
@@ -1843,7 +1905,7 @@ def load_table(
             )
             raise ValueError(msg)
 
-        with FolderLock(db_root):
+        with utils.lock_cache(db_root):
             # Start with database header without tables
             db, backend_interface = load_header_to(
                 db_root,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1700,8 +1700,7 @@ def _load_media(
             raise ValueError(msg)
 
         # A complete database is never modified,
-        # so its cache folder does not need to be locked,
-        # see https://github.com/audeering/audb/issues/197
+        # so its cache folder does not need to be locked.
         complete = utils.database_is_complete(db_root)
         if complete:
             lock = contextlib.nullcontext()

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1202,7 +1202,6 @@ def _load(
             cache_root=cache_root,
         )
 
-        complete = utils.database_is_complete(db_root)
         with utils.lock_cache(db_root, timeout=timeout):
             # Start with database header without tables
             db, backend_interface = load_header_to(
@@ -1217,7 +1216,9 @@ def _load(
             # stores its completeness in the header instead of
             # in a ``.complete`` file, which is migrated here,
             # see https://github.com/audeering/audb/pull/569
-            db_is_complete = complete or utils.legacy_complete(db_root, db)
+            db_is_complete = utils.database_is_complete(
+                db_root
+            ) or utils.legacy_complete(db_root, db)
 
             # load attachments
             if not db_is_complete and not only_metadata:
@@ -1691,7 +1692,6 @@ def _load_media(
             )
             raise ValueError(msg)
 
-        complete = utils.database_is_complete(db_root)
         with utils.lock_cache(db_root, timeout=timeout):
             # Start with database header without tables
             db, backend_interface = load_header_to(
@@ -1706,7 +1706,9 @@ def _load_media(
             # stores its completeness in the header instead of
             # in a ``.complete`` file, which is migrated here,
             # see https://github.com/audeering/audb/pull/569
-            db_is_complete = complete or utils.legacy_complete(db_root, db)
+            db_is_complete = utils.database_is_complete(
+                db_root
+            ) or utils.legacy_complete(db_root, db)
 
             # load missing media
             if not db_is_complete:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -203,29 +203,6 @@ def _database_check_complete(
     return True
 
 
-def _database_is_complete_in_header(
-    db: audformat.Database,
-) -> bool:
-    r"""Check if a database is marked complete in its header.
-
-    Before the introduction of the ``.complete`` file,
-    the information if a database is complete
-    was stored in the database header (``db.yaml``).
-    This is still checked
-    for databases that were cached
-    with such an older version of audb,
-    see :func:`audb.core.utils.database_is_complete`.
-
-    Args:
-        db: database object
-
-    Returns:
-        ``True`` if the header marks the database as complete
-
-    """
-    return db.meta.get("audb", {}).get("complete", False)
-
-
 def _files_duration(
     db: audformat.Database,
     deps: Dependencies,
@@ -1228,9 +1205,6 @@ def _load(
 
         # A complete database is never modified,
         # so its cache folder does not need to be locked.
-        # Completeness is indicated by a ``.complete`` file,
-        # which can be checked without acquiring the lock,
-        # see https://github.com/audeering/audb/issues/197
         complete = utils.database_is_complete(db_root)
         if complete:
             lock = contextlib.nullcontext()
@@ -1247,15 +1221,11 @@ def _load(
                 add_audb_meta=True,
             )
 
-            db_is_complete = complete
-            if not db_is_complete and _database_is_complete_in_header(db):
-                # Database was cached as complete
-                # with an older version of audb,
-                # which stored this information in the header.
-                # Create the ``.complete`` file,
-                # so locking can be skipped next time.
-                db_is_complete = True
-                utils.mark_database_complete(db_root)
+            # A database cached with an older version of audb
+            # stores its completeness in the header instead of
+            # in a ``.complete`` file, which is migrated here,
+            # see https://github.com/audeering/audb/pull/569
+            db_is_complete = complete or utils.legacy_complete(db_root, db)
 
             # load attachments
             if not db_is_complete and not only_metadata:
@@ -1387,9 +1357,7 @@ def _load(
                     deps,
                 )
 
-            # Store completeness in the returned database object.
-            # It is no longer written to the database header,
-            # see https://github.com/audeering/audb/issues/197
+            # Store completeness in the returned database object
             if "audb" in db.meta:
                 db.meta["audb"]["complete"] = db_is_complete
 
@@ -1754,13 +1722,11 @@ def _load_media(
                 add_audb_meta=True,
             )
 
-            db_is_complete = complete
-            if not db_is_complete and _database_is_complete_in_header(db):
-                # Database was cached as complete
-                # with an older version of audb,
-                # which stored this information in the header.
-                db_is_complete = True
-                utils.mark_database_complete(db_root)
+            # A database cached with an older version of audb
+            # stores its completeness in the header instead of
+            # in a ``.complete`` file, which is migrated here,
+            # see https://github.com/audeering/audb/pull/569
+            db_is_complete = complete or utils.legacy_complete(db_root, db)
 
             # load missing media
             if not db_is_complete:

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-import contextlib
 import os
 import shutil
 
@@ -1203,15 +1202,8 @@ def _load(
             cache_root=cache_root,
         )
 
-        # A complete database is never modified,
-        # so its cache folder does not need to be locked.
         complete = utils.database_is_complete(db_root)
-        if complete:
-            lock = contextlib.nullcontext()
-        else:
-            lock = FolderLock(db_root, timeout=timeout)
-
-        with lock:
+        with utils.lock_cache(db_root, timeout=timeout):
             # Start with database header without tables
             db, backend_interface = load_header_to(
                 db_root,
@@ -1699,15 +1691,8 @@ def _load_media(
             )
             raise ValueError(msg)
 
-        # A complete database is never modified,
-        # so its cache folder does not need to be locked.
         complete = utils.database_is_complete(db_root)
-        if complete:
-            lock = contextlib.nullcontext()
-        else:
-            lock = FolderLock(db_root, timeout=timeout)
-
-        with lock:
+        with utils.lock_cache(db_root, timeout=timeout):
             # Start with database header without tables
             db, backend_interface = load_header_to(
                 db_root,

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1531,10 +1531,6 @@ def load_header_to(
         backend_interface.get_file(remote_header, local_header, version)
         if add_audb_meta:
             db = audformat.Database.load(db_root_tmp, load_data=False)
-            # Whether a database is complete
-            # is no longer stored in the header,
-            # but indicated by a ``.complete`` file in the cache folder,
-            # see https://github.com/audeering/audb/issues/197
             db.meta["audb"] = {
                 "root": db_root,
                 "version": version,

--- a/audb/core/stream.py
+++ b/audb/core/stream.py
@@ -23,8 +23,8 @@ from audb.core.load import _update_path
 from audb.core.load import latest_version
 from audb.core.load import load_header_to
 from audb.core.load import load_media
-from audb.core.lock import FolderLock
 from audb.core.utils import is_empty
+from audb.core.utils import lock_cache
 
 
 class DatabaseIterator(audformat.Database, metaclass=abc.ABCMeta):
@@ -558,7 +558,7 @@ def stream(
         msg = error_message_missing_object("table", [table], name, version)
         raise ValueError(msg)
 
-    with FolderLock(db_root):
+    with lock_cache(db_root):
         # Start with database header without tables
         db, backend_interface = load_header_to(
             db_root,

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+import contextlib
 import os
 import warnings
 
@@ -9,7 +10,83 @@ import audeer
 
 from audb.core import define
 from audb.core.config import config
+from audb.core.lock import FolderLock
 from audb.core.repository import Repository
+
+
+def database_is_complete(db_root: str) -> bool:
+    r"""Check if a database is completely cached.
+
+    A database is considered complete,
+    if a ``.complete`` file is present
+    in its cache folder.
+    As this file can be checked
+    without acquiring a lock on the cache folder,
+    it allows to load a complete database
+    without locking,
+    see https://github.com/audeering/audb/issues/197.
+
+    Databases that were cached
+    with a version of audb
+    before the introduction of the ``.complete`` file
+    do not contain this file.
+    For those, completeness is still stored
+    in the database header (``db.yaml``),
+    which has to be checked separately.
+
+    Args:
+        db_root: database cache folder
+
+    Returns:
+        ``True`` if the ``.complete`` file exists
+
+    """
+    return os.path.exists(os.path.join(db_root, define.COMPLETE_FILE))
+
+
+def mark_database_complete(db_root: str):
+    r"""Mark a database as completely cached.
+
+    Creates a ``.complete`` file
+    in the database cache folder,
+    see :func:`database_is_complete`.
+    The file is never removed afterwards,
+    as a complete database
+    does not change anymore.
+
+    Args:
+        db_root: database cache folder
+
+    """
+    audeer.touch(os.path.join(db_root, define.COMPLETE_FILE))
+
+
+def lock_cache(
+    db_root: str,
+    timeout: float = define.TIMEOUT,
+) -> contextlib.AbstractContextManager:
+    r"""Context manager to lock the cache folder of a database.
+
+    If the database is already complete
+    (see :func:`database_is_complete`),
+    a no-op context manager is returned,
+    as a complete database is never modified
+    and therefore does not need to be locked.
+    Otherwise a :class:`audb.core.lock.FolderLock`
+    for ``db_root`` is returned.
+
+    Args:
+        db_root: database cache folder
+        timeout: maximum time in seconds
+            before giving up acquiring a lock
+
+    Returns:
+        context manager locking the cache folder
+
+    """
+    if database_is_complete(db_root):
+        return contextlib.nullcontext()
+    return FolderLock(db_root, timeout=timeout)
 
 
 def is_empty(path: str) -> bool:

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -24,8 +24,7 @@ def database_is_complete(db_root: str) -> bool:
     As this file can be checked
     without acquiring a lock on the cache folder,
     it allows to load a complete database
-    without locking,
-    see https://github.com/audeering/audb/issues/197.
+    without locking.
 
     Databases that were cached
     with a version of audb

--- a/audb/core/utils.py
+++ b/audb/core/utils.py
@@ -7,6 +7,7 @@ import pyarrow.parquet as parquet
 
 import audbackend
 import audeer
+import audformat
 
 from audb.core import define
 from audb.core.config import config
@@ -59,6 +60,53 @@ def mark_database_complete(db_root: str):
 
     """
     audeer.touch(os.path.join(db_root, define.COMPLETE_FILE))
+
+
+def database_is_complete_in_header(db: audformat.Database) -> bool:
+    r"""Check if a database is marked complete in its header.
+
+    Before the introduction of the ``.complete`` file
+    (see :func:`database_is_complete`),
+    the information if a database is complete
+    was stored in the database header (``db.yaml``).
+    This is still checked
+    for databases that were cached
+    with such an older version of audb.
+
+    Args:
+        db: database header object
+
+    Returns:
+        ``True`` if the header marks the database as complete
+
+    """
+    return db.meta.get("audb", {}).get("complete", False)
+
+
+def legacy_complete(db_root: str, db: audformat.Database) -> bool:
+    r"""Create a ``.complete`` file from a legacy header flag.
+
+    Databases cached with a version of audb
+    before the introduction of the ``.complete`` file
+    store their completeness in the database header instead
+    (see :func:`database_is_complete_in_header`).
+    If the header marks the database as complete,
+    the ``.complete`` file is created,
+    so the database can be loaded
+    without locking its cache folder afterwards.
+
+    Args:
+        db_root: database cache folder
+        db: database header object
+
+    Returns:
+        ``True`` if the header marks the database as complete
+
+    """
+    if database_is_complete_in_header(db):
+        mark_database_complete(db_root)
+        return True
+    return False
 
 
 def lock_cache(

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -342,18 +342,53 @@ def test_complete_file(dbs):
 
 
 def test_complete_skips_lock(dbs):
-    r"""A complete database is loaded without acquiring the lock."""
+    r"""The cache folder is locked only for an incomplete database.
+
+    A complete database is loaded without acquiring the lock,
+    whereas an incomplete database still requires it.
+
+    """
+    # Partially load the database
+    # -> no `.complete` file
     db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        only_metadata=True,
+        full_path=False,
+        verbose=False,
+    )
+    db_root = db.meta["audb"]["root"]
+    lock_file = os.path.join(db_root, audb.core.define.LOCK_FILE)
+    assert not os.path.exists(os.path.join(db_root, audb.core.define.COMPLETE_FILE))
+
+    # Simulate a lock held by another process
+    audeer.touch(lock_file)
+    try:
+        # Loading acquires the lock for an incomplete database,
+        # hence it cannot be loaded with ``timeout=0``
+        with pytest.warns(UserWarning, match=audb.core.define.TIMEOUT_MSG):
+            db = audb.load(
+                DB_NAME,
+                version=DB_VERSION,
+                full_path=False,
+                timeout=0,
+                verbose=False,
+            )
+        assert db is None
+    finally:
+        os.remove(lock_file)
+
+    # Completely load the database
+    # -> `.complete` file is created
+    audb.load(
         DB_NAME,
         version=DB_VERSION,
         full_path=False,
         verbose=False,
     )
-    db_root = db.meta["audb"]["root"]
     assert os.path.exists(os.path.join(db_root, audb.core.define.COMPLETE_FILE))
 
     # Simulate a lock held by another process
-    lock_file = os.path.join(db_root, audb.core.define.LOCK_FILE)
     audeer.touch(lock_file)
     try:
         # Loading does not acquire the lock for a complete database,

--- a/tests/test_load_on_demand.py
+++ b/tests/test_load_on_demand.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import audeer
+import audformat
 import audformat.testing
 
 import audb
@@ -307,3 +308,157 @@ def test_load_filter(
         else:
             assert not os.path.exists(path)
     assert db.meta["audb"]["complete"] == complete
+
+
+def test_complete_file(dbs):
+    r"""A completely loaded database is marked by a ``.complete`` file."""
+    # Partial load does not mark the database as complete
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        tables=[],
+        media=[],
+        full_path=False,
+        verbose=False,
+    )
+    db_root = db.meta["audb"]["root"]
+    complete_file = os.path.join(db_root, audb.core.define.COMPLETE_FILE)
+    assert not os.path.exists(complete_file)
+    assert not db.meta["audb"]["complete"]
+
+    # Full load creates the ``.complete`` file
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        full_path=False,
+        verbose=False,
+    )
+    assert os.path.exists(complete_file)
+    assert db.meta["audb"]["complete"]
+
+    # Completeness is no longer stored in the database header
+    header = audformat.Database.load(db_root, load_data=False)
+    assert "complete" not in header.meta["audb"]
+
+
+def test_complete_skips_lock(dbs):
+    r"""A complete database is loaded without acquiring the lock."""
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        full_path=False,
+        verbose=False,
+    )
+    db_root = db.meta["audb"]["root"]
+    assert os.path.exists(os.path.join(db_root, audb.core.define.COMPLETE_FILE))
+
+    # Simulate a lock held by another process
+    lock_file = os.path.join(db_root, audb.core.define.LOCK_FILE)
+    audeer.touch(lock_file)
+    try:
+        # Loading does not acquire the lock for a complete database,
+        # hence it succeeds even with ``timeout=0``
+        db = audb.load(
+            DB_NAME,
+            version=DB_VERSION,
+            full_path=False,
+            timeout=0,
+            verbose=False,
+        )
+        assert db is not None
+        assert db.meta["audb"]["complete"]
+    finally:
+        os.remove(lock_file)
+
+
+def test_complete_legacy_header(dbs):
+    r"""Fall back to completeness stored in the header.
+
+    Databases cached with a version of audb
+    before the introduction of the ``.complete`` file
+    store the completeness information
+    in the database header instead.
+
+    """
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        full_path=False,
+        verbose=False,
+    )
+    db_root = db.meta["audb"]["root"]
+    complete_file = os.path.join(db_root, audb.core.define.COMPLETE_FILE)
+    assert os.path.exists(complete_file)
+
+    # Emulate an old cache:
+    # remove the ``.complete`` file
+    # and store the completeness in the header
+    os.remove(complete_file)
+    header = audformat.Database.load(db_root, load_data=False)
+    header.meta["audb"]["complete"] = True
+    header.save(db_root, header_only=True)
+
+    # Loading recognizes the database as complete
+    # and recreates the ``.complete`` file
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        full_path=False,
+        verbose=False,
+    )
+    assert os.path.exists(complete_file)
+    assert db.meta["audb"]["complete"]
+
+
+def test_complete_other_loaders(dbs):
+    r"""On-demand loaders use no lock for a complete database."""
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        full_path=False,
+        verbose=False,
+    )
+    db_root = db.meta["audb"]["root"]
+    assert os.path.exists(os.path.join(db_root, audb.core.define.COMPLETE_FILE))
+    media = list(db.files)[0]
+
+    # All on-demand loaders work on a complete database without locking
+    audb.info.header(DB_NAME, version=DB_VERSION)
+    audb.load_table(DB_NAME, "table1", version=DB_VERSION, verbose=False)
+    audb.load_media(DB_NAME, media, version=DB_VERSION, verbose=False)
+    audb.load_attachment(DB_NAME, "file", version=DB_VERSION, verbose=False)
+    next(
+        audb.stream(
+            DB_NAME,
+            "table1",
+            version=DB_VERSION,
+            batch_size=1,
+            verbose=False,
+        )
+    )
+
+
+def test_complete_legacy_header_load_media(dbs):
+    r"""``load_media`` falls back to completeness stored in the header."""
+    db = audb.load(
+        DB_NAME,
+        version=DB_VERSION,
+        full_path=False,
+        verbose=False,
+    )
+    db_root = db.meta["audb"]["root"]
+    complete_file = os.path.join(db_root, audb.core.define.COMPLETE_FILE)
+    media = list(db.files)[0]
+
+    # Emulate an old cache:
+    # remove the ``.complete`` file
+    # and store the completeness in the header
+    os.remove(complete_file)
+    header = audformat.Database.load(db_root, load_data=False)
+    header.meta["audb"]["complete"] = True
+    header.save(db_root, header_only=True)
+
+    # ``load_media`` recognizes the database as complete from the header,
+    # and recreates the ``.complete`` file
+    audb.load_media(DB_NAME, media, version=DB_VERSION, verbose=False)
+    assert os.path.exists(complete_file)


### PR DESCRIPTION
Closes #197 

Mark fully downloaded database flavors in cache with a `.complete` file instead of storing it as metadata in `db.yaml`. This has the advantage that we don't need to acquire the lock for loading those databases.

Note: we still need to acquire the lock when running `audb.dependencies()` as the dependency file is shared among flavors and not stored in the flavor folders.

Backward compatibility:

* When loading a complete database, we still set `db.meta["audb"]["complete"]` in the returned database object so the user sees no difference
* When no `.complete` file can be found we still check `db.yaml` and write a `.complete` file when it has a `db.meta["audb"]["complete"] = True` entry