### PR TITLE
Depend on audbackend[all]>=3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audbackend[all] >=2.4.0',
+    'audbackend[all] >=3.0.0',
     'audeer >=2.2.0',
     'audformat >=1.4.2',
     'audiofile >=1.0.0',


### PR DESCRIPTION
Depend on `audbackend[all]>=3.0.0` to ensure we can use the new host specific environment variables from `audbackend.backend.Minio`.