### PR TITLE
Improve error message for filter media in load()

### DIFF
--- a/audb/core/dependencies.py
+++ b/audb/core/dependencies.py
@@ -731,6 +731,7 @@ def error_message_missing_object(
     missing_object_id: str | Sequence,
     database_name: str = None,
     database_version: str = None,
+    tables: Sequence[str] = None,
 ) -> str:
     r"""Error message for missing objects.
 
@@ -743,6 +744,11 @@ def error_message_missing_object(
         missing_object_id: ID of missing object
         database_name: name of affected database
         database_version: name of affected database
+        tables: tables the object was searched in.
+            If provided,
+            the error message clarifies
+            that the object was only looked for
+            inside those tables
 
     Returns:
         error message
@@ -757,7 +763,15 @@ def error_message_missing_object(
         msg = f"Could not find a {object_name} matching '{missing_object_id}'"
     else:
         msg = f"Could not find the {object_name} '{missing_object_id[0]}'"
-    if database_name is not None and database_version is not None:
+    if tables is not None and len(tables) > 0:
+        if len(tables) == 1:
+            msg += f" in table '{tables[0]}'"
+        else:
+            table_list = ", ".join(f"'{table}'" for table in tables)
+            msg += f" in tables {table_list}"
+        if database_name is not None and database_version is not None:
+            msg += f" of {database_name} v{database_version}"
+    elif database_name is not None and database_version is not None:
         msg += f" in {database_name} v{database_version}"
     return msg
 
@@ -768,6 +782,7 @@ def filter_deps(
     deps_type: str,
     database_name: str = None,
     database_version: str = None,
+    tables: Sequence[str] = None,
 ) -> Sequence[str]:
     r"""Filter dependency files by requested files.
 
@@ -779,6 +794,11 @@ def filter_deps(
         deps_type: ``'attachment'``, ``'media'`` or ``'table'``
         database_name: name of affected database
         database_version: name of affected database
+        tables: tables ``available_deps`` was restricted to.
+            If provided,
+            an error message for a missing dependency
+            clarifies that it was only searched for
+            inside those tables
 
     Returns:
         list of attachments, media or tables
@@ -804,6 +824,7 @@ def filter_deps(
                 request,
                 database_name,
                 database_version,
+                tables,
             )
             raise ValueError(msg)
     else:
@@ -814,6 +835,7 @@ def filter_deps(
                     [dep],
                     database_name,
                     database_version,
+                    tables,
                 )
                 raise ValueError(msg)
 

--- a/audb/core/load.py
+++ b/audb/core/load.py
@@ -1246,6 +1246,12 @@ def _load(
             # filter tables (convert regexp pattern to list of tables)
             requested_tables = filter_deps(tables, list(db), "table")
 
+            # Store requested tables
+            # to provide a helpful error message
+            # if a requested media file
+            # is not part of them
+            media_tables = requested_tables if tables is not None else None
+
             # add/split into misc tables used in a scheme
             # and all other (misc) tables
             requested_misc_tables = _misc_tables_used_in_scheme(db)
@@ -1296,6 +1302,7 @@ def _load(
                 "media",
                 name,
                 version,
+                media_tables,
             )
 
             # load missing media

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -601,3 +601,124 @@ def test_update_media_version(deps, files, version):
     assert len(deps) == len(ROWS)
     for file in files:
         assert deps.version(file) == version
+
+
+@pytest.mark.parametrize(
+    "object_type, missing_object_id, database_name, database_version, "
+    "tables, expected",
+    [
+        # No database and no tables
+        ("media", ["b.wav"], None, None, None, "Could not find the media file 'b.wav'"),
+        (
+            "media",
+            "b.*",
+            None,
+            None,
+            None,
+            "Could not find a media file matching 'b.*'",
+        ),
+        # Database, but no tables
+        (
+            "media",
+            ["b.wav"],
+            "mydb",
+            "1.0.0",
+            None,
+            "Could not find the media file 'b.wav' in mydb v1.0.0",
+        ),
+        (
+            "table",
+            ["a"],
+            "mydb",
+            "1.0.0",
+            None,
+            "Could not find the table 'a' in mydb v1.0.0",
+        ),
+        # Single table
+        (
+            "media",
+            ["b.wav"],
+            "mydb",
+            "1.0.0",
+            ["a"],
+            "Could not find the media file 'b.wav' in table 'a' of mydb v1.0.0",
+        ),
+        # Multiple tables
+        (
+            "media",
+            ["b.wav"],
+            "mydb",
+            "1.0.0",
+            ["a", "c"],
+            "Could not find the media file 'b.wav' in tables 'a', 'c' of mydb v1.0.0",
+        ),
+        # Regular expression request with tables
+        (
+            "media",
+            "b.*",
+            "mydb",
+            "1.0.0",
+            ["a"],
+            "Could not find a media file matching 'b.*' in table 'a' of mydb v1.0.0",
+        ),
+        # Empty table list behaves as no tables
+        (
+            "media",
+            ["b.wav"],
+            "mydb",
+            "1.0.0",
+            [],
+            "Could not find the media file 'b.wav' in mydb v1.0.0",
+        ),
+    ],
+)
+def test_error_message_missing_object(
+    object_type,
+    missing_object_id,
+    database_name,
+    database_version,
+    tables,
+    expected,
+):
+    msg = audb.core.dependencies.error_message_missing_object(
+        object_type,
+        missing_object_id,
+        database_name,
+        database_version,
+        tables,
+    )
+    assert msg == expected
+
+
+@pytest.mark.parametrize(
+    "requested_deps, available_deps, tables, expected_msg",
+    [
+        (
+            ["b.wav"],
+            ["a.wav"],
+            None,
+            "Could not find the media file 'b.wav' in mydb v1.0.0",
+        ),
+        (
+            ["b.wav"],
+            ["a.wav"],
+            ["a"],
+            "Could not find the media file 'b.wav' in table 'a' of mydb v1.0.0",
+        ),
+    ],
+)
+def test_filter_deps_missing_media(
+    requested_deps,
+    available_deps,
+    tables,
+    expected_msg,
+):
+    with pytest.raises(ValueError, match=re.escape(expected_msg)):
+        audb.core.dependencies.filter_deps(
+            requested_deps,
+            available_deps,
+            "media",
+            "mydb",
+            "1.0.0",
+            tables,
+        )

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -604,8 +604,7 @@ def test_update_media_version(deps, files, version):
 
 
 @pytest.mark.parametrize(
-    "object_type, missing_object_id, database_name, database_version, "
-    "tables, expected",
+    "object_type, missing_object_id, database_name, database_version, tables, expected",
     [
         # No database and no tables
         ("media", ["b.wav"], None, None, None, "Could not find the media file 'b.wav'"),


### PR DESCRIPTION
Closes #209

If we request `media` and `tables` in `audb.load()` it can happen that a selected media file is part of the database, but not part of the selected tables. Before you got the wrong error message

> Could not find the media file 'b.wav' in mydb v1.0.0

now you get

> Could not find the media file 'b.wav' in table 'a' of mydb v1.0.0