### PR TITLE
Remove deprecated flavor sampling rate of 22500

### DIFF
--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -81,7 +81,7 @@ class Flavor(audobject.Object):
             sampling_rate = int(sampling_rate)
             if sampling_rate not in define.SAMPLING_RATES:
                 raise ValueError(
-                    f"Sampling_rate has to be one of "
+                    f"sampling_rate has to be one of "
                     f"{define.SAMPLING_RATES}, not {sampling_rate}."
                 )
 

--- a/audb/core/flavor.py
+++ b/audb/core/flavor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 import os
 import shutil
-import warnings
 
 import numpy as np
 
@@ -80,14 +79,7 @@ class Flavor(audobject.Object):
 
         if sampling_rate is not None:
             sampling_rate = int(sampling_rate)
-            if sampling_rate == 22500:
-                message = (
-                    "A sampling rate of 22500 Hz is deprecated "
-                    "and will be removed with version 1.13.0 of audb. "
-                    "Use 22050 Hz instead."
-                )
-                warnings.warn(message, category=UserWarning, stacklevel=2)
-            elif sampling_rate not in define.SAMPLING_RATES:
+            if sampling_rate not in define.SAMPLING_RATES:
                 raise ValueError(
                     f"Sampling_rate has to be one of "
                     f"{define.SAMPLING_RATES}, not {sampling_rate}."

--- a/tests/test_flavor.py
+++ b/tests/test_flavor.py
@@ -73,13 +73,6 @@ def test_init(bit_depth, channels, format, mixdown, sampling_rate):
     assert flavor.id == flavor_2.id
 
 
-def test_deprecated_sampling_rate():
-    """Test a sampling rate of 22500 Hz raises user warning."""
-    message = "removed with version 1.13.0"
-    with pytest.warns(UserWarning, match=message):
-        audb.Flavor(sampling_rate=22500)
-
-
 @pytest.mark.parametrize(
     "format",
     [


### PR DESCRIPTION
Closes #484 

In #484 we promised to remove the deprecated flavor sampling rate of 22500 Hz in version 1.13.0. As we have now released version 1.13.0, it's time to remove it.