### PR TITLE
Fix publish() looking for previous versions

### DIFF
--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -797,28 +797,23 @@ def _publish(
         # We search the union of ``audb.config.REPOSITORIES`` + ``repository``.
         all_versions = audeer.sort_versions(list(set(api_versions(db.name) + versions)))
         previous_version = all_versions[-1] if len(all_versions) > 0 else None
-    # Check repository consistency when previous_version is specified.
-    #
-    # If the previous version is already stored in the target repository,
-    # publishing does not split the database across repositories,
-    # so no further lookup is needed.
+    # Check previous_version is in same repository
     if previous_version is not None and previous_version not in versions:
         previous_repository = utils._lookup(db.name, previous_version)[0]
-        if previous_repository != repository:
-            raise RuntimeError(
-                f"Cannot publish version '{version}' "
-                f"to repository '{repository.name}' "
-                f"based on previous version '{previous_version}'. "
-                "The previous version is stored in repository "
-                f"'{previous_repository.name}'. "
-                "Publishing to a different repository would split the database "
-                "across multiple repositories, "
-                "which can create data privacy risks "
-                "and is not supported. "
-                "Use previous_version=None "
-                f"to start a new database in '{repository.name}' "
-                f"or publish to the same repository '{previous_repository.name}'."
-            )
+        raise RuntimeError(
+            f"Cannot publish version '{version}' "
+            f"to repository '{repository.name}' "
+            f"based on previous version '{previous_version}'. "
+            "The previous version is stored in repository "
+            f"'{previous_repository.name}'. "
+            "Publishing to a different repository would split the database "
+            "across multiple repositories, "
+            "which can create data privacy risks "
+            "and is not supported. "
+            "Use previous_version=None "
+            f"to start a new database in '{repository.name}' "
+            f"or publish to the same repository '{previous_repository.name}'."
+        )
 
     # load database and dependencies
     deps = Dependencies()

--- a/audb/core/publish.py
+++ b/audb/core/publish.py
@@ -793,11 +793,16 @@ def _publish(
             f"A version '{version}' already exists for database '{db.name}'."
         )
     if previous_version == "latest":
-        # Find latest version across all repositories (like audb.latest_version)
-        all_versions = api_versions(db.name)
+        # Resolve to the latest version of the database.
+        # We search the union of ``audb.config.REPOSITORIES`` + ``repository``.
+        all_versions = audeer.sort_versions(list(set(api_versions(db.name) + versions)))
         previous_version = all_versions[-1] if len(all_versions) > 0 else None
-    # Check repository consistency when previous_version is specified
-    if previous_version is not None:
+    # Check repository consistency when previous_version is specified.
+    #
+    # If the previous version is already stored in the target repository,
+    # publishing does not split the database across repositories,
+    # so no further lookup is needed.
+    if previous_version is not None and previous_version not in versions:
         previous_repository = utils._lookup(db.name, previous_version)[0]
         if previous_repository != repository:
             raise RuntimeError(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -634,7 +634,7 @@ def test_publish_change_archive(tmpdir, dbs, repository):
     )
 
 
-def test_publish_previous_version_latest_not_in_config(tmpdir, dbs):
+def test_publish_previous_version_latest_not_in_config(tmpdir, dbs, monkeypatch):
     """Publish with ``previous_version='latest'`` for an unregistered repo.
 
     Regression test for
@@ -651,45 +651,42 @@ def test_publish_previous_version_latest_not_in_config(tmpdir, dbs):
     repository = audb.Repository(name=name, host=host, backend="file-system")
     audeer.mkdir(host, name)
 
-    current_repositories = audb.config.REPOSITORIES
-    try:
-        # Publish version 1.0.0 with the repository registered globally,
-        # so that it can be loaded again below.
-        audb.config.REPOSITORIES = [repository]
-        build_dir = audeer.path(tmpdir, "build")
-        shutil.copytree(dbs["1.0.0"], build_dir)
-        audb.publish(
-            build_dir,
-            "1.0.0",
-            repository,
-            previous_version=None,
-            verbose=False,
-        )
+    # Publish version 1.0.0 with the repository registered globally,
+    # so that it can be loaded again below.
+    # ``monkeypatch`` restores ``audb.config.REPOSITORIES`` after the test.
+    monkeypatch.setattr(audb.config, "REPOSITORIES", [repository])
+    build_dir = audeer.path(tmpdir, "build")
+    shutil.copytree(dbs["1.0.0"], build_dir)
+    audb.publish(
+        build_dir,
+        "1.0.0",
+        repository,
+        previous_version=None,
+        verbose=False,
+    )
 
-        # Recreate the build dir in the state a user has
-        # before publishing a follow-up version:
-        # loading the previous version writes
-        # the dependency file into the build dir.
-        audeer.rmdir(build_dir)
-        db = audb.load_to(build_dir, DB_NAME, version="1.0.0", verbose=False)
-        db.save(build_dir)
-        assert os.path.exists(audeer.path(build_dir, "db.parquet"))
+    # Recreate the build dir in the state a user has
+    # before publishing a follow-up version:
+    # loading the previous version writes
+    # the dependency file into the build dir.
+    audeer.rmdir(build_dir)
+    db = audb.load_to(build_dir, DB_NAME, version="1.0.0", verbose=False)
+    db.save(build_dir)
+    assert os.path.exists(audeer.path(build_dir, "db.parquet"))
 
-        # The target repository is now *not* part of the global config.
-        audb.config.REPOSITORIES = []
-        audb.publish(
-            build_dir,
-            "2.0.0",
-            repository,
-            previous_version="latest",
-            verbose=False,
-        )
+    # The target repository is now *not* part of the global config.
+    monkeypatch.setattr(audb.config, "REPOSITORIES", [])
+    audb.publish(
+        build_dir,
+        "2.0.0",
+        repository,
+        previous_version="latest",
+        verbose=False,
+    )
 
-        # Version 2.0.0 was published on top of 1.0.0.
-        audb.config.REPOSITORIES = [repository]
-        assert "2.0.0" in audb.versions(DB_NAME)
-    finally:
-        audb.config.REPOSITORIES = current_repositories
+    # Version 2.0.0 was published on top of 1.0.0.
+    monkeypatch.setattr(audb.config, "REPOSITORIES", [repository])
+    assert "2.0.0" in audb.versions(DB_NAME)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -634,6 +634,64 @@ def test_publish_change_archive(tmpdir, dbs, repository):
     )
 
 
+def test_publish_previous_version_latest_not_in_config(tmpdir, dbs):
+    """Publish with ``previous_version='latest'`` for an unregistered repo.
+
+    Regression test for
+    https://github.com/audeering/audb/issues/519.
+
+    ``previous_version='latest'`` has to be resolved against the repository
+    that is passed to :func:`audb.publish`,
+    even when that repository is not part of
+    the globally configured ``audb.config.REPOSITORIES``.
+
+    """
+    host = audeer.mkdir(tmpdir, "host")
+    name = "data-unittests-local"
+    repository = audb.Repository(name=name, host=host, backend="file-system")
+    audeer.mkdir(host, name)
+
+    current_repositories = audb.config.REPOSITORIES
+    try:
+        # Publish version 1.0.0 with the repository registered globally,
+        # so that it can be loaded again below.
+        audb.config.REPOSITORIES = [repository]
+        build_dir = audeer.path(tmpdir, "build")
+        shutil.copytree(dbs["1.0.0"], build_dir)
+        audb.publish(
+            build_dir,
+            "1.0.0",
+            repository,
+            previous_version=None,
+            verbose=False,
+        )
+
+        # Recreate the build dir in the state a user has
+        # before publishing a follow-up version:
+        # loading the previous version writes
+        # the dependency file into the build dir.
+        audeer.rmdir(build_dir)
+        db = audb.load_to(build_dir, DB_NAME, version="1.0.0", verbose=False)
+        db.save(build_dir)
+        assert os.path.exists(audeer.path(build_dir, "db.parquet"))
+
+        # The target repository is now *not* part of the global config.
+        audb.config.REPOSITORIES = []
+        audb.publish(
+            build_dir,
+            "2.0.0",
+            repository,
+            previous_version="latest",
+            verbose=False,
+        )
+
+        # Version 2.0.0 was published on top of 1.0.0.
+        audb.config.REPOSITORIES = [repository]
+        assert "2.0.0" in audb.versions(DB_NAME)
+    finally:
+        audb.config.REPOSITORIES = current_repositories
+
+
 @pytest.mark.parametrize(
     "version1, version2, media_difference, attachment_difference",
     [


### PR DESCRIPTION
Closes #519 

This ensures that `audb.publish(root, version, repository, previous_version="latest")` will also look inside `repository` and not only in `audb.config.REPOSITORIES` for a previous version of the database as `repository` does not need to be part of `audb.config.REPOSITORIES`.