### PR TITLE
Fix audb.available() on Artifactory backends

### DIFF
--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -96,66 +96,14 @@ def available(
             # as the pool is created lazily on the first request.
             _match_connection_pool_size(backend_interface.backend, workers)
             with backend_interface.backend as backend:
-                if repository.backend == "artifactory":
-                    # The Artifactory backend uses a ``Maven`` interface,
-                    # which stores the version folders and header file under
-                    # ``/<name>/db/<version>/db-<version>.yaml``,
-                    # see ``audb.Repository.create_backend_interface()``.
-                    #
-                    # We do not use ``backend.ls_dirs()``/``backend.exists()``
-                    # here, as each of those calls is slow on Artifactory,
-                    # see https://github.com/audeering/audbackend/issues/132.
-                    # Instead we walk the ``ArtifactoryPath`` objects directly,
-                    # which only requires a single listing per database
-                    # and is significantly faster.
-                    for p in backend.path("/"):
-                        name = p.name
-                        try:
-                            for version in [str(x).split("/")[-1] for x in p / "db"]:
-                                add_database(name, version, repository)
-                        except FileNotFoundError:
-                            # If the ``db`` folder does not exist,
-                            # the dataset is not included
-                            pass
-
+                # The on-backend folder layout depends on the interface,
+                # see ``audb.Repository.create_backend_interface()``.
+                if isinstance(backend_interface, audbackend.interface.Maven):
+                    versions = _collect_versions_maven(backend)
                 else:
-                    # All other backends use a ``Versioned`` interface,
-                    # storing the version folders and header file under
-                    # ``/<name>/<version>/db.yaml``.
-
-                    def version_exists(name, version):
-                        """Check if a database version exists on the backend.
-
-                        A version exists
-                        if the corresponding header file
-                        can be found on the backend.
-
-                        """
-                        header_file = f"/{name}/{version}/{define.HEADER_FILE}"
-                        return backend.exists(header_file)
-
-                    def collect_versions(name):
-                        """Existing versions of a database on the backend.
-
-                        Is limited to the latest with ``latest_version``.
-
-                        """
-                        versions = audeer.sort_versions(
-                            [
-                                v
-                                for v in backend.ls_dirs(f"/{name}/")
-                                if audeer.is_semantic_version(v)
-                            ]
-                        )
-                        existing = [v for v in versions if version_exists(name, v)]
-                        return name, existing
-
-                    names = backend.ls_dirs("/")
-                    max_workers = min(workers, max(1, len(names)))
-                    with concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
-                        for name, versions in pool.map(collect_versions, names):
-                            for version in versions:
-                                add_database(name, version, repository)
+                    versions = _collect_versions_versioned(backend, workers)
+                for name, version in versions:
+                    add_database(name, version, repository)
 
         except (audbackend.BackendError, ValueError):
             continue
@@ -178,6 +126,77 @@ def available(
         df = df.sort_values(by=["version"], key=audeer.sort_versions)
     df = df.sort_values(by=["name"])
     return df.set_index("name")
+
+
+def _collect_versions_maven(backend):
+    r"""Yield ``(name, version)`` for databases on a Maven interface.
+
+    The ``Maven`` interface, used by the Artifactory backend,
+    stores the version folders and header file under
+    ``/<name>/db/<version>/db-<version>.yaml``.
+
+    ``backend.ls_dirs()``/``backend.exists()`` are not used here,
+    as each of those calls is slow on Artifactory,
+    see https://github.com/audeering/audbackend/issues/132.
+    Instead the ``ArtifactoryPath`` objects are walked directly,
+    which only requires a single listing per database
+    and is significantly faster.
+
+    Args:
+        backend: opened backend
+
+    Yields:
+        tuple of database name and version
+
+    """
+    for p in backend.path("/"):
+        name = p.name
+        try:
+            versions = [str(x).split("/")[-1] for x in p / "db"]
+        except FileNotFoundError:
+            # If the ``db`` folder does not exist,
+            # the dataset is not included
+            continue
+        for version in versions:
+            yield name, version
+
+
+def _collect_versions_versioned(backend, workers: int):
+    r"""Yield ``(name, version)`` for databases on a Versioned interface.
+
+    All backends besides Artifactory use a ``Versioned`` interface,
+    which stores the version folders and header file under
+    ``/<name>/<version>/db.yaml``.
+    A version exists
+    if the corresponding header file
+    can be found on the backend.
+
+    Args:
+        backend: opened backend
+        workers: number of parallel workers
+            used to collect the versions
+
+    Yields:
+        tuple of database name and version
+
+    """
+
+    def version_exists(name, version):
+        header_file = f"/{name}/{version}/{define.HEADER_FILE}"
+        return backend.exists(header_file)
+
+    def collect_versions(name):
+        versions = audeer.sort_versions(
+            [v for v in backend.ls_dirs(f"/{name}/") if audeer.is_semantic_version(v)]
+        )
+        return name, [v for v in versions if version_exists(name, v)]
+
+    names = backend.ls_dirs("/")
+    max_workers = min(workers, max(1, len(names)))
+    with concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
+        for name, versions in pool.map(collect_versions, names):
+            for version in versions:
+                yield name, version
 
 
 def _match_connection_pool_size(backend, maxsize: int) -> None:

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -96,40 +96,66 @@ def available(
             # as the pool is created lazily on the first request.
             _match_connection_pool_size(backend_interface.backend, workers)
             with backend_interface.backend as backend:
+                if repository.backend == "artifactory":
+                    # The Artifactory backend uses a ``Maven`` interface,
+                    # which stores the version folders and header file under
+                    # ``/<name>/db/<version>/db-<version>.yaml``,
+                    # see ``audb.Repository.create_backend_interface()``.
+                    #
+                    # We do not use ``backend.ls_dirs()``/``backend.exists()``
+                    # here, as each of those calls is slow on Artifactory,
+                    # see https://github.com/audeering/audbackend/issues/132.
+                    # Instead we walk the ``ArtifactoryPath`` objects directly,
+                    # which only requires a single listing per database
+                    # and is significantly faster.
+                    for p in backend.path("/"):
+                        name = p.name
+                        try:
+                            for version in [str(x).split("/")[-1] for x in p / "db"]:
+                                add_database(name, version, repository)
+                        except FileNotFoundError:
+                            # If the ``db`` folder does not exist,
+                            # the dataset is not included
+                            pass
 
-                def version_exists(name, version):
-                    """Check if a database version exists on the backend.
+                else:
+                    # All other backends use a ``Versioned`` interface,
+                    # storing the version folders and header file under
+                    # ``/<name>/<version>/db.yaml``.
 
-                    A version exists
-                    if the corresponding header file
-                    can be found on the backend.
+                    def version_exists(name, version):
+                        """Check if a database version exists on the backend.
 
-                    """
-                    header_file = f"/{name}/{version}/{define.HEADER_FILE}"
-                    return backend.exists(header_file)
+                        A version exists
+                        if the corresponding header file
+                        can be found on the backend.
 
-                def collect_versions(name):
-                    """Existing versions of a database on the backend.
+                        """
+                        header_file = f"/{name}/{version}/{define.HEADER_FILE}"
+                        return backend.exists(header_file)
 
-                    Is limited to the latest with ``latest_version``.
+                    def collect_versions(name):
+                        """Existing versions of a database on the backend.
 
-                    """
-                    versions = audeer.sort_versions(
-                        [
-                            v
-                            for v in backend.ls_dirs(f"/{name}/")
-                            if audeer.is_semantic_version(v)
-                        ]
-                    )
-                    existing = [v for v in versions if version_exists(name, v)]
-                    return name, existing
+                        Is limited to the latest with ``latest_version``.
 
-                names = backend.ls_dirs("/")
-                max_workers = min(workers, max(1, len(names)))
-                with concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
-                    for name, versions in pool.map(collect_versions, names):
-                        for version in versions:
-                            add_database(name, version, repository)
+                        """
+                        versions = audeer.sort_versions(
+                            [
+                                v
+                                for v in backend.ls_dirs(f"/{name}/")
+                                if audeer.is_semantic_version(v)
+                            ]
+                        )
+                        existing = [v for v in versions if version_exists(name, v)]
+                        return name, existing
+
+                    names = backend.ls_dirs("/")
+                    max_workers = min(workers, max(1, len(names)))
+                    with concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
+                        for name, versions in pool.map(collect_versions, names):
+                            for version in versions:
+                                add_database(name, version, repository)
 
         except (audbackend.BackendError, ValueError):
             continue

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,13 +118,6 @@ class _FakeBackend:
         return _FakeArtifactoryPath(path, self.files)
 
 
-class _FakeInterface:
-    r"""Mimic a backend interface wrapping a ``_FakeBackend``."""
-
-    def __init__(self, backend):
-        self.backend = backend
-
-
 class TestAvailable:
     r"""Test collecting available datasets."""
 
@@ -344,7 +337,7 @@ class TestAvailable:
 
         def create_backend_interface(self):
             if self.backend == "s3":
-                return _FakeInterface(backend)
+                return audbackend.interface.Versioned(backend)
             return original(self)
 
         monkeypatch.setattr(
@@ -412,7 +405,7 @@ class TestAvailable:
         repository = audb.Repository("repo-art", "host-art", "artifactory")
 
         def create_backend_interface(self):
-            return _FakeInterface(backend)
+            return audbackend.interface.Maven(backend)
 
         monkeypatch.setattr(
             audb.Repository, "create_backend_interface", create_backend_interface
@@ -477,7 +470,7 @@ class TestAvailable:
         repository = audb.Repository("repo-custom", "host-custom", "custom")
 
         def create_backend_interface(self):
-            return _FakeInterface(backend)
+            return audbackend.interface.Versioned(backend)
 
         monkeypatch.setattr(
             audb.Repository, "create_backend_interface", create_backend_interface

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import concurrent.futures
 
 import pytest
 
+import audbackend
 import audeer
 import audformat
 
@@ -22,22 +23,77 @@ class _FakeClient:
         self._http = _FakePoolManager()
 
 
-class _FakeBackend:
-    r"""Mimic a MinIO/S3 backend.
+def _children(files, path):
+    r"""Immediate subdirectory names of ``path`` in ``files``."""
+    prefix = "/" if path.strip("/") == "" else "/" + path.strip("/") + "/"
+    return sorted(
+        {
+            file[len(prefix) :].split("/")[0]
+            for file in files
+            if file.startswith(prefix) and "/" in file[len(prefix) :]
+        }
+    )
+
+
+class _FakeArtifactoryPath:
+    r"""Mimic an :class:`artifactory.ArtifactoryPath`.
+
+    Provides just enough behaviour for ``audb.available()``:
+    iterating yields the immediate child paths,
+    ``name`` returns the last path part,
+    ``/`` joins a sub-path,
+    and iterating a non-existing path
+    raises a ``FileNotFoundError``
+    (as the real Artifactory backend does).
 
     Args:
-        folders: mapping of database name
-            to the list of folders stored under it,
-            e.g. ``{"db": ["1.0.0", "media"]}``
-        headers: mapping of database name
-            to the list of versions
-            for which a header file exists
+        path: backend path
+        files: backend paths of all files stored on the backend
 
     """
 
-    def __init__(self, folders, headers):
-        self.folders = folders
-        self.headers = headers
+    def __init__(self, path, files):
+        self.path = "/" + path.strip("/") if path.strip("/") else "/"
+        self.files = files
+
+    @property
+    def name(self):
+        return self.path.rstrip("/").split("/")[-1]
+
+    def __str__(self):
+        return self.path
+
+    def __truediv__(self, other):
+        return _FakeArtifactoryPath(f"{self.path.rstrip('/')}/{other}", self.files)
+
+    def __iter__(self):
+        prefix = "/" if self.path == "/" else self.path.rstrip("/") + "/"
+        if not any(file.startswith(prefix) for file in self.files):
+            raise FileNotFoundError(self.path)
+        for child in _children(self.files, self.path):
+            yield _FakeArtifactoryPath(prefix + child, self.files)
+
+
+class _FakeBackend:
+    r"""Mimic a backend storing a fixed set of files.
+
+    ``ls_dirs()``, ``exists()`` and ``path()`` are derived
+    from the given list of file paths,
+    so the fake faithfully reproduces
+    the on-backend folder structure,
+    including the different layouts of the
+    ``Versioned`` interface (``/<name>/<version>/db.yaml``)
+    and the ``Maven`` interface used by Artifactory
+    (``/<name>/db/<version>/db-<version>.yaml``).
+
+    Args:
+        files: backend paths of all files stored on the backend,
+            e.g. ``["/name/1.0.0/db.yaml"]``
+
+    """
+
+    def __init__(self, files):
+        self.files = ["/" + file.strip("/") for file in files]
         self._client = _FakeClient()
 
     def __enter__(self):
@@ -46,18 +102,20 @@ class _FakeBackend:
     def __exit__(self, *args):
         return False
 
-    def ls_dirs(self, path):
-        path = path.strip("/")
-        if path == "":
-            # Top level: database names
-            return list(self.folders)
-        # Sub level: folders under the database
-        return self.folders[path]
+    def ls_dirs(self, path, *, suppress_backend_errors=False):
+        prefix = "/" if path.strip("/") == "" else "/" + path.strip("/") + "/"
+        path_exists = prefix == "/" or any(
+            file.startswith(prefix) for file in self.files
+        )
+        if not path_exists and not suppress_backend_errors:
+            raise audbackend.BackendError(FileNotFoundError(prefix))
+        return _children(self.files, path)
 
     def exists(self, path):
-        # ``path`` has the form ``/<name>/<version>/db.yaml``
-        name, version = path.strip("/").split("/")[:2]
-        return version in self.headers.get(name, [])
+        return ("/" + path.strip("/")) in self.files
+
+    def path(self, path):
+        return _FakeArtifactoryPath(path, self.files)
 
 
 class _FakeInterface:
@@ -274,9 +332,13 @@ class TestAvailable:
             so its connection pool can be inspected
 
         """
-        folders = {"name-s3": ["1.0.0", "2.0.0", "3.0.0", "media"]}
-        headers = {"name-s3": ["1.0.0", "2.0.0"]}
-        backend = _FakeBackend(folders, headers)
+        files = [
+            "/name-s3/1.0.0/db.yaml",  # proper version
+            "/name-s3/2.0.0/db.yaml",  # proper version
+            "/name-s3/3.0.0/db.zip",  # version folder without header
+            "/name-s3/media/file.wav",  # non-version folder
+        ]
+        backend = _FakeBackend(files)
 
         original = audb.Repository.create_backend_interface
 
@@ -324,7 +386,77 @@ class TestAvailable:
     def artifactory_repository(self, monkeypatch):
         """Add an Artifactory repository served by a fake backend.
 
-        ``artifactory`` is not in the thread-safe allowlist,
+        The Artifactory backend uses a ``Maven`` interface,
+        which stores files under
+        ``/<name>/db/<version>/db-<version>.yaml``,
+        a different layout than all other backends,
+        see https://github.com/audeering/audb/issues/571.
+
+        Yields:
+            the repository
+
+        """
+        files = [
+            # Maven layout: ``/<name>/db/<version>/db-<version>.yaml``
+            "/db-a/db/1.0.0/db-1.0.0.yaml",
+            "/db-a/db/2.0.0/db-2.0.0.yaml",
+            "/db-b/db/1.0.0/db-1.0.0.yaml",
+            # Other interface folders next to ``db``,
+            # which must not be mistaken for version folders
+            "/db-a/meta/db/1.0.0/db.zip",
+            "/db-a/media/db/1.0.0/file.wav",
+            # Dataset without a ``db`` folder, which is not included
+            "/db-c/attachment/file.txt",
+        ]
+        backend = _FakeBackend(files)
+        repository = audb.Repository("repo-art", "host-art", "artifactory")
+
+        def create_backend_interface(self):
+            return _FakeInterface(backend)
+
+        monkeypatch.setattr(
+            audb.Repository, "create_backend_interface", create_backend_interface
+        )
+        yield repository
+
+    @pytest.mark.parametrize(
+        "only_latest, expected_index, expected_versions",
+        [
+            (False, ["db-a", "db-a", "db-b"], ["1.0.0", "2.0.0", "1.0.0"]),
+            (True, ["db-a", "db-b"], ["2.0.0", "1.0.0"]),
+        ],
+    )
+    def test_artifactory_backend(
+        self,
+        artifactory_repository,
+        only_latest,
+        expected_index,
+        expected_versions,
+    ):
+        """Test collecting versions from an Artifactory backend.
+
+        The ``Maven`` interface stores versions under a ``db`` subfolder,
+        which broke ``audb.available()`` in v1.12.0,
+        see https://github.com/audeering/audb/issues/571.
+
+        Args:
+            artifactory_repository: artifactory_repository fixture
+            only_latest: only_latest argument of audb.available()
+            expected_index: expected database names in the index
+            expected_versions: expected versions
+
+        """
+        df = audb.available(
+            only_latest=only_latest, repositories=artifactory_repository
+        )
+        assert list(df.index) == expected_index
+        assert list(df["version"]) == expected_versions
+
+    @pytest.fixture(scope="function", autouse=False)
+    def custom_backend_repository(self, monkeypatch):
+        """Add a repository served by a custom, non-thread-safe backend.
+
+        A custom backend is not part of the thread-safe allowlist,
         so ``audb.available()`` must access it
         with a single worker,
         regardless of ``num_workers``.
@@ -336,10 +468,13 @@ class TestAvailable:
             tuple of the fake backend instance and the repository
 
         """
-        folders = {"db-a": ["1.0.0", "2.0.0"], "db-b": ["1.0.0"]}
-        headers = {"db-a": ["1.0.0", "2.0.0"], "db-b": ["1.0.0"]}
-        backend = _FakeBackend(folders, headers)
-        repository = audb.Repository("repo-art", "host-art", "artifactory")
+        files = [
+            "/db-a/1.0.0/db.yaml",
+            "/db-a/2.0.0/db.yaml",
+            "/db-b/1.0.0/db.yaml",
+        ]
+        backend = _FakeBackend(files)
+        repository = audb.Repository("repo-custom", "host-custom", "custom")
 
         def create_backend_interface(self):
             return _FakeInterface(backend)
@@ -350,16 +485,16 @@ class TestAvailable:
         yield backend, repository
 
     def test_non_thread_safe_backend_single_worker(
-        self, artifactory_repository, monkeypatch
+        self, custom_backend_repository, monkeypatch
     ):
         """Test non-thread-safe backends are accessed with a single worker.
 
         Args:
-            artifactory_repository: artifactory_repository fixture
+            custom_backend_repository: custom_backend_repository fixture
             monkeypatch: monkeypatch fixture
 
         """
-        backend, repository = artifactory_repository
+        backend, repository = custom_backend_repository
 
         # Record the number of workers requested from the thread pool
         requested_workers = []


### PR DESCRIPTION
Closes #571 

In https://github.com/audeering/audb/pull/566 we simplified `audb.available()` to the same approach for all backends, but forgot that the Artifactory backend is storing its fails as Maven, not as Versioned interface as all other backends.

This was not covered by the tests as we do not use a real Artifactory server for testing, but mock one.

The code for Artifactory is reverted back here to how it was before.