### PR TITLE
Remove support for Artifactory backends

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,7 @@ and manages different versions of a database.
 Databases are stored in repositories
 on local file systems,
 MinIO_,
-S3_,
-or Artifactory_ servers.
+or S3_.
 
 You can request resampling or remixing of audio content
 and filter the downloaded data,
@@ -44,7 +43,6 @@ If you want to cite **audb**, you can refer to our paper_:
     }
 
 
-.. _Artifactory: https://jfrog.com/artifactory/
 .. _common format: https://audeering.github.io/audformat/
 .. _installation: https://audeering.github.io/audb/install.html
 .. _MinIO: https://min.io

--- a/audb/core/api.py
+++ b/audb/core/api.py
@@ -24,16 +24,8 @@ from audb.core.lock import FolderLock
 from audb.core.repository import Repository
 
 
-# Backends whose read operations (``ls_dirs``/``exists``)
-# are safe to call concurrently from multiple threads,
-# and that benefit from doing so:
-# ``file-system`` uses stateless ``os`` calls,
-# ``minio``/``s3`` use the MinIO client,
-# which is documented as thread-safe under ``threading``.
-# Other backends (e.g. ``artifactory``, or custom ones
-# registered via ``Repository.register``) are accessed
-# with a single worker to avoid sharing a potentially
-# non-thread-safe client across threads.
+# Backends whose read operations are thread-safe.
+# Skip custom backends, for which we don't have this information.
 _THREAD_SAFE_BACKENDS = ("file-system", "minio", "s3")
 
 
@@ -96,12 +88,7 @@ def available(
             # as the pool is created lazily on the first request.
             _match_connection_pool_size(backend_interface.backend, workers)
             with backend_interface.backend as backend:
-                # The on-backend folder layout depends on the interface,
-                # see ``audb.Repository.create_backend_interface()``.
-                if isinstance(backend_interface, audbackend.interface.Maven):
-                    versions = _collect_versions_maven(backend)
-                else:
-                    versions = _collect_versions_versioned(backend, workers)
+                versions = _collect_versions(backend, workers)
                 for name, version in versions:
                     add_database(name, version, repository)
 
@@ -128,43 +115,10 @@ def available(
     return df.set_index("name")
 
 
-def _collect_versions_maven(backend):
-    r"""Yield ``(name, version)`` for databases on a Maven interface.
+def _collect_versions(backend, workers: int):
+    r"""Yield ``(name, version)`` for all databases in a repository.
 
-    The ``Maven`` interface, used by the Artifactory backend,
-    stores the version folders and header file under
-    ``/<name>/db/<version>/db-<version>.yaml``.
-
-    ``backend.ls_dirs()``/``backend.exists()`` are not used here,
-    as each of those calls is slow on Artifactory,
-    see https://github.com/audeering/audbackend/issues/132.
-    Instead the ``ArtifactoryPath`` objects are walked directly,
-    which only requires a single listing per database
-    and is significantly faster.
-
-    Args:
-        backend: opened backend
-
-    Yields:
-        tuple of database name and version
-
-    """
-    for p in backend.path("/"):
-        name = p.name
-        try:
-            versions = [str(x).split("/")[-1] for x in p / "db"]
-        except FileNotFoundError:
-            # If the ``db`` folder does not exist,
-            # the dataset is not included
-            continue
-        for version in versions:
-            yield name, version
-
-
-def _collect_versions_versioned(backend, workers: int):
-    r"""Yield ``(name, version)`` for databases on a Versioned interface.
-
-    All backends besides Artifactory use a ``Versioned`` interface,
+    All backends use a ``Versioned`` interface,
     which stores the version folders and header file under
     ``/<name>/<version>/db.yaml``.
     A version exists
@@ -706,44 +660,11 @@ def versions(
     for repository in config.REPOSITORIES:
         try:
             backend_interface = repository.create_backend_interface()
-            with backend_interface.backend as backend:
-                if repository.backend == "artifactory":  # pragma: nocover
-                    # Do not use `backend_interface.versions()` on Artifactory,
-                    # as calling `backend_interface.ls()` is slow on Artifactory,
-                    # see https://github.com/devopshq/artifactory/issues/423.
-                    # Instead, use `backend.path()`
-                    # from the low level backend object
-                    # to return an ArtifactoryPath object,
-                    # which allows to walk through the dataset directory
-                    # and to collect all existing versions.
-                    folder = backend.join("/", name, "db")
-                    path = backend.path(folder)
-                    try:
-                        if path.exists():
-                            for p in path:
-                                version = p.parts[-1]
-                                header = p.joinpath(f"db-{version}.yaml")
-                                if header.exists():
-                                    vs.extend([version])
-                    except Exception:
-                        # Might happen,
-                        # if a database is not available on the backend,
-                        # or we don't have read permissions.
-                        #
-                        # We cannot test this at the moment
-                        # on the public Artifactory server.
-                        # Because after trying
-                        # to connect to a path without read access
-                        # the connection is also blocked for valid paths.
-                        pass
-                else:
-                    header = backend_interface.join("/", name, "db.yaml")
-                    vs.extend(
-                        backend_interface.versions(
-                            header,
-                            suppress_backend_errors=True,
-                        )
-                    )
+            with backend_interface.backend:
+                header = backend_interface.join("/", name, "db.yaml")
+                vs.extend(
+                    backend_interface.versions(header, suppress_backend_errors=True)
+                )
         except (audbackend.BackendError, ValueError):
             # If the backend cannot be accessed,
             # e.g. host or repository do not exist,

--- a/audb/core/conftest.py
+++ b/audb/core/conftest.py
@@ -60,7 +60,7 @@ def cache(tmpdir_factory):
 
 @pytest.fixture(autouse=True)
 def public_repository():
-    r"""Provide access to the public Artifactory repository."""
+    r"""Provide access to the public repository."""
     audb.config.REPOSITORIES = [
         audb.Repository(
             name="audb-public",

--- a/audb/core/define.py
+++ b/audb/core/define.py
@@ -1,9 +1,6 @@
 import os
 
 
-# First Python version without Artifactory support
-PYTHON_VERSION_WITHOUT_ARTIFACTORY = "3.14"
-
 # Configuration files
 CONFIG_FILE = os.path.join("etc", "audb.yaml")
 USER_CONFIG_FILE = "~/.config/audb.yaml"

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -716,7 +716,6 @@ def publish(
         ValueError: if ``version`` or ``previous_version``
             cannot be parsed by :class:`audeer.StrictVersion`
         ValueError: if ``previous_version`` >= ``version``
-        ValueError: if ``repository`` has artifactory as backend in Python>=3.13
         ValueError: if ``repository`` has a non-supported backend
 
     """

--- a/audb/core/repository.py
+++ b/audb/core/repository.py
@@ -1,8 +1,4 @@
-import sys
-
 import audbackend
-
-from audb.core.define import PYTHON_VERSION_WITHOUT_ARTIFACTORY
 
 
 class Repository:
@@ -34,9 +30,6 @@ class Repository:
         "minio": audbackend.backend.Minio,
         "s3": audbackend.backend.Minio,
     }
-
-    if hasattr(audbackend.backend, "Artifactory"):
-        _backends["artifactory"] = audbackend.backend.Artifactory  # pragma: no cover
 
     backend_registry = _backends
     r"""Backend registry.
@@ -98,19 +91,6 @@ class Repository:
             emodb/media/1.0.0/...          <-- media files
             emodb/meta/1.0.0/...           <-- tables
 
-        When :attr:`Repository.backend` equals ``artifactory``,
-        it wraps an :class:`audbackend.interface.Maven` interface
-        around it.
-        The files will then be stored
-        with the following structure on the Artifactory backend
-        (shown by the example of version 1.0.0 of the emodb dataset)::
-
-            emodb/db/1.0.0/db-1.0.0.yaml   <-- header
-            emodb/db/1.0.0/db-1.0.0.zip    <-- dependency table
-            emodb/attachment/.../1.0.0/... <-- attachments
-            emodb/media/.../1.0.0/...      <-- media files
-            emodb/meta/.../1.0.0/...       <-- tables
-
         The returned backend instance
         has not yet established a connection to the backend.
         To establish a connection,
@@ -123,27 +103,14 @@ class Repository:
             interface to repository
 
         Raises:
-            ValueError: if an artifactory backend is requested in with a Python version
-                that does not yet support it
             ValueError: if a non-supported backend is requested
 
         """
-        version_tuple = tuple(
-            int(x) for x in PYTHON_VERSION_WITHOUT_ARTIFACTORY.split(".")
-        )
-        if sys.version_info >= version_tuple and self.backend == "artifactory":
-            raise ValueError(  # pragma: no cover
-                "The 'artifactory' backend is not supported in "
-                f"Python>={PYTHON_VERSION_WITHOUT_ARTIFACTORY}"
-            )
         if self.backend not in self.backend_registry:
             raise ValueError(f"'{self.backend}' is not a registered backend")
         backend_class = self.backend_registry[self.backend]
         backend = backend_class(self.host, self.name)
-        if self.backend == "artifactory":
-            interface = audbackend.interface.Maven(backend)  # pragma: no cover
-        else:
-            interface = audbackend.interface.Versioned(backend)
+        interface = audbackend.interface.Versioned(backend)
         return interface
 
     @classmethod

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1,10 +1,8 @@
 Authentication
 ==============
 
-Using Artifactory,
-MinIO or S3
+Using MinIO or S3
 as backend
 might require authentication.
 For more information,
-see :class:`audbackend.backend.Artifactory`
-and :class:`audbackend.backend.Minio` (for MinIO and S3).
+see :class:`audbackend.backend.Minio`.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -31,9 +31,7 @@ to communicate with the underlying backend.
 At the moment,
 it supports to store the data
 in a folder on a local file system,
-in a bucket on MinIO_ or S3_ storage,
-or inside a `Generic repository`_
-on an `Artifactory server`_.
+or in a bucket on MinIO_ or S3_.
 
 You could easily expand this,
 by adding your own backend
@@ -92,8 +90,6 @@ the following operations are performed:
 .. graphviz:: pics/load.dot
 
 
-.. _Artifactory server: https://jfrog.com/artifactory/
-.. _Generic repository: https://jfrog.com/help/r/jfrog-artifactory-documentation/repository-management
 .. _implements the required functions: https://github.com/audeering/audbackend/blob/edd23462799ae9052a43cdd045698f78e19dbcaf/audbackend/core/backend.py#L559-L659
 .. _MinIO: https://min.io
 .. _S3: https://aws.amazon.com/s3/

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -279,7 +279,7 @@ and let a database grow every day.
 Real world example
 ------------------
 
-We published a version of a small German acted emotional speech databases
+We published a version of a small German acted emotional speech database
 called emodb_
 in the public repository of :mod:`audb`.
 You can find the example code at

--- a/docs/publish.rst
+++ b/docs/publish.rst
@@ -144,11 +144,8 @@ the database header in the file ``db.yaml``,
 and the database dependencies
 in the file ``db.parquet``.
 Note,
-that the structure of the folders
-used for versioning
-:meth:`depends on the backend <audb.Repository.create_backend_interface>`,
-and differs slightly
-for an Artifactory backend.
+the structure of the folders
+is managed by :class:`audbackend.interface.Versioned`.
 
 To load the database,
 or see which databases are available in your repository,
@@ -284,7 +281,7 @@ Real world example
 
 We published a version of a small German acted emotional speech databases
 called emodb_
-in the default Artifactory repository of :mod:`audb`.
+in the public repository of :mod:`audb`.
 You can find the example code at
 https://github.com/audeering/emodb
 and can continue at :ref:`load`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import platform
-import sys
 
 import pytest
 
@@ -194,11 +193,8 @@ def private_and_public_repository():
 
     Configure the following repositories:
 
-    * data-private: repo on public Artifactory without access
     * audb-private: repo on public S3 without access
-    * data-public: repo on public Artifactory with anonymous access
     * audb-public: repo on public S3 with anonymous access
-    * data-public2: repo on public Artifactory with anonymous access
 
     Note, that the order of the repos is important.
     audb will visit the repos in the given order
@@ -206,18 +202,11 @@ def private_and_public_repository():
 
     """
     current_repositories = audb.config.REPOSITORIES
-    public_artifactory_host = "https://audeering.jfrog.io/artifactory"
     public_s3_host = "s3.dualstack.eu-north-1.amazonaws.com"
     audb.config.REPOSITORIES = [
         audb.Repository("audb-private", public_s3_host, "s3"),
         audb.Repository("audb-public", public_s3_host, "s3"),
     ]
-    if sys.version_info < (3, 13):
-        audb.config.REPOSITORIES += [
-            audb.Repository("data-private", public_artifactory_host, "artifactory"),
-            audb.Repository("data-public", public_artifactory_host, "artifactory"),
-            audb.Repository("data-public2", public_artifactory_host, "artifactory"),
-        ]
 
     yield repository
 
@@ -229,8 +218,8 @@ def non_existing_repository():
     r"""Non-existing repository.
 
     Configure the following repositories:
-    * non-existing: non-exsiting repo on public Artifactory
-    * audb-public: repo on public Artifactory with anonymous access
+    * non-existing: non-exsiting repo on public backend
+    * audb-public: repo on public backend with anonymous access
 
     Note, that the order of the repos is important.
     audb will visit the repos in the given order

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,56 +35,14 @@ def _children(files, path):
     )
 
 
-class _FakeArtifactoryPath:
-    r"""Mimic an :class:`artifactory.ArtifactoryPath`.
-
-    Provides just enough behaviour for ``audb.available()``:
-    iterating yields the immediate child paths,
-    ``name`` returns the last path part,
-    ``/`` joins a sub-path,
-    and iterating a non-existing path
-    raises a ``FileNotFoundError``
-    (as the real Artifactory backend does).
-
-    Args:
-        path: backend path
-        files: backend paths of all files stored on the backend
-
-    """
-
-    def __init__(self, path, files):
-        self.path = "/" + path.strip("/") if path.strip("/") else "/"
-        self.files = files
-
-    @property
-    def name(self):
-        return self.path.rstrip("/").split("/")[-1]
-
-    def __str__(self):
-        return self.path
-
-    def __truediv__(self, other):
-        return _FakeArtifactoryPath(f"{self.path.rstrip('/')}/{other}", self.files)
-
-    def __iter__(self):
-        prefix = "/" if self.path == "/" else self.path.rstrip("/") + "/"
-        if not any(file.startswith(prefix) for file in self.files):
-            raise FileNotFoundError(self.path)
-        for child in _children(self.files, self.path):
-            yield _FakeArtifactoryPath(prefix + child, self.files)
-
-
 class _FakeBackend:
     r"""Mimic a backend storing a fixed set of files.
 
-    ``ls_dirs()``, ``exists()`` and ``path()`` are derived
+    ``ls_dirs()`` and ``exists()`` are derived
     from the given list of file paths,
     so the fake faithfully reproduces
-    the on-backend folder structure,
-    including the different layouts of the
-    ``Versioned`` interface (``/<name>/<version>/db.yaml``)
-    and the ``Maven`` interface used by Artifactory
-    (``/<name>/db/<version>/db-<version>.yaml``).
+    the on-backend folder structure
+    (``/<name>/<version>/db.yaml``).
 
     Args:
         files: backend paths of all files stored on the backend,
@@ -113,9 +71,6 @@ class _FakeBackend:
 
     def exists(self, path):
         return ("/" + path.strip("/")) in self.files
-
-    def path(self, path):
-        return _FakeArtifactoryPath(path, self.files)
 
 
 class TestAvailable:
@@ -170,20 +125,6 @@ class TestAvailable:
         repository = audb.config.REPOSITORIES[0]
         audb.config.REPOSITORIES.append(
             audb.Repository("non-existing", repository.host, "file-system")
-        )
-        yield
-        audb.config.REPOSITORIES = audb.config.REPOSITORIES[:-1]
-
-    @pytest.fixture(scope="function", autouse=False)
-    def non_existing_artifactory_host(self):
-        """Add non-existing host on Artifactory backend.
-
-        This should also not fail under Python 3.12,
-        which no longher supports Artifactory.
-
-        """
-        audb.config.REPOSITORIES.append(
-            audb.Repository("repo", "https:artifactory.url.com", "artifactory")
         )
         yield
         audb.config.REPOSITORIES = audb.config.REPOSITORIES[:-1]
@@ -265,13 +206,6 @@ class TestAvailable:
 
     def test_non_existing_repository(self, non_existing_repository):
         """Test having a non-existing repository in config."""
-        df = audb.available()
-        assert len(df) == 2
-        assert "name0" in df.index
-        assert "name1" in df.index
-
-    def test_non_existing_artifactory_host(self, non_existing_artifactory_host):
-        """Test having a non-existing host on an Artifactory backend."""
         df = audb.available()
         assert len(df) == 2
         assert "name0" in df.index
@@ -374,76 +308,6 @@ class TestAvailable:
         # The HTTP connection pool size is matched to num_workers
         pool_kw = minio_repository._client._http.connection_pool_kw
         assert pool_kw["maxsize"] == num_workers
-
-    @pytest.fixture(scope="function", autouse=False)
-    def artifactory_repository(self, monkeypatch):
-        """Add an Artifactory repository served by a fake backend.
-
-        The Artifactory backend uses a ``Maven`` interface,
-        which stores files under
-        ``/<name>/db/<version>/db-<version>.yaml``,
-        a different layout than all other backends,
-        see https://github.com/audeering/audb/issues/571.
-
-        Yields:
-            the repository
-
-        """
-        files = [
-            # Maven layout: ``/<name>/db/<version>/db-<version>.yaml``
-            "/db-a/db/1.0.0/db-1.0.0.yaml",
-            "/db-a/db/2.0.0/db-2.0.0.yaml",
-            "/db-b/db/1.0.0/db-1.0.0.yaml",
-            # Other interface folders next to ``db``,
-            # which must not be mistaken for version folders
-            "/db-a/meta/db/1.0.0/db.zip",
-            "/db-a/media/db/1.0.0/file.wav",
-            # Dataset without a ``db`` folder, which is not included
-            "/db-c/attachment/file.txt",
-        ]
-        backend = _FakeBackend(files)
-        repository = audb.Repository("repo-art", "host-art", "artifactory")
-
-        def create_backend_interface(self):
-            return audbackend.interface.Maven(backend)
-
-        monkeypatch.setattr(
-            audb.Repository, "create_backend_interface", create_backend_interface
-        )
-        yield repository
-
-    @pytest.mark.parametrize(
-        "only_latest, expected_index, expected_versions",
-        [
-            (False, ["db-a", "db-a", "db-b"], ["1.0.0", "2.0.0", "1.0.0"]),
-            (True, ["db-a", "db-b"], ["2.0.0", "1.0.0"]),
-        ],
-    )
-    def test_artifactory_backend(
-        self,
-        artifactory_repository,
-        only_latest,
-        expected_index,
-        expected_versions,
-    ):
-        """Test collecting versions from an Artifactory backend.
-
-        The ``Maven`` interface stores versions under a ``db`` subfolder,
-        which broke ``audb.available()`` in v1.12.0,
-        see https://github.com/audeering/audb/issues/571.
-
-        Args:
-            artifactory_repository: artifactory_repository fixture
-            only_latest: only_latest argument of audb.available()
-            expected_index: expected database names in the index
-            expected_versions: expected versions
-
-        """
-        df = audb.available(
-            only_latest=only_latest, repositories=artifactory_repository
-        )
-        assert list(df.index) == expected_index
-        assert list(df["version"]) == expected_versions
 
     @pytest.fixture(scope="function", autouse=False)
     def custom_backend_repository(self, monkeypatch):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,21 +1,8 @@
-import sys
-
 import pytest
 
 import audbackend
 
 import audb
-from audb.core.define import PYTHON_VERSION_WITHOUT_ARTIFACTORY
-
-
-PYTHON_VERSION_WITHOUT_ARTIFACTORY_TUPLE = tuple(
-    int(x) for x in PYTHON_VERSION_WITHOUT_ARTIFACTORY.split(".")
-)
-
-if hasattr(audbackend.backend, "Artifactory"):
-    artifactory_backend = audbackend.backend.Artifactory
-else:
-    artifactory_backend = None
 
 
 @pytest.mark.parametrize(
@@ -144,20 +131,6 @@ def test_repository_repr(backend, host, repo, expected):
             audbackend.backend.FileSystem,
             audbackend.interface.Versioned,
         ),
-        pytest.param(
-            "artifactory",
-            "host",
-            "repo",
-            artifactory_backend,
-            audbackend.interface.Maven,
-            marks=pytest.mark.skipif(
-                sys.version_info >= PYTHON_VERSION_WITHOUT_ARTIFACTORY_TUPLE,
-                reason=(
-                    "No artifactory backend support in "
-                    f"Python>={PYTHON_VERSION_WITHOUT_ARTIFACTORY}"
-                ),
-            ),
-        ),
     ],
 )
 def test_repository_create_backend_interface(
@@ -193,22 +166,6 @@ def test_repository_create_backend_interface(
             "repo",
             "'custom' is not a registered backend",
             ValueError,
-        ),
-        pytest.param(
-            "artifactory",
-            "host",
-            "repo",
-            (
-                "The 'artifactory' backend is not supported in "
-                f"Python>={PYTHON_VERSION_WITHOUT_ARTIFACTORY}"
-            ),
-            ValueError,
-            marks=pytest.mark.skipif(
-                sys.version_info < PYTHON_VERSION_WITHOUT_ARTIFACTORY_TUPLE,
-                reason=(
-                    f"Should only fail for Python>={PYTHON_VERSION_WITHOUT_ARTIFACTORY}"
-                ),
-            ),
         ),
     ],
 )


### PR DESCRIPTION
Remove support for Artifactory backends, which will also no longer be supported by `audbackend` (https://github.com/audeering/audbackend/pull/296).